### PR TITLE
Transform response error to form error

### DIFF
--- a/src/utils/restRequest/error.ts
+++ b/src/utils/restRequest/error.ts
@@ -1,0 +1,169 @@
+import {
+    isNotDefined,
+    listToMap,
+    mapToMap,
+} from '@togglecorp/fujs';
+import { nonFieldError as nonFieldErrorSymbol } from '@togglecorp/toggle-form';
+
+type ResponseLeafError = string[];
+
+type ResponseObjectError = {
+    [key: string]: ResponseObjectError | ResponseArrayError | ResponseLeafError | undefined;
+} & {
+    nonFieldError?: string | undefined;
+};
+
+type ResponseArrayError = (ResponseObjectError | ResponseArrayError | ResponseLeafError)[];
+
+type FormLeafError = string;
+type FormArrayError = {
+    [key: string]: FormLeafError | FormObjectError | FormArrayError | undefined;
+}
+type FormObjectError = {
+    [nonFieldErrorSymbol]?: string
+} & {
+    [key: string]: FormLeafError | FormObjectError | FormArrayError | undefined;
+};
+
+export const NUM = Symbol('NUMBER');
+
+export function matchArray(
+    array: (string | number)[],
+    expressions: (string | number | typeof NUM)[],
+) {
+    if (array.length !== expressions.length) {
+        return undefined;
+    }
+    const response: number[] = [];
+    for (let i = 0; i < array.length; i += 1) {
+        const item = array[i];
+        const expression = expressions[i];
+
+        if (expression === NUM) {
+            if (typeof item !== 'number') {
+                return undefined;
+            }
+
+            response.push(item);
+            // eslint-disable-next-line no-continue
+            continue;
+        }
+
+        if (expression === item) {
+            // eslint-disable-next-line no-continue
+            continue;
+        }
+
+        return undefined;
+    }
+    return response;
+}
+
+function isObjectError(
+    err: ResponseObjectError | ResponseArrayError | ResponseLeafError,
+): err is ResponseObjectError {
+    return !Array.isArray(err) && typeof err === 'object';
+}
+
+function isLeafError(
+    err: ResponseObjectError | ResponseArrayError | ResponseLeafError,
+): err is ResponseLeafError {
+    if (isObjectError(err)) {
+        return false;
+    }
+    const unsafeErr: unknown[] = err;
+    return Array.isArray(unsafeErr) && unsafeErr.every(
+        (e: unknown) => typeof e === 'string',
+    );
+}
+
+function isArrayError(
+    err: ResponseObjectError | ResponseArrayError | ResponseLeafError,
+): err is ResponseLeafError {
+    if (isObjectError(err)) {
+        return false;
+    }
+    if (isLeafError(err)) {
+        return false;
+    }
+    return Array.isArray(err) && err.every(
+        (e) => isArrayError(e) || isObjectError(e),
+    );
+}
+
+function transformLeafError(error: ResponseLeafError | undefined) {
+    if (isNotDefined(error)) {
+        return undefined;
+    }
+    return error.join(' ');
+}
+
+export type Location = (string | number)[];
+type GetKey = (location: Location) => string | undefined;
+
+function transformArrayError(
+    error: ResponseArrayError | undefined,
+    getKey: GetKey,
+    location: Location = [],
+): FormArrayError | undefined {
+    if (isNotDefined(error)) {
+        return undefined;
+    }
+    const EMPTY_KEY = '';
+    const formErrors = listToMap(
+        error,
+        (_, index) => getKey([...location, index]) ?? EMPTY_KEY,
+        (memberError, _, index) => {
+            if (isObjectError(memberError)) {
+                // eslint-disable-next-line @typescript-eslint/no-use-before-define
+                return transformObjectError(memberError, getKey, [...location, index]);
+            }
+            if (isLeafError(memberError)) {
+                return transformLeafError(memberError);
+            }
+            if (isArrayError(memberError)) {
+                return transformArrayError(memberError, getKey, [...location, index]);
+            }
+            return undefined;
+        },
+    );
+    delete formErrors[EMPTY_KEY];
+    return formErrors;
+}
+
+export function transformObjectError(
+    error: ResponseObjectError | undefined,
+    getKey: GetKey,
+    location: Location = [],
+): FormObjectError | undefined {
+    if (isNotDefined(error)) {
+        return undefined;
+    }
+    const {
+        nonFieldError,
+        ...fieldErrors
+    } = error;
+
+    return {
+        [nonFieldErrorSymbol]: nonFieldError,
+        ...mapToMap(
+            fieldErrors,
+            (key) => key,
+            (fieldError, key) => {
+                if (isNotDefined(fieldError)) {
+                    return undefined;
+                }
+                if (isObjectError(fieldError)) {
+                    return transformObjectError(fieldError, getKey, [...location, key]);
+                }
+                if (isLeafError(fieldError)) {
+                    return transformLeafError(fieldError);
+                }
+                if (isArrayError(fieldError)) {
+                    return transformArrayError(fieldError, getKey, [...location, key]);
+                }
+                return undefined;
+            },
+        ),
+    };
+}

