### PR TITLE
Fix error transformations on FileInput components

### DIFF
--- a/src/components/domain/GoMultiFileInput/index.tsx
+++ b/src/components/domain/GoMultiFileInput/index.tsx
@@ -6,6 +6,7 @@ import {
 } from '@togglecorp/fujs';
 import { nonFieldError } from '@togglecorp/toggle-form';
 
+import { transformObjectError } from '#utils/restRequest/error';
 import InputError from '#components/InputError';
 import Link from '#components/Link';
 import { NameType } from '#components/types';
@@ -118,9 +119,18 @@ function GoMultiFileInput<T extends NameType>(props: Props<T>) {
             }
             onChange([...(value ?? []), ...ids], name);
         },
-        onFailure: (e) => {
-            const serverError = e?.value?.formErrors;
-            const serverErrorMessage = String(serverError?.file ?? serverError?.[nonFieldError]);
+        onFailure: ({
+            value: {
+                formErrors,
+            },
+        }) => {
+            const err = transformObjectError(formErrors, () => undefined);
+            // NOTE: could not use getErrorObject
+            const serverErrorMessage = err?.[nonFieldError] || (
+                typeof err?.file === 'object'
+                    ? err[nonFieldError]
+                    : err?.file
+            );
             alert.show(
                 // FIXME use translation
                 'Failed to upload the file!',

--- a/src/components/domain/GoSingleFileInput/index.tsx
+++ b/src/components/domain/GoSingleFileInput/index.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback } from 'react';
 import { _cs, isDefined } from '@togglecorp/fujs';
 
+import { transformObjectError } from '#utils/restRequest/error';
 import InputError from '#components/InputError';
 import { NameType } from '#components/types';
 import Link from '#components/Link';
@@ -93,12 +94,25 @@ function GoSingleFileInput<T extends NameType>(props: Props<T>) {
                 });
             }
         },
-        onFailure: (e) => {
-            const serverError = e?.value?.formErrors;
-            const message = `Failed to upload the file! ${serverError?.file ?? serverError?.[nonFieldError] ?? ''}`;
+        onFailure: ({
+            value: {
+                formErrors,
+            },
+        }) => {
+            const err = transformObjectError(formErrors, () => undefined);
+            // NOTE: could not use getErrorObject
+            const serverErrorMessage = err?.[nonFieldError] || (
+                typeof err?.file === 'object'
+                    ? err[nonFieldError]
+                    : err?.file
+            );
             alert.show(
-                message,
-                { variant: 'danger' },
+                // FIXME use translation
+                'Failed to upload the file!',
+                {
+                    variant: 'danger',
+                    description: serverErrorMessage,
+                },
             );
         },
     });

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -255,6 +255,10 @@ export function formatNumber(
     options?: FormatNumberOptions,
 ): undefined
 export function formatNumber(
+    value: number | null | undefined,
+    options?: FormatNumberOptions,
+): undefined
+export function formatNumber(
     value: number,
     options?: FormatNumberOptions,
 ): string


### PR DESCRIPTION
## This PR doesn't introduce:
- [x] typos
- [x] conflict markers
- [x] unwanted comments
- [x] temporary files, auto-generated files or secret keys
- [x] `console.log` meant for debugging
- [x] codegen errors