--- a/src/views/DrefApplicationForm/Overview/CopyFieldReportSection/index.tsx
+++ b/src/views/DrefApplicationForm/Overview/CopyFieldReportSection/index.tsx
@@ -106,7 +106,6 @@ function CopyFieldReportSection(props: Props) {
             const un_or_other_actor = value.un_or_other_actor ?? fieldReportResponse.actions_others;
             const country = value.country ?? fieldReportResponse.countries[0];
 
-            // TODO verify the following
             const district = (value.district && value.district.length > 0)
                 ? value.district
                 : fieldReportResponse.districts;
@@ -116,7 +115,6 @@ function CopyFieldReportSection(props: Props) {
                 ?? fieldReportResponse.gov_num_affected
                 ?? fieldReportResponse.other_num_affected;
 
-            // FIXME: use constants
             const partner_national_society = value?.partner_national_society
                 ?? fieldReportResponse.actions_taken?.find((a) => a.organization === 'PNS')?.summary;
             const ifrc = value?.ifrc
@@ -126,25 +124,24 @@ function CopyFieldReportSection(props: Props) {
 
             let {
                 national_society_contact_name,
-                national_society_contact_title,
                 national_society_contact_email,
                 national_society_contact_phone_number,
+                national_society_contact_title,
                 ifrc_emergency_name,
-                ifrc_emergency_title,
                 ifrc_emergency_email,
+                ifrc_emergency_title,
                 ifrc_emergency_phone_number,
                 media_contact_name,
-                media_contact_title,
                 media_contact_email,
+                media_contact_title,
                 media_contact_phone_number,
             } = value;
 
-            // FIXME: Should this be `and` or `or` logic
             if (
-                !national_society_contact_name
-                && !national_society_contact_email
-                && !national_society_contact_title
-                && !national_society_contact_phone_number
+                !value.national_society_contact_name
+                && !value.national_society_contact_email
+                && !value.national_society_contact_title
+                && !value.national_society_contact_phone_number
             ) {
                 const nsContact = fieldReportResponse.contacts?.find(
                     (contact) => contact.ctype === 'NationalSociety',
@@ -157,12 +154,11 @@ function CopyFieldReportSection(props: Props) {
                 }
             }
 
-            // FIXME: Should this be `and` or `or` logic
             if (
-                !ifrc_emergency_name
-                && !ifrc_emergency_email
-                && !ifrc_emergency_title
-                && !ifrc_emergency_phone_number
+                !value.ifrc_emergency_name
+                && !value.ifrc_emergency_email
+                && !value.ifrc_emergency_title
+                && !value.ifrc_emergency_phone_number
             ) {
                 const federationContact = fieldReportResponse.contacts?.find(
                     (contact) => contact.ctype === 'Federation',
@@ -175,12 +171,11 @@ function CopyFieldReportSection(props: Props) {
                 }
             }
 
-            // FIXME: Should this be `and` or `or` logic
             if (
-                !media_contact_name
-                && !media_contact_email
-                && !media_contact_title
-                && !media_contact_phone_number
+                !value.media_contact_name
+                && !value.media_contact_email
+                && !value.media_contact_title
+                && !value.media_contact_phone_number
             ) {
                 const mediaContact = fieldReportResponse.contacts?.find(
                     (contact) => contact.ctype === 'Media',
@@ -212,22 +207,10 @@ function CopyFieldReportSection(props: Props) {
             setFieldValue(fieldReportResponse.id, 'field_report');
             setFieldValue(country, 'country');
             setFieldValue(district, 'district');
-
-            if (isDefined(num_affected)) {
-                setFieldValue(num_affected, 'num_affected');
-            }
-
-            if (isDefined(partner_national_society)) {
-                setFieldValue(partner_national_society, 'partner_national_society');
-            }
-
-            if (isDefined(ifrc)) {
-                setFieldValue(ifrc, 'ifrc');
-            }
-
-            if (isDefined(icrc)) {
-                setFieldValue(icrc, 'icrc');
-            }
+            setFieldValue(num_affected, 'num_affected');
+            setFieldValue(partner_national_society, 'partner_national_society');
+            setFieldValue(ifrc, 'ifrc');
+            setFieldValue(icrc, 'icrc');
 
             alert.show(
                 strings.drefFormCopyFRSuccessMessage,

--- a/src/views/DrefApplicationForm/index.tsx
+++ b/src/views/DrefApplicationForm/index.tsx
@@ -3,6 +3,7 @@ import {
     useCallback,
     useContext,
     useRef,
+    type ElementRef,
 } from 'react';
 import {
     generatePath,
@@ -108,6 +109,8 @@ export function Component() {
     const alert = useAlert();
     const navigate = useNavigate();
     const strings = useTranslation(i18n);
+
+    const formContentRef = useRef<ElementRef<'div'>>(null);
 
     const [activeTab, setActiveTab] = useState<TabKeys>('overview');
     const [fileIdToUrlMap, setFileIdToUrlMap] = useState<Record<number, string>>({});
@@ -320,6 +323,8 @@ export function Component() {
 
     const handleFormSubmit = useCallback(
         (modifiedAt?: string) => {
+            formContentRef.current?.scrollIntoView();
+
             // FIXME: use createSubmitHandler
             const result = validate();
             if (result.errored) {
@@ -367,6 +372,11 @@ export function Component() {
         [],
     );
 
+    const handleTabChange = useCallback((newTab: TabKeys) => {
+        formContentRef.current?.scrollIntoView();
+        setActiveTab(newTab);
+    }, []);
+
     const nextStep = getNextStep(activeTab, 1, value.type_of_dref);
     const prevStep = getNextStep(activeTab, -1, value.type_of_dref);
     const saveDrefPending = createDrefPending || updateDrefPending;
@@ -375,10 +385,12 @@ export function Component() {
     return (
         <Tabs
             value={activeTab}
+            // NOTE: not using handleTabChange here
             onChange={setActiveTab}
             variant="step"
         >
             <Page
+                elementRef={formContentRef}
                 className={styles.drefApplicationForm}
                 title={strings.drefFormPageTitle}
                 heading={strings.drefFormPageHeading}
@@ -493,7 +505,7 @@ export function Component() {
                     <div className={styles.pageActions}>
                         <Button
                             name={prevStep ?? activeTab}
-                            onClick={setActiveTab}
+                            onClick={handleTabChange}
                             disabled={!prevStep}
                             variant="secondary"
                         >
@@ -501,7 +513,7 @@ export function Component() {
                         </Button>
                         <Button
                             name={nextStep ?? activeTab}
-                            onClick={setActiveTab}
+                            onClick={handleTabChange}
                             disabled={!nextStep}
                             variant="secondary"
                         >

--- a/src/views/DrefApplicationForm/schema.ts
+++ b/src/views/DrefApplicationForm/schema.ts
@@ -19,7 +19,14 @@ import {
 } from '#utils/form';
 import { type GoApiResponse, type GoApiBody } from '#utils/restRequest';
 
-import { TYPE_ASSESSMENT } from './common';
+import {
+    DISASTER_FIRE,
+    DISASTER_FLOOD,
+    DISASTER_FLASH_FLOOD,
+    TYPE_ASSESSMENT,
+    TYPE_IMMINENT,
+    TYPE_LOAN,
+} from './common';
 
 // FIXME: Do we need this limit?
 // Is this a server side limit or client side limit?
@@ -109,129 +116,28 @@ type DrefFormSchemaFields = ReturnType<DrefFormSchema['fields']>;
 const schema: DrefFormSchema = {
     fields: (formValue): DrefFormSchemaFields => {
         let formFields: DrefFormSchemaFields = {
-            field_report: {},
-            title: { required: true },
+            // OVERVIEW
+            users: { defaultValue: [] },
             national_society: { required: true },
-            disaster_category: {},
-            disaster_type: {},
+            type_of_dref: { required: true },
             type_of_onset: { required: true },
+            disaster_category: {},
             country: {},
             district: { defaultValue: [] },
+            disaster_type: {},
+            title: {
+                required: true,
+                requiredValidation: requiredStringCondition,
+            },
             num_affected: { validations: [positiveIntegerCondition] },
             num_assisted: { validations: [positiveIntegerCondition] },
-            amount_requested: { validations: [positiveNumberCondition] },
-            emergency_appeal_planned: {},
-            cover_image_file: {
-                fields: () => ({
-                    client_id: {},
-                    id: { defaultValue: undefinedValue },
-                    caption: { defaultValue: undefinedValue },
-                }),
-            },
-            event_map_file: {
-                fields: () => ({
-                    client_id: {},
-                    id: { defaultValue: undefinedValue },
-                    caption: { defaultValue: undefinedValue },
-                }),
-            },
-            event_date: {},
-            event_text: { validations: [max500CharCondition] },
-            anticipatory_actions: {},
-            // go_field_report_date: {},
-            ns_respond_date: {},
-            event_description: {},
-            images_file: {
-                keySelector: (image_file) => image_file.client_id,
-                member: () => ({
-                    fields: () => ({
-                        client_id: {},
-                        id: {},
-                        caption: {
-                            required: true,
-                            requiredValidation: requiredStringCondition,
-                        },
-                    }),
-                }),
-                // FIXME: this is not defined on array type
-                defaultValue: [],
-                validations: [lessThanEqualToTwoImagesCondition],
-            },
-            government_requested_assistance: {},
-            government_requested_assistance_date: {},
-            national_authorities: {},
-            partner_national_society: {},
-            ifrc: {},
-            icrc: {},
-            un_or_other_actor: {},
-            major_coordination_mechanism: {},
-            people_assisted: {},
-            selection_criteria: {},
-            community_involved: {},
-            disability_people_per: {
-                // FIXME: shouldn't these be integer?
-                validations: [greaterThanOrEqualToCondition(0), lessThanOrEqualToCondition(100)],
-            },
-            people_per_urban: {
-                // FIXME: shouldn't these be integer?
-                validations: [greaterThanOrEqualToCondition(0), lessThanOrEqualToCondition(100)],
-            },
-            people_per_local: {
-                // FIXME: shouldn't these be integer?
-                validations: [greaterThanOrEqualToCondition(0), lessThanOrEqualToCondition(100)],
-            },
-            displaced_people: { validations: [positiveIntegerCondition] },
-            people_targeted_with_early_actions: { validations: [positiveIntegerCondition] },
-            total_targeted_population: { validations: [positiveIntegerCondition] },
-            operation_objective: {},
-            response_strategy: {},
-            budget_file: {},
-            ns_request_date: {},
-            // start_date: {},
-            submission_to_geneva: {},
-            end_date: {},
-            date_of_approval: {},
-            publishing_date: {},
-            appeal_code: {},
-            glide_code: {},
-            ifrc_appeal_manager_name: {},
-            ifrc_appeal_manager_email: { validations: [emailCondition] },
-            ifrc_appeal_manager_phone_number: {},
-            ifrc_appeal_manager_title: {},
-            ifrc_project_manager_name: {},
-            ifrc_project_manager_email: { validations: [emailCondition] },
-            ifrc_project_manager_title: {},
-            ifrc_project_manager_phone_number: {},
-            national_society_contact_name: {},
-            national_society_contact_title: {},
-            national_society_contact_email: { validations: [emailCondition] },
-            national_society_contact_phone_number: {},
-            ifrc_emergency_name: {},
-            ifrc_emergency_title: {},
-            ifrc_emergency_email: { validations: [emailCondition] },
-            ifrc_emergency_phone_number: {},
-            media_contact_name: {},
-            media_contact_title: {},
-            media_contact_email: { validations: [emailCondition] },
-            media_contact_phone_number: {},
-            human_resource: {},
-            surge_personnel_deployed: {},
-            users: { defaultValue: [] },
-            is_there_major_coordination_mechanism: {},
-            is_surge_personnel_deployed: {},
-            people_in_need: {},
-            supporting_document: {},
+            field_report: {}, // This value is set from CopyFieldReportSection
+
+            // EVENT DETAILS
+
+            // ACTIONS
+
             did_national_society: {},
-            risk_security_concern: {},
-            is_man_made_event: {},
-            // is_assessment_report: {},
-            type_of_dref: { required: true },
-            operation_timeframe: {
-                validations: [
-                    positiveIntegerCondition,
-                    lessThanOrEqualToCondition(30),
-                ],
-            },
             national_society_actions: {
                 keySelector: (nsAction) => nsAction.client_id,
                 member: () => ({
@@ -248,6 +154,46 @@ const schema: DrefFormSchema = {
                     }),
                 }),
             },
+            ifrc: {},
+            icrc: {},
+            partner_national_society: {},
+            government_requested_assistance: {},
+            national_authorities: {},
+            un_or_other_actor: {},
+            is_there_major_coordination_mechanism: {},
+
+            // OPERATION
+
+            operation_objective: {},
+            response_strategy: {},
+            people_assisted: {},
+            selection_criteria: {},
+            total_targeted_population: { validations: [positiveIntegerCondition] },
+            disability_people_per: {
+                // FIXME: shouldn't these be integer?
+                validations: [greaterThanOrEqualToCondition(0), lessThanOrEqualToCondition(100)],
+            },
+            people_per_urban: {
+                // FIXME: shouldn't these be integer?
+                validations: [greaterThanOrEqualToCondition(0), lessThanOrEqualToCondition(100)],
+            },
+            people_per_local: {
+                // FIXME: shouldn't these be integer?
+                validations: [greaterThanOrEqualToCondition(0), lessThanOrEqualToCondition(100)],
+            },
+            displaced_people: { validations: [positiveIntegerCondition] },
+            risk_security: {
+                keySelector: (riskSecurity) => riskSecurity.client_id,
+                member: () => ({
+                    fields: () => ({
+                        client_id: {},
+                        risk: { required: true },
+                        mitigation: { required: true },
+                    }),
+                }),
+            },
+            risk_security_concern: {},
+            budget_file: {}, // FIXME: may need to check if this exits
             planned_interventions: {
                 keySelector: (n) => n.client_id,
                 member: () => ({
@@ -280,92 +226,318 @@ const schema: DrefFormSchema = {
                     }),
                 }),
             },
-            risk_security: {
-                keySelector: (riskSecurity) => riskSecurity.client_id,
-                member: () => ({
-                    fields: () => ({
-                        client_id: {},
-                        risk: { required: true },
-                        mitigation: { required: true },
-                    }),
-                }),
+            human_resource: {},
+            is_surge_personnel_deployed: {},
+
+            // SUBMISSION
+            ns_request_date: {},
+            submission_to_geneva: {},
+            date_of_approval: {},
+            operation_timeframe: {
+                validations: [
+                    positiveIntegerCondition,
+                    lessThanOrEqualToCondition(30),
+                ],
             },
+            appeal_code: {},
+            ifrc_appeal_manager_name: {},
+            ifrc_appeal_manager_email: { validations: [emailCondition] },
+            ifrc_appeal_manager_phone_number: {},
+            ifrc_appeal_manager_title: {},
+            ifrc_project_manager_name: {},
+            ifrc_project_manager_email: { validations: [emailCondition] },
+            ifrc_project_manager_title: {},
+            ifrc_project_manager_phone_number: {},
+
+            national_society_contact_name: {},
+            national_society_contact_title: {},
+            national_society_contact_email: { validations: [emailCondition] },
+            national_society_contact_phone_number: {},
+            ifrc_emergency_name: {},
+            ifrc_emergency_title: {},
+            ifrc_emergency_email: { validations: [emailCondition] },
+            ifrc_emergency_phone_number: {},
+            media_contact_name: {},
+            media_contact_title: {},
+            media_contact_email: { validations: [emailCondition] },
+            media_contact_phone_number: {},
+            end_date: {},
+            publishing_date: {},
+            glide_code: {},
+
+            // government_requested_assistance_date: {}, // NOTE: Not found in the UI
+            // community_involved: {}, // NOTE: Not found in the UI
         };
 
-        const assessmentAffectedFields = [
-            'did_it_affect_same_area',
-            'did_it_affect_same_population',
-            'did_ns_respond',
-            'did_ns_request_fund',
-            'ns_request_text',
-            'lessons_learned',
-            'dref_recurrent_text',
-            'identified_gaps',
-            'women',
-            'men',
-            'girls',
-            'boys',
-            'event_scope',
-            'assessment_report',
-            'logistic_capacity_of_ns',
-            'pmer',
-            'communication',
-            'needs_identified',
-        ] as const;
+        // OVERVIEW
 
-        type ConditionalReturnType = Pick<
-            DrefFormSchemaFields,
-            (typeof assessmentAffectedFields)[number]
-        >;
+        formFields = addCondition(
+            formFields,
+            formValue,
+            ['disaster_type'],
+            ['is_man_made_event'],
+            (val) => {
+                if (
+                    val?.disaster_type === DISASTER_FIRE
+                    || val?.disaster_type === DISASTER_FLOOD
+                    || val?.disaster_type === DISASTER_FLASH_FLOOD
+                ) {
+                    return {
+                        is_man_made_event: {},
+                    };
+                }
+                return {
+                    is_man_made_event: { forceValue: nullValue },
+                };
+            },
+        );
 
-        // TODO: verify schema, add condition for loan type
         formFields = addCondition(
             formFields,
             formValue,
             ['type_of_dref'],
-            assessmentAffectedFields,
-            (): ConditionalReturnType => {
-                const schemaForAssessment: ConditionalReturnType = {
+            [
+                'people_in_need',
+                'amount_requested',
+                'emergency_appeal_planned',
+                'event_map_file',
+                'cover_image_file',
+            ],
+            (val) => {
+                const conditionalFields: DrefFormSchemaFields = {
+                    people_in_need: { forceValue: nullValue },
+                    amount_requested: { forceValue: nullValue },
+                    emergency_appeal_planned: { forceValue: nullValue },
+                    event_map_file: { forceValue: nullValue },
+                    cover_image_file: { forceValue: nullValue },
+                };
+                if (val?.type_of_dref === TYPE_LOAN) {
+                    return conditionalFields;
+                }
+                return {
+                    ...conditionalFields,
+                    // OVERVIEW
+                    people_in_need: {},
+                    amount_requested: { validations: [positiveNumberCondition] },
+                    emergency_appeal_planned: {},
+                    event_map_file: {
+                        fields: () => ({
+                            client_id: {},
+                            id: { defaultValue: undefinedValue },
+                            caption: { defaultValue: undefinedValue },
+                        }),
+                    },
+                    cover_image_file: {
+                        fields: () => ({
+                            client_id: {},
+                            id: { defaultValue: undefinedValue },
+                            caption: { defaultValue: undefinedValue },
+                        }),
+                    },
+                };
+            },
+        );
+
+        // EVENT DETAILS
+
+        formFields = addCondition(
+            formFields,
+            formValue,
+            ['type_of_dref'],
+            [
+                'did_it_affect_same_area',
+                'did_it_affect_same_population',
+                'did_ns_respond',
+                'did_ns_request_fund',
+                'lessons_learned',
+                'event_scope',
+
+                'event_text',
+                'anticipatory_actions',
+                'supporting_document',
+
+                'event_date',
+
+                'event_description',
+                'images_file',
+            ],
+            (val) => {
+                let conditionalFields: DrefFormSchemaFields = {
                     did_it_affect_same_area: { forceValue: nullValue },
                     did_it_affect_same_population: { forceValue: nullValue },
                     did_ns_respond: { forceValue: nullValue },
                     did_ns_request_fund: { forceValue: nullValue },
-                    ns_request_text: { forceValue: nullValue },
                     lessons_learned: { forceValue: nullValue },
-                    dref_recurrent_text: { forceValue: nullValue },
-                    identified_gaps: { forceValue: nullValue },
-                    women: { forceValue: nullValue },
-                    men: { forceValue: nullValue },
-                    girls: { forceValue: nullValue },
-                    boys: { forceValue: nullValue },
                     event_scope: { forceValue: nullValue },
-                    assessment_report: { forceValue: nullValue },
-                    logistic_capacity_of_ns: { forceValue: nullValue },
-                    pmer: { forceValue: nullValue },
-                    communication: { forceValue: nullValue },
-                    needs_identified: { forceValue: nullValue },
+                    event_text: { forceValue: nullValue },
+                    anticipatory_actions: { forceValue: nullValue },
+                    supporting_document: { forceValue: nullValue },
+                    event_date: { forceValue: nullValue },
+                    event_description: { forceValue: nullValue },
+                    images_file: { forceValue: nullValue },
                 };
 
-                if (formValue?.type_of_dref === TYPE_ASSESSMENT) {
-                    return {
-                        ...schemaForAssessment,
+                if (
+                    val?.type_of_dref !== TYPE_ASSESSMENT
+                    && val?.type_of_dref !== TYPE_LOAN
+                ) {
+                    conditionalFields = {
+                        ...conditionalFields,
                         did_it_affect_same_area: {},
                         did_it_affect_same_population: {},
                         did_ns_respond: {},
                         did_ns_request_fund: {},
-                        ns_request_text: {},
                         lessons_learned: {},
-                        dref_recurrent_text: {},
-                        identified_gaps: {},
-                        women: { validations: [positiveIntegerCondition] },
-                        men: { validations: [positiveIntegerCondition] },
-                        girls: { validations: [positiveIntegerCondition] },
-                        boys: { validations: [positiveIntegerCondition] },
                         event_scope: {},
-                        assessment_report: {},
-                        logistic_capacity_of_ns: {},
-                        pmer: {},
-                        communication: {},
+                    };
+                }
+
+                if (val?.type_of_dref === TYPE_IMMINENT) {
+                    conditionalFields = {
+                        ...conditionalFields,
+                        event_text: { validations: [max500CharCondition] },
+                        anticipatory_actions: {},
+                        supporting_document: {},
+                    };
+                } else {
+                    conditionalFields = {
+                        ...conditionalFields,
+                        event_date: {},
+                    };
+                }
+
+                if (val?.type_of_dref !== TYPE_LOAN) {
+                    conditionalFields = {
+                        ...conditionalFields,
+                        event_description: {},
+                        images_file: {
+                            keySelector: (image_file) => image_file.client_id,
+                            member: () => ({
+                                fields: () => ({
+                                    client_id: {},
+                                    id: {},
+                                    caption: {
+                                        required: true,
+                                        requiredValidation: requiredStringCondition,
+                                    },
+                                }),
+                            }),
+                            // FIXME: this is not defined on array type
+                            defaultValue: [],
+                            validations: [lessThanEqualToTwoImagesCondition],
+                        },
+                    };
+                }
+
+                return conditionalFields;
+            },
+        );
+
+        formFields = addCondition(
+            formFields,
+            formValue,
+            ['type_of_dref', 'did_ns_request_fund'],
+            ['ns_request_text'],
+            (val) => {
+                if (
+                    val?.type_of_dref !== TYPE_ASSESSMENT
+                    && val?.type_of_dref !== TYPE_LOAN
+                    && val?.did_ns_request_fund
+                ) {
+                    return {
+                        ns_request_text: {},
+                    };
+                }
+                return {
+                    ns_request_text: { forceValue: nullValue },
+                };
+            },
+        );
+
+        formFields = addCondition(
+            formFields,
+            formValue,
+            [
+                'type_of_dref',
+                'did_ns_request_fund',
+                'did_ns_respond',
+                'did_it_affect_same_population',
+                'did_it_affect_same_area',
+            ],
+            ['dref_recurrent_text'],
+            (val) => {
+                if (
+                    val?.type_of_dref !== TYPE_ASSESSMENT
+                    && val?.type_of_dref !== TYPE_LOAN
+                    && val?.did_ns_request_fund
+                    && val?.did_ns_respond
+                    && val?.did_it_affect_same_population
+                    && val?.did_it_affect_same_area
+                ) {
+                    return {
+                        dref_recurrent_text: {},
+                    };
+                }
+                return {
+                    dref_recurrent_text: { forceValue: nullValue },
+                };
+            },
+        );
+
+        // ACTIONS
+
+        formFields = addCondition(
+            formFields,
+            formValue,
+            ['did_national_society'],
+            ['ns_respond_date'],
+            (val) => {
+                if (val?.did_national_society) {
+                    return {
+                        ns_respond_date: {},
+                    };
+                }
+                return {
+                    ns_respond_date: { forceValue: nullValue },
+                };
+            },
+        );
+
+        formFields = addCondition(
+            formFields,
+            formValue,
+            ['is_there_major_coordination_mechanism'],
+            ['major_coordination_mechanism'],
+            (val) => {
+                if (val?.is_there_major_coordination_mechanism) {
+                    return {
+                        major_coordination_mechanism: {},
+                    };
+                }
+                return {
+                    major_coordination_mechanism: { forceValue: nullValue },
+                };
+            },
+        );
+
+        formFields = addCondition(
+            formFields,
+            formValue,
+            ['type_of_dref'],
+            [
+                'assessment_report',
+                'needs_identified',
+                'identified_gaps',
+            ],
+            (val) => {
+                let conditionalFields: DrefFormSchemaFields = {
+                    assessment_report: { forceValue: nullValue },
+                    needs_identified: { forceValue: nullValue },
+                    identified_gaps: { forceValue: nullValue },
+                };
+                if (val?.type_of_dref !== TYPE_ASSESSMENT) {
+                    conditionalFields = {
+                        ...conditionalFields,
                         needs_identified: {
                             keySelector: (need) => need.client_id,
                             member: () => ({
@@ -378,9 +550,93 @@ const schema: DrefFormSchema = {
                         },
                     };
                 }
-                return schemaForAssessment;
+                if (
+                    val?.type_of_dref !== TYPE_ASSESSMENT
+                    && val?.type_of_dref !== TYPE_IMMINENT
+                ) {
+                    conditionalFields = {
+                        ...conditionalFields,
+                        assessment_report: {},
+                        identified_gaps: {},
+                    };
+                }
+                return conditionalFields;
             },
         );
+
+        // OPERATION
+
+        formFields = addCondition(
+            formFields,
+            formValue,
+            ['type_of_dref'],
+            [
+                'women',
+                'men',
+                'girls',
+                'boys',
+                'people_targeted_with_early_actions',
+                'logistic_capacity_of_ns',
+                'pmer',
+                'communication',
+            ],
+            (val) => {
+                let conditionalFields: DrefFormSchemaFields = {
+                    women: { forceValue: nullValue },
+                    men: { forceValue: nullValue },
+                    girls: { forceValue: nullValue },
+                    boys: { forceValue: nullValue },
+                    people_targeted_with_early_actions: { forceValue: nullValue },
+                    logistic_capacity_of_ns: { forceValue: nullValue },
+                    pmer: { forceValue: nullValue },
+                    communication: { forceValue: nullValue },
+                };
+                if (val?.type_of_dref !== TYPE_ASSESSMENT) {
+                    conditionalFields = {
+                        ...conditionalFields,
+                        women: { validations: [positiveIntegerCondition] },
+                        men: { validations: [positiveIntegerCondition] },
+                        girls: { validations: [positiveIntegerCondition] },
+                        boys: { validations: [positiveIntegerCondition] },
+                    };
+                }
+                if (val?.type_of_dref === TYPE_IMMINENT) {
+                    conditionalFields = {
+                        ...conditionalFields,
+                        people_targeted_with_early_actions: {
+                            validations: [positiveIntegerCondition],
+                        },
+                    };
+                } else {
+                    conditionalFields = {
+                        ...conditionalFields,
+                        logistic_capacity_of_ns: {},
+                        pmer: {},
+                        communication: {},
+                    };
+                }
+                return conditionalFields;
+            },
+        );
+
+        formFields = addCondition(
+            formFields,
+            formValue,
+            ['is_surge_personnel_deployed'],
+            ['surge_personnel_deployed'],
+            (val) => {
+                if (val?.is_surge_personnel_deployed) {
+                    return {
+                        surge_personnel_deployed: {},
+                    };
+                }
+                return {
+                    surge_personnel_deployed: { forceValue: nullValue },
+                };
+            },
+        );
+
+        // SUBMISSION
 
         return formFields;
     },


### PR DESCRIPTION
## Changes
- Add transform function
- Add helpers

## Example usage of helper function

```javascript
{
    onFailure(errorFromServer) {
        const value = {};


        function getKey(locations) {
            let match = match(locations, ['area_responses', NUM, 'component_responses', NUM, 'question_responses', NUM]);
            if (isDefined(match)) {
                const [response_index, component_index, question_index] = match;
                return value?.[response_index]?.component_respones?.[component_index]?.question_responses?.[question_index]?.client_id;
            }
            match = match(locations, ['area_responses', NUM, 'component_responses', NUM);
            if (isDefined(match)) {
                const [response_index, component_index] = match;
                return value?.[response_index]?.component_respones?.[component_index]?.client_id;
            }
            match = match(locations, ['area_responses', NUM);
            if (isDefined(match)) {
                const [response_index] = match;
                return value?.[response_index]?.client_id;
            }
            return undefined;
        }

        const newError = transformError(
            errorFromServer,
            getKey
        );
        console.warn(newError);
    }
}

```


## This PR doesn't introduce:
- [x] typos
- [x] conflict markers
- [x] unwanted comments
- [x] temporary files, auto-generated files or secret keys
- [x] `console.log` meant for debugging
- [x] codegen errors
