### PR TITLE
Use request type helpers instead of directly using generated types

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
         "eslint-plugin-react-refresh": "^0.3.4",
         "fast-glob": "^3.3.0",
         "happy-dom": "^9.18.3",
-        "openapi-typescript": "^5.4.0",
+        "openapi-typescript": "^6.5.5",
         "patch-package": "^7.0.0",
         "postcss": "^8.3.0",
         "postcss-nested": "^6.0.1",

--- a/patches/openapi-typescript+6.5.5.patch
+++ b/patches/openapi-typescript+6.5.5.patch
@@ -1,0 +1,169 @@
+diff --git a/node_modules/openapi-typescript/dist/index.js b/node_modules/openapi-typescript/dist/index.js
+index 716afaa..497d0ac 100644
+--- a/node_modules/openapi-typescript/dist/index.js
++++ b/node_modules/openapi-typescript/dist/index.js
+@@ -89,9 +89,19 @@ async function openapiTS(schema, options = {}) {
+     if (options.inject)
+         output.push(options.inject);
+     const rootTypes = transformSchema(allSchemas["."].schema, ctx);
++    const genericParams = "<TMode extends 'read' | 'write' | 'none' = 'none'>";
++
+     for (const k of Object.keys(rootTypes)) {
+         if (rootTypes[k] && !EMPTY_OBJECT_RE.test(rootTypes[k])) {
+-            output.push(options.exportType ? `export type ${k} = ${rootTypes[k]};` : `export interface ${k} ${rootTypes[k]}`, "");
++            if (k === "paths" || k === "webhooks" || k === "$defs") {
++                output.push(options.exportType
++                    ? `export type ${k} = ${rootTypes[k]};`
++                    : `export interface ${k} ${rootTypes[k]}`, "");
++            } else {
++                output.push(options.exportType
++                    ? `export type ${k}${genericParams} = ${rootTypes[k]};`
++                    : `export interface ${k}${genericParams} ${rootTypes[k]}`, "");
++            }
+         }
+         else {
+             output.push(`export type ${k} = Record<string, never>;`, "");
+@@ -187,7 +197,7 @@ async function openapiTS(schema, options = {}) {
+         output.push(indent(`}${options.exportType ? ";" : ""}`, indentLv), "");
+     }
+     else {
+-        output.push(`export type external = Record<string, never>;`, "");
++        output.push("export type external = Record<string, never>;", "");
+     }
+     if (Object.keys(ctx.operations).length) {
+         output.push(options.exportType ? "export type operations = {" : "export interface operations {", "");
+@@ -199,7 +209,7 @@ async function openapiTS(schema, options = {}) {
+         output.push(`}${options.exportType ? ";" : ""}`, "");
+     }
+     else {
+-        output.push(`export type operations = Record<string, never>;`, "");
++        output.push("export type operations = Record<string, never>;", "");
+     }
+     if (output.join("\n").includes("OneOf")) {
+         output.splice(1, 0, "/** OneOf type helpers */", "type Without<T, U> = { [P in Exclude<keyof T, keyof U>]?: never };", "type XOR<T, U> = (T | U) extends object ? (Without<T, U> & U) | (Without<U, T> & T) : T | U;", "type OneOf<T extends any[]> = T extends [infer Only] ? Only : T extends [infer A, infer B, ...infer Rest] ? OneOf<[XOR<A, B>, ...Rest]> : never;", "");
+diff --git a/node_modules/openapi-typescript/dist/load.js b/node_modules/openapi-typescript/dist/load.js
+index aea4fe0..426fdd8 100644
+--- a/node_modules/openapi-typescript/dist/load.js
++++ b/node_modules/openapi-typescript/dist/load.js
+@@ -67,8 +67,7 @@ export default async function load(schema, options) {
+             return options.schemas;
+         }
+         options.urlCache.add(schemaID);
+-        const ext = path.extname(schema.pathname).toLowerCase();
+-        if (schema.protocol.startsWith("http")) {
++        if (schema.protocol.startsWith("http") || schema.protocol.startsWith("https")) {
+             const headers = { "User-Agent": "openapi-typescript" };
+             if (options.auth)
+                 headers.Authorization = options.auth;
+@@ -83,6 +82,14 @@ export default async function load(schema, options) {
+                 headers,
+             });
+             const contentType = res.headers.get("content-type");
++            const contentDisposition = res.headers.get("content-disposition");
++
++            const match = contentDisposition.match(/^.*filename="?(?<name>.+?)"?(?:;|$)/);
++            const filename = match
++                ? match.groups.name
++                : undefined;
++
++            const ext = path.extname(filename).toLowerCase();
+             if (ext === ".json" || contentType?.includes("json")) {
+                 options.schemas[schemaID] = {
+                     hint,
+@@ -97,6 +104,7 @@ export default async function load(schema, options) {
+             }
+         }
+         else {
++            const ext = path.extname(schema.pathname).toLowerCase();
+             const contents = fs.readFileSync(schema, "utf8");
+             if (ext === ".yaml" || ext === ".yml") {
+                 options.schemas[schemaID] = {
+diff --git a/node_modules/openapi-typescript/dist/transform/request-body-object.js b/node_modules/openapi-typescript/dist/transform/request-body-object.js
+index 33c24be..453a060 100644
+--- a/node_modules/openapi-typescript/dist/transform/request-body-object.js
++++ b/node_modules/openapi-typescript/dist/transform/request-body-object.js
+@@ -20,13 +20,13 @@ export default function transformRequestBodyObject(requestBodyObject, { path, ct
+         if ("$ref" in mediaTypeObject) {
+             output.push(indent(`${key}: ${transformSchemaObject(mediaTypeObject, {
+                 path: `${path}/${contentType}`,
+-                ctx: { ...ctx, indentLv },
++                ctx: { ...ctx, indentLv, mode: "write" },
+             })};`, indentLv));
+         }
+         else {
+             const mediaType = transformMediaTypeObject(mediaTypeObject, {
+                 path: `${path}/${contentType}`,
+-                ctx: { ...ctx, indentLv },
++                ctx: { ...ctx, indentLv, mode: "write" },
+             });
+             output.push(indent(`${key}: ${mediaType};`, indentLv));
+         }
+diff --git a/node_modules/openapi-typescript/dist/transform/response-object.js b/node_modules/openapi-typescript/dist/transform/response-object.js
+index b0e1c20..1f739a8 100644
+--- a/node_modules/openapi-typescript/dist/transform/response-object.js
++++ b/node_modules/openapi-typescript/dist/transform/response-object.js
+@@ -23,7 +23,7 @@ export default function transformResponseObject(responseObject, { path, ctx }) {
+                     key = tsOptionalProperty(key);
+                 output.push(indent(`${key}: ${transformHeaderObject(headerObject, {
+                     path: `${path}/headers/${name}`,
+-                    ctx: { ...ctx, indentLv },
++                    ctx: { ...ctx, indentLv, mode: "read" },
+                 })};`, indentLv));
+             }
+         }
+@@ -41,7 +41,7 @@ export default function transformResponseObject(responseObject, { path, ctx }) {
+                 key = tsReadonly(key);
+             output.push(indent(`${key}: ${transformMediaTypeObject(mediaTypeObject, {
+                 path: `${path}/content/${contentType}`,
+-                ctx: { ...ctx, indentLv: indentLv },
++                ctx: { ...ctx, indentLv: indentLv, mode: "read" },
+             })};`, indentLv));
+         }
+         indentLv--;
+diff --git a/node_modules/openapi-typescript/dist/transform/schema-object.js b/node_modules/openapi-typescript/dist/transform/schema-object.js
+index 15f144c..25e853c 100644
+--- a/node_modules/openapi-typescript/dist/transform/schema-object.js
++++ b/node_modules/openapi-typescript/dist/transform/schema-object.js
+@@ -21,13 +21,29 @@ export function defaultSchemaObjectTransform(schemaObject, { path, ctx }) {
+         return ctx.immutableTypes ? tsReadonly(finalType) : finalType;
+     }
+     if ("$ref" in schemaObject) {
+-        return schemaObject.$ref;
++        const genericValue = ctx.mode ? `'${ctx.mode}'` : "TMode";
++        return schemaObject.$ref.replace(/^(\w+)/, `$1<${genericValue}>`);
+     }
+     if (typeof ctx.transform === "function") {
+         const result = ctx.transform(schemaObject, { path, ctx });
+         if (result)
+             return result;
+     }
++
++    if (schemaObject.readOnly) {
++        return `TMode extends 'write' ? never : ${defaultSchemaObjectTransform(
++            { ...schemaObject, readOnly: undefined },
++            { path, ctx }
++        )}`;
++    }
++
++    if (schemaObject.writeOnly) {
++        return `TMode extends 'read' ? never : ${defaultSchemaObjectTransform(
++            { ...schemaObject, writeOnly: undefined },
++            { path, ctx }
++        )}`;
++    }
++
+     if (schemaObject.const !== null && schemaObject.const !== undefined) {
+         return transformSchemaObject(escStr(schemaObject.const), {
+             path,
+diff --git a/node_modules/openapi-typescript/dist/types.d.ts b/node_modules/openapi-typescript/dist/types.d.ts
+index 9b28fc0..732a789 100644
+--- a/node_modules/openapi-typescript/dist/types.d.ts
++++ b/node_modules/openapi-typescript/dist/types.d.ts
+@@ -380,6 +380,7 @@ export interface GlobalContext {
+     silent: boolean;
+     supportArrayLength: boolean;
+     excludeDeprecated: boolean;
++    mode?: "read" | "write";
+ }
+ export type $defs = Record<string, SchemaObject>;
+ export type Fetch = (input: RequestInfo, init?: RequestInit) => Promise<Response>;

--- a/src/components/Table/ColumnShortcuts/index.ts
+++ b/src/components/Table/ColumnShortcuts/index.ts
@@ -8,37 +8,37 @@ import {
 } from '@togglecorp/fujs';
 
 import DateOutput from '#components/DateOutput';
-import type { Props as DateOutputProps } from '#components/DateOutput';
+import { type Props as DateOutputProps } from '#components/DateOutput';
 import DateRangeOutput from '#components/DateRangeOutput';
-import type { Props as DateRangeOutputProps } from '#components/DateRangeOutput';
+import { type Props as DateRangeOutputProps } from '#components/DateRangeOutput';
 import NumberOutput from '#components/NumberOutput';
-import type { Props as NumberOutputProps } from '#components/NumberOutput';
+import { type Props as NumberOutputProps } from '#components/NumberOutput';
 import BooleanOutput from '#components/BooleanOutput';
-import type { Props as BooleanOutputProps } from '#components/BooleanOutput';
+import { type Props as BooleanOutputProps } from '#components/BooleanOutput';
 import ProgressBar from '#components/ProgressBar';
-import type { Props as ProgressBarProps } from '#components/ProgressBar';
+import { type Props as ProgressBarProps } from '#components/ProgressBar';
 import ReducedListDisplay, {
     Props as ReducedListDisplayProps,
 } from '#components/ReducedListDisplay';
-import type { Props as LinkProps } from '#components/Link';
+import { type Props as LinkProps } from '#components/Link';
 import Link from '#components/Link';
-import { paths } from '#generated/types';
 import { numericIdSelector } from '#utils/selectors';
+import { type GoApiResponse } from '#utils/restRequest';
 
 import TableActions, {
     Props as TableActionsProps,
 } from '../TableActions';
 import HeaderCell from '../HeaderCell';
-import type { HeaderCellProps } from '../HeaderCell';
+import { type HeaderCellProps } from '../HeaderCell';
 import Cell from '../Cell';
-import type { CellProps } from '../Cell';
-import type { SortDirection, Column } from '../types';
+import { type CellProps } from '../Cell';
+import { type SortDirection, Column } from '../types';
 import ExpandButton from './ExpandButton';
-import type { ExpandButtonProps } from './ExpandButton';
+import { type ExpandButtonProps } from './ExpandButton';
 import ExpansionIndicator from './ExpansionIndicator';
-import type { Props as ExpansionIndicatorProps } from './ExpansionIndicator';
+import { type Props as ExpansionIndicatorProps } from './ExpansionIndicator';
 import CountryLink from './CountryLink';
-import type { Props as CountryLinkProps } from './CountryLink';
+import { type Props as CountryLinkProps } from './CountryLink';
 
 import styles from './styles.module.css';
 
@@ -500,8 +500,7 @@ export function createListDisplayColumn<DATUM, KEY, LIST_ITEM, RENDERER_PROPS>(
     return item;
 }
 
-type GetCountry = paths['/api/v2/country/']['get'];
-type CountryResponse = GetCountry['responses']['200']['content']['application/json'];
+type CountryResponse = GoApiResponse<'/api/v2/country/'>;
 type CountryListItem = NonNullable<CountryResponse['results']>[number];
 type PartialCountry = Pick<CountryListItem, 'id' | 'name'>;
 

--- a/src/components/domain/ActivityEventSearchSelectInput.tsx
+++ b/src/components/domain/ActivityEventSearchSelectInput.tsx
@@ -3,13 +3,11 @@ import { useState } from 'react';
 import SearchSelectInput, {
     Props as SearchSelectInputProps,
 } from '#components/SearchSelectInput';
-import { useRequest } from '#utils/restRequest';
+import { useRequest, type GoApiResponse, type GoApiUrlQuery } from '#utils/restRequest';
 import useDebouncedValue from '#hooks/useDebouncedValue';
-import { paths } from '#generated/types';
 
-type GetEvent = paths['/api/v2/event/response-activity/']['get'];
-type GetEventParams = GetEvent['parameters']['query'];
-type GetEventResponse = GetEvent['responses']['200']['content']['application/json'];
+type GetEventParams = GoApiUrlQuery<'/api/v2/event/response-activity/'>;
+type GetEventResponse = GoApiResponse<'/api/v2/event/response-activity/'>;
 export type EventItem = Pick<NonNullable<GetEventResponse['results']>[number], 'id' | 'name' | 'dtype' | 'emergency_response_contact_email'>;
 
 const keySelector = (d: EventItem) => d.id;

--- a/src/components/domain/AppealsOverYearsChart/PointDetails/index.tsx
+++ b/src/components/domain/AppealsOverYearsChart/PointDetails/index.tsx
@@ -3,12 +3,12 @@ import { _cs } from '@togglecorp/fujs';
 import Container from '#components/Container';
 import TextOutput from '#components/TextOutput';
 import useTranslation from '#hooks/useTranslation';
-import { paths } from '#generated/types';
+import { type GoApiResponse } from '#utils/restRequest';
 
 import i18n from './i18n.json';
 import styles from './styles.module.css';
 
-type AggregateResponse = paths['/api/v1/aggregate/']['get']['responses']['200']['content']['application/json'];
+type AggregateResponse = GoApiResponse<'/api/v1/aggregate/'>;
 type AggregateItem = AggregateResponse[number];
 
 interface Props {

--- a/src/components/domain/DistrictSearchMultiSelectInput/index.tsx
+++ b/src/components/domain/DistrictSearchMultiSelectInput/index.tsx
@@ -9,16 +9,16 @@ import SearchMultiSelectInput, {
 import {
     useRequest,
     useLazyRequest,
+    type GoApiUrlQuery,
+    type GoApiResponse,
 } from '#utils/restRequest';
 import Button from '#components/Button';
 import useDebouncedValue from '#hooks/useDebouncedValue';
-import { paths } from '#generated/types';
 
 import styles from './styles.module.css';
 
-type GetDistrict = paths['/api/v2/district/']['get'];
-type GetDistrictParams = GetDistrict['parameters']['query'];
-type GetDistrictResponse = GetDistrict['responses']['200']['content']['application/json'];
+type GetDistrictParams = GoApiUrlQuery<'/api/v2/district/'>;
+type GetDistrictResponse = GoApiResponse<'/api/v2/district/'>;
 
 export type DistrictItem = Pick<NonNullable<GetDistrictResponse['results']>[number], 'id' | 'name'>;
 

--- a/src/components/domain/EventSearchSelectInput.tsx
+++ b/src/components/domain/EventSearchSelectInput.tsx
@@ -6,13 +6,13 @@ import SearchSelectInput, {
 
 import {
     useRequest,
+    type GoApiUrlQuery,
+    type GoApiResponse,
 } from '#utils/restRequest';
 import useDebouncedValue from '#hooks/useDebouncedValue';
-import { paths } from '#generated/types';
 
-type GetEvent = paths['/api/v2/event/mini/']['get'];
-type GetEventParams = GetEvent['parameters']['query'];
-type GetEventResponse = GetEvent['responses']['200']['content']['application/json'];
+type GetEventParams = GoApiUrlQuery<'/api/v2/event/mini/'>;
+type GetEventResponse = GoApiResponse<'/api/v2/event/mini/'>;
 export type EventItem = Pick<NonNullable<GetEventResponse['results']>[number], 'id' | 'name' | 'dtype'>;
 
 const keySelector = (d: EventItem) => d.id;

--- a/src/components/domain/FieldReportSearchSelectInput.tsx
+++ b/src/components/domain/FieldReportSearchSelectInput.tsx
@@ -6,13 +6,13 @@ import SearchSelectInput, {
 
 import {
     useRequest,
+    type GoApiUrlQuery,
+    type GoApiResponse,
 } from '#utils/restRequest';
 import useDebouncedValue from '#hooks/useDebouncedValue';
-import { paths } from '#generated/types';
 
-type GetFieldReport = paths['/api/v2/field-report/']['get'];
-type GetFieldReportParams = GetFieldReport['parameters']['query'];
-type GetFieldReportResponse = GetFieldReport['responses']['200']['content']['application/json'];
+type GetFieldReportParams = GoApiUrlQuery<'/api/v2/field-report/'>;
+type GetFieldReportResponse = GoApiResponse<'/api/v2/field-report/'>;
 export type FieldReportItem = Pick<NonNullable<GetFieldReportResponse['results']>[number], 'id' | 'summary'>;
 
 const keySelector = (d: FieldReportItem) => d.id;

--- a/src/components/domain/HighlightedOperations/OperationCard/index.tsx
+++ b/src/components/domain/HighlightedOperations/OperationCard/index.tsx
@@ -10,17 +10,16 @@ import KeyFigure from '#components/KeyFigure';
 import Tooltip from '#components/Tooltip';
 import TextOutput from '#components/TextOutput';
 import SeverityIndicator from '#components/domain/SeverityIndicator';
-import { paths } from '#generated/types';
 import useTranslation from '#hooks/useTranslation';
 import { resolveToComponent } from '#utils/translation';
 import { useLazyRequest } from '#utils/restRequest';
 import { sumSafe } from '#utils/common';
+import { type GoApiResponse } from '#utils/restRequest';
 
 import i18n from './i18n.json';
 import styles from './styles.module.css';
 
-type GetEvent = paths['/api/v2/event/']['get'];
-type EventResponse = GetEvent['responses']['200']['content']['application/json'];
+type EventResponse = GoApiResponse<'/api/v2/event/'>;
 type EventListItem = NonNullable<EventResponse['results']>[number];
 
 interface Props {

--- a/src/components/domain/PerAssessmentSummary/index.tsx
+++ b/src/components/domain/PerAssessmentSummary/index.tsx
@@ -15,13 +15,13 @@ import NumberOutput from '#components/NumberOutput';
 import StackedProgressBar from '#components/StackedProgressBar';
 import TextOutput from '#components/TextOutput';
 import { sumSafe } from '#utils/common';
-import type { paths } from '#generated/types';
+import { type GoApiResponse } from '#utils/restRequest';
 
 import styles from './styles.module.css';
 
-type PerOptionsResponse = paths['/api/v2/per-options/']['get']['responses']['200']['content']['application/json'];
+type PerOptionsResponse = GoApiResponse<'/api/v2/per-options/'>;
+type AssessmentRequestBody = GoApiResponse<'/api/v2/per-assessment/{id}/', 'PUT'>;
 
-type AssessmentRequestBody = paths['/api/v2/per-assessment/{id}/']['put']['requestBody']['content']['application/json'];
 export type PartialAssessment = PartialForm<
     AssessmentRequestBody,
     'area' | 'component' | 'question'

--- a/src/components/domain/RegionSelectInput.tsx
+++ b/src/components/domain/RegionSelectInput.tsx
@@ -1,10 +1,10 @@
 import type { Props as SelectInputProps } from '#components/SelectInput';
 import SelectInput from '#components/SelectInput';
 import useGlobalEnums from '#hooks/domain/useGlobalEnums';
-import { components } from '#generated/types';
+import { type components } from '#generated/types';
 import { stringValueSelector } from '#utils/selectors';
 
-export type RegionOption = components['schemas']['ApiRegionNameEnum'];
+export type RegionOption = components<'read'>['schemas']['ApiRegionNameEnum'];
 function regionKeySelector(option: RegionOption) {
     return option.key;
 }

--- a/src/components/domain/RiskImminentEventMap/index.tsx
+++ b/src/components/domain/RiskImminentEventMap/index.tsx
@@ -26,7 +26,7 @@ import {
     defaultNavControlOptions,
     defaultNavControlPosition,
 } from '#utils/map';
-import type { components } from '#generated/riskTypes';
+import { type components } from '#generated/riskTypes';
 import {
     COLOR_WHITE,
     DEFAULT_MAP_PADDING,
@@ -51,7 +51,7 @@ const mapImageOption = {
     sdf: true,
 };
 
-type HazardType = components['schemas']['HazardTypeEnum'];
+type HazardType = components<'read'>['schemas']['HazardTypeEnum'];
 
 const hazardKeys = Object.keys(hazardKeyToIconmap) as HazardType[];
 

--- a/src/components/domain/RiskImminentEventMap/mapStyles.ts
+++ b/src/components/domain/RiskImminentEventMap/mapStyles.ts
@@ -17,9 +17,9 @@ import cycloneIcon from '#assets/icons/risk/cyclone.png';
 import droughtIcon from '#assets/icons/risk/drought.png';
 import wildfireIcon from '#assets/icons/risk/wildfire.png';
 
-import type { components } from '#generated/riskTypes';
+import { type components } from '#generated/riskTypes';
 
-type HazardType = components['schemas']['HazardTypeEnum'];
+type HazardType = components<'read'>['schemas']['HazardTypeEnum'];
 
 export const hazardKeyToIconmap: Record<HazardType, string | null> = {
     EQ: earthquakeIcon,

--- a/src/components/domain/RiskImminentEvents/index.tsx
+++ b/src/components/domain/RiskImminentEvents/index.tsx
@@ -11,7 +11,7 @@ import {
 import RadioInput from '#components/RadioInput';
 import { stringLabelSelector } from '#utils/selectors';
 import { hazardTypeToColorMap } from '#utils/domain/risk';
-import type { components } from '#generated/riskTypes';
+import { type components } from '#generated/riskTypes';
 import Container from '#components/Container';
 import useTranslation from '#hooks/useTranslation';
 
@@ -28,7 +28,7 @@ function viewKeySelector(option: ViewOption) {
     return option.key;
 }
 
-type HazardType = components['schemas']['HazardTypeEnum'];
+type HazardType = components<'read'>['schemas']['HazardTypeEnum'];
 const riskHazards: Array<{
     key: HazardType,
     label: string,

--- a/src/contexts/domain.tsx
+++ b/src/contexts/domain.tsx
@@ -3,7 +3,7 @@ import { type GoApiResponse } from '#utils/restRequest';
 
 export type CacheKey = 'country' | 'global-enums' | 'disaster-type' | 'user-me';
 
-export type GlobalEnums = GoApiResponse<'/api/v2/global-enums/'>;
+export type GlobalEnums = Partial<GoApiResponse<'/api/v2/global-enums/'>>;
 export type Countries = GoApiResponse<'/api/v2/country/'>;
 export type DisasterTypes = GoApiResponse<'/api/v2/disaster_type/'>;
 export type UserMe = GoApiResponse<'/api/v2/user/me/'>;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,6 +1,4 @@
-import {
-    components,
-} from '#generated/types';
+import { type components } from '#generated/types';
 
 export const DEFAULT_DATE_FORMAT = 'dd-MM-yyyy';
 
@@ -67,17 +65,17 @@ export const COLOR_PRIMARY_RED = '#f5333f';
 
 // Three W
 
-type OperationTypeEnum = components['schemas']['OperationTypeEnum'];
+type OperationTypeEnum = components<'read'>['schemas']['OperationTypeEnum'];
 export const OPERATION_TYPE_PROGRAMME = 0 satisfies OperationTypeEnum;
 export const OPERATION_TYPE_EMERGENCY = 1 satisfies OperationTypeEnum;
 export const OPERATION_TYPE_MULTI = -1;
 
-type ProgrammeTypeEnum = components['schemas']['Key1d2Enum'];
+type ProgrammeTypeEnum = components<'read'>['schemas']['Key1d2Enum'];
 export const PROGRAMME_TYPE_MULTILATERAL = 1 satisfies ProgrammeTypeEnum;
 export const PROGRAMME_TYPE_DOMESTIC = 2 satisfies ProgrammeTypeEnum;
 export const PROGRAMME_TYPE_BILATERAL = 0 satisfies ProgrammeTypeEnum;
 
-type StatusTypeEnum = components['schemas']['Key1d2Enum'];
+type StatusTypeEnum = components<'read'>['schemas']['Key1d2Enum'];
 export const PROJECT_STATUS_COMPLETED = 2 satisfies StatusTypeEnum;
 export const PROJECT_STATUS_ONGOING = 1 satisfies StatusTypeEnum;
 export const PROJECT_STATUS_PLANNED = 0 satisfies StatusTypeEnum;
@@ -86,15 +84,15 @@ export const PROJECT_STATUS_PLANNED = 0 satisfies StatusTypeEnum;
 
 // FIXME: fix typing in server (medium priority)
 // This should not be the same as OperationType.
-type DrefStatus = components['schemas']['OperationTypeEnum'];
+type DrefStatus = components<'read'>['schemas']['OperationTypeEnum'];
 export const DREF_STATUS_COMPLETED = 1 satisfies DrefStatus;
 export const DREF_STATUS_IN_PROGRESS = 0 satisfies DrefStatus;
-type TypeOfDrefEnum = components['schemas']['TypeOfDrefEnum'];
+type TypeOfDrefEnum = components<'read'>['schemas']['TypeOfDrefEnum'];
 export const DREF_TYPE_IMMINENT = 0 satisfies TypeOfDrefEnum;
 export const DREF_TYPE_ASSESSMENT = 1 satisfies TypeOfDrefEnum;
 
 // Subscriptions
-type SubscriptionRecordTypeEnum = components['schemas']['RtypeEnum'];
+type SubscriptionRecordTypeEnum = components<'read'>['schemas']['RtypeEnum'];
 export const SUBSCRIPTION_SURGE_ALERT = 3 satisfies SubscriptionRecordTypeEnum;
 export const SUBSCRIPTION_COUNTRY = 4 satisfies SubscriptionRecordTypeEnum;
 export const SUBSCRIPTION_REGION = 5 satisfies SubscriptionRecordTypeEnum;
@@ -109,29 +107,29 @@ export const SUBSCRIPTION_GENERAL = 14 satisfies SubscriptionRecordTypeEnum;
 
 // Field Report
 
-export type FieldReportStatusEnum = components['schemas']['StatusBb2Enum'];
+export type FieldReportStatusEnum = components<'read'>['schemas']['StatusBb2Enum'];
 export const FIELD_REPORT_STATUS_EARLY_WARNING = 8 satisfies FieldReportStatusEnum;
 export const FIELD_REPORT_STATUS_EVENT = 9 satisfies FieldReportStatusEnum;
 
-export type Bulletin = components['schemas']['BulletinEnum'];
+export type Bulletin = components<'read'>['schemas']['BulletinEnum'];
 export const BULLETIN_PUBLISHED_NO = 0 satisfies Bulletin;
 export const BULLETIN_PUBLISHED_PLANNED = 2 satisfies Bulletin;
 export const BULLETIN_PUBLISHED_YES = 3 satisfies Bulletin;
 
-type RequestChoices = components['schemas']['Key02bEnum'];
+type RequestChoices = components<'read'>['schemas']['Key02bEnum'];
 export const REQUEST_CHOICES_NO = 0 satisfies RequestChoices;
 
 export type ContactType = 'Originator' | 'NationalSociety' | 'Federation' | 'Media';
-export type OrganizationType = components['schemas']['Key1aeEnum'];
-export type ReportType = components['schemas']['FieldReportTypesEnum'];
-export type CategoryType = components['schemas']['KeyA87Enum'];
+export type OrganizationType = components<'read'>['schemas']['Key1aeEnum'];
+export type ReportType = components<'read'>['schemas']['FieldReportTypesEnum'];
+export type CategoryType = components<'read'>['schemas']['KeyA87Enum'];
 
 // Common
 
 // FIXME: we need to identify a typesafe way to get this value
 export const DISASTER_TYPE_EPIDEMIC = 1;
 
-export type Visibility = components['schemas']['VisibilityD1bEnum'];
+export type Visibility = components<'read'>['schemas']['VisibilityD1bEnum'];
 export const VISIBILITY_RCRC_MOVEMENT = 1 satisfies Visibility;
 export const VISIBILITY_IFRC_SECRETARIAT = 2 satisfies Visibility;
 export const VISIBILITY_PUBLIC = 3 satisfies Visibility;

--- a/src/utils/domain/emergency.ts
+++ b/src/utils/domain/emergency.ts
@@ -1,9 +1,8 @@
 import { max } from '@togglecorp/fujs';
 import { sumSafe } from '#utils/common';
-import type { paths } from '#generated/types';
+import { type GoApiResponse } from '#utils/restRequest';
 
-type GetEvent = paths['/api/v2/event/']['get'];
-type EventResponse = GetEvent['responses']['200']['content']['application/json'];
+type EventResponse = GoApiResponse<'/api/v2/event/'>;
 type EventListItem = NonNullable<EventResponse['results']>[number];
 
 // eslint-disable-next-line import/prefer-default-export

--- a/src/utils/domain/per.ts
+++ b/src/utils/domain/per.ts
@@ -1,7 +1,8 @@
 import { isNotDefined, isDefined } from '@togglecorp/fujs';
-import type { paths, components } from '#generated/types';
+import { type GoApiResponse } from '#utils/restRequest';
+import { type components } from '#generated/types';
 
-type PerPhase = components['schemas']['PhaseEnum'];
+type PerPhase = components<'read'>['schemas']['PhaseEnum'];
 
 export const PER_PHASE_OVERVIEW = 1 satisfies PerPhase;
 export const PER_PHASE_ASSESSMENT = 2 satisfies PerPhase;
@@ -9,7 +10,7 @@ export const PER_PHASE_PRIORITIZATION = 3 satisfies PerPhase;
 export const PER_PHASE_WORKPLAN = 4 satisfies PerPhase;
 export const PER_PHASE_ACTION = 5 satisfies PerPhase;
 
-type PerProcessStatusResponse = paths['/api/v2/per-process-status/{id}/']['get']['responses']['200']['content']['application/json'];
+type PerProcessStatusResponse = GoApiResponse<'/api/v2/per-process-status/{id}/'>;
 
 export function getCurrentPerProcessStep(status: PerProcessStatusResponse | undefined) {
     if (isNotDefined(status)) {

--- a/src/utils/domain/risk.ts
+++ b/src/utils/domain/risk.ts
@@ -9,7 +9,8 @@ import {
     unique,
 } from '@togglecorp/fujs';
 
-import type { paths, components } from '#generated/riskTypes';
+import { type RiskApiResponse } from '#utils/restRequest';
+import { type components } from '#generated/riskTypes';
 import { sumSafe, maxSafe, avgSafe } from '#utils/common';
 import {
     CATEGORY_RISK_HIGH,
@@ -27,7 +28,11 @@ import {
     COLOR_LIGHT_GREY,
 } from '#utils/constants';
 
-export type HazardType = components['schemas']['HazardTypeEnum'];
+export type HazardType = components<'read'>['schemas']['HazardTypeEnum'];
+type IpcEstimationType = components<'read'>['schemas']['EstimationTypeEnum'];
+type CountrySeasonal = RiskApiResponse<'/api/v1/country-seasonal/'>;
+type IpcData = CountrySeasonal[number]['ipc_displacement_data'];
+type GwisData = CountrySeasonal[number]['gwis'];
 
 export const hazardTypeToColorMap: Record<HazardType, string> = {
     EQ: COLOR_HAZARD_EARTHQUAKE,
@@ -42,6 +47,7 @@ export const hazardTypeToColorMap: Record<HazardType, string> = {
     WF: COLOR_HAZARD_WILDFIRE,
 };
 
+// FIXME: fix typings in server (medium priority)
 export function getDataWithTruthyHazardType<
     HAZARD_TYPE extends HazardType | '',
     DATA extends { hazard_type?: HAZARD_TYPE | undefined | null }
@@ -117,12 +123,6 @@ export function getValueForSelectedMonths(
 
     return sumSafe(valueList);
 }
-
-type GetCountrySeasonal = paths['/api/v1/country-seasonal/']['get'];
-type CountrySeasonal = GetCountrySeasonal['responses']['200']['content']['application/json'];
-type IpcData = CountrySeasonal[number]['ipc_displacement_data'];
-type GwisData = CountrySeasonal[number]['gwis'];
-type IpcEstimationType = components['schemas']['EstimationTypeEnum'];
 
 const estimationPriorityMap: Record<IpcEstimationType, number> = {
     current: 0,

--- a/src/utils/outletContext.ts
+++ b/src/utils/outletContext.ts
@@ -1,7 +1,7 @@
-import type { paths } from '#generated/types';
 import type { GoApiResponse } from '#utils/restRequest';
 
-type EmergencyResponse = paths['/api/v2/event/{id}/']['get']['responses']['200']['content']['application/json'];
+type EmergencyResponse = GoApiResponse<'/api/v2/event/{id}/'>;
+
 export interface EmergencyOutletContext {
     emergencyResponse: EmergencyResponse | undefined;
 }
@@ -20,7 +20,7 @@ export interface RegionOutletContext {
     regionKeyFigureResponse: RegionKeyFigureResponse | undefined;
 }
 
-type PerProcessStatusResponse = paths['/api/v2/per-process-status/{id}/']['get']['responses']['200']['content']['application/json'];
+type PerProcessStatusResponse = GoApiResponse<'/api/v2/per-process-status/{id}/'>;
 export interface PerProcessOutletContext {
     statusResponse: PerProcessStatusResponse | undefined,
     refetchStatusResponse: () => void,

--- a/src/utils/restRequest/overrideTypes.ts
+++ b/src/utils/restRequest/overrideTypes.ts
@@ -4,6 +4,7 @@ import {
     useRequest,
     useLazyRequest,
 } from '@togglecorp/toggle-request';
+import { type DeepNevaRemove } from '#utils/common';
 
 import {
     TransformedError,
@@ -17,42 +18,42 @@ export type VALID_METHOD = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
 export type ApiResponse<SCHEME, URL extends keyof SCHEME, METHOD extends 'GET' | 'POST' | 'PUT' | 'PATCH' = 'GET'> = (
     METHOD extends 'GET'
     ? SCHEME[URL] extends { get: { responses: { 200: { content: { 'application/json': infer Res } } } } }
-        ? Res
+        ? DeepNevaRemove<Res>
         : never
     : METHOD extends 'POST'
         ? SCHEME[URL] extends { post: { responses: { 201: { content: { 'application/json': infer Res } } } } }
-            ? Res
+            ? DeepNevaRemove<Res>
             : never
         : METHOD extends 'PATCH'
             ? SCHEME[URL] extends { patch: { responses: { 200: { content: { 'application/json': infer Res } } } } }
-                ? Res
+                ? DeepNevaRemove<Res>
                 : never
             : METHOD extends 'PUT'
                 ? SCHEME[URL] extends { put: { responses: { 200: { content: { 'application/json': infer Res } } } } }
-                    ? Res
+                    ? DeepNevaRemove<Res>
                     : never
                 : never
 )
 
 export type ApiUrlQuery<SCHEME, URL extends keyof SCHEME, METHOD extends 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' = 'GET'> = (
     METHOD extends 'GET'
-    ? SCHEME[URL] extends { get: { parameters: { query: infer Query } } }
+    ? SCHEME[URL] extends { get: { parameters: { query?: infer Query } } }
         ? Query
         : never
     : METHOD extends 'POST'
-        ? SCHEME[URL] extends { post: { parameters: { query: infer Query } } }
+        ? SCHEME[URL] extends { post: { parameters: { query?: infer Query } } }
             ? Query
             : never
         : METHOD extends 'PATCH'
-            ? SCHEME[URL] extends { patch: { parameters: { query: infer Query } } }
+            ? SCHEME[URL] extends { patch: { parameters: { query?: infer Query } } }
                 ? Query
                 : never
             : METHOD extends 'PUT'
-                ? SCHEME[URL] extends { put: { parameters: { query: infer Query } } }
+                ? SCHEME[URL] extends { put: { parameters: { query?: infer Query } } }
                     ? Query
                     : never
                 : METHOD extends 'DELETE'
-                    ? SCHEME[URL] extends { delete: { parameters: { query: infer Query } } }
+                    ? SCHEME[URL] extends { delete: { parameters: { query?: infer Query } } }
                         ? Query
                         : never
                     : never
@@ -60,16 +61,16 @@ export type ApiUrlQuery<SCHEME, URL extends keyof SCHEME, METHOD extends 'GET' |
 
 export type ApiBody<SCHEME, URL extends keyof SCHEME, METHOD extends 'POST' | 'PUT' | 'PATCH'> = (
     METHOD extends 'POST'
-        ? SCHEME[URL] extends { post: { requestBody: { content: { 'application/json': infer Res } } } }
-            ? Res
+        ? SCHEME[URL] extends { post: { requestBody?: { content: { 'application/json': infer Res } } } }
+            ? DeepNevaRemove<Res>
             : never
         : METHOD extends 'PATCH'
-            ? SCHEME[URL] extends { patch: { requestBody: { content: { 'application/json': infer Res } } } }
-                ? Res
+            ? SCHEME[URL] extends { patch: { requestBody?: { content: { 'application/json': infer Res } } } }
+                ? DeepNevaRemove<Res>
                 : never
             : METHOD extends 'PUT'
-                ? SCHEME[URL] extends { put: { requestBody: { content: { 'application/json': infer Res } } } }
-                    ? Res
+                ? SCHEME[URL] extends { put: { requestBody?: { content: { 'application/json': infer Res } } } }
+                    ? DeepNevaRemove<Res>
                     : never
                 : never
 )
@@ -80,10 +81,10 @@ export type ApiBody<SCHEME, URL extends keyof SCHEME, METHOD extends 'POST' | 'P
 type ResolveResponseContent<RESPONSES, METHOD> = (
     METHOD extends 'POST'
         ? RESPONSES extends { 201 : { content: { 'application/json': infer Response } } }
-            ? Response
+            ? DeepNevaRemove<Response>
             : ResolveResponseContent<RESPONSES, undefined>
         : RESPONSES extends { 200 : { content: { 'application/json': infer Response } } }
-            ? Response
+            ? DeepNevaRemove<Response>
             : unknown
 );
 
@@ -94,14 +95,14 @@ type ResolvePath<PARAMETERS> = (
 );
 
 type ResolveQuery<PARAMETERS> = (
-    PARAMETERS extends { query: infer Query }
+    PARAMETERS extends { query?: infer Query }
         ? Query
         : unknown
 );
 
 type ResolveRequestBody<REQUEST_BODY> = (
     REQUEST_BODY extends { content: { 'application/json': infer RequestBody } }
-        ? RequestBody
+        ? DeepNevaRemove<RequestBody>
         : unknown
 );
 

--- a/src/views/AccountDrefApplications/CompletedDrefTable/index.tsx
+++ b/src/views/AccountDrefApplications/CompletedDrefTable/index.tsx
@@ -172,9 +172,16 @@ function CompletedDrefTable(props: Props) {
                     (opsUpdate) => ({
                         ...opsUpdate,
                         dref: datum.dref,
+                        glide_code: datum.glide_code,
+                        date_of_publication: datum.date_of_publication,
                     }),
                 ),
-                { ...datum.dref, dref: datum.dref },
+                {
+                    ...datum.dref,
+                    dref: datum.dref,
+                    glide_code: datum.glide_code,
+                    date_of_publication: datum.date_of_publication,
+                },
             ];
 
             return (

--- a/src/views/AccountDrefApplications/DrefTableActions/DrefExportModal/index.tsx
+++ b/src/views/AccountDrefApplications/DrefTableActions/DrefExportModal/index.tsx
@@ -53,9 +53,7 @@ function DrefExportModal(props: Props) {
         skip: isDefined(exportId) || isNotDefined(id),
         method: 'POST',
         url: '/api/v2/pdf-export/',
-        // FIXME: fix typing in server (low priority)
-        // the server generated type for response and body is the same
-        body: exportTriggerBody as never,
+        body: exportTriggerBody,
         onSuccess: (response) => {
             if (isDefined(response.id)) {
                 setExportId(response.id);

--- a/src/views/AccountDrefApplications/DrefTableActions/index.tsx
+++ b/src/views/AccountDrefApplications/DrefTableActions/index.tsx
@@ -15,7 +15,7 @@ import TableActions from '#components/Table/TableActions';
 import Link from '#components/Link';
 import useBooleanState from '#hooks/useBooleanState';
 import useTranslation from '#hooks/useTranslation';
-import { components } from '#generated/types';
+import { type components } from '#generated/types';
 import {
     DREF_STATUS_COMPLETED,
     DREF_STATUS_IN_PROGRESS,
@@ -26,7 +26,7 @@ import i18n from './i18n.json';
 import styles from './styles.module.css';
 import DrefShareModal from './DrefShareModal';
 
-type DrefStatus = components['schemas']['OperationTypeEnum'];
+type DrefStatus = components<'read'>['schemas']['OperationTypeEnum'];
 
 export interface Props {
     drefId: number;

--- a/src/views/AccountDrefApplications/Filters/index.tsx
+++ b/src/views/AccountDrefApplications/Filters/index.tsx
@@ -8,11 +8,11 @@ import DisasterTypeSelectInput from '#components/domain/DisasterTypeSelectInput'
 import useTranslation from '#hooks/useTranslation';
 import useGlobalEnums from '#hooks/domain/useGlobalEnums';
 import { stringValueSelector } from '#utils/selectors';
-import { components } from '#generated/types';
+import { type components } from '#generated/types';
 
 import i18n from './i18n.json';
 
-type TypeOfDref = components['schemas']['TypeOfDrefEnum'];
+type TypeOfDref = components<'read'>['schemas']['TypeOfDrefEnum'];
 function typeOfDrefKeySelector({ key } : { key: TypeOfDref }) {
     return key;
 }

--- a/src/views/AccountInformation/EditAccountInfo/index.tsx
+++ b/src/views/AccountInformation/EditAccountInfo/index.tsx
@@ -37,13 +37,13 @@ import styles from './styles.module.css';
 
 type GlobalEnumsResponse = GoApiResponse<'/api/v2/global-enums/'>;
 type OrganizationTypeOption = {
-    key: NonNullable<GlobalEnumsResponse['api_profile_org_types']>[number]['key'] | '';
+    key: NonNullable<GlobalEnumsResponse['api_profile_org_types']>[number]['key'];
     value: string;
 }
 
 type UserMeResponse = GoApiResponse<'/api/v2/user/me/'>;
 
-type AccountRequestBody = GoApiBody<'/api/v2/user/{id}/', 'PUT'>;
+type AccountRequestBody = GoApiBody<'/api/v2/user/{id}/', 'PATCH'>;
 
 type PartialFormFields = PartialForm<AccountRequestBody>;
 
@@ -95,8 +95,7 @@ function EditAccountInfo(props: Props) {
         last_name: userDetails?.last_name,
         profile: {
             city: userDetails?.profile?.city,
-            org_type: userDetails?.profile?.org_type === ''
-                ? undefined : userDetails?.profile?.org_type,
+            org_type: userDetails?.profile?.org_type,
             org: userDetails?.profile?.org,
             department: userDetails?.profile?.department,
             phone_number: userDetails?.profile?.phone_number,

--- a/src/views/AccountNotifications/SubscriptionPreferences/index.tsx
+++ b/src/views/AccountNotifications/SubscriptionPreferences/index.tsx
@@ -14,7 +14,7 @@ import useCountry from '#hooks/domain/useCountry';
 import useDisasterTypes from '#hooks/domain/useDisasterType';
 import useGlobalEnums from '#hooks/domain/useGlobalEnums';
 import { numericIdSelector, stringNameSelector, stringValueSelector } from '#utils/selectors';
-import { components } from '#generated/types';
+import { type components } from '#generated/types';
 import Checkbox from '#components/Checkbox';
 import Button from '#components/Button';
 import useUserMe from '#hooks/domain/useUserMe';
@@ -39,7 +39,7 @@ import useTranslation from '#hooks/useTranslation';
 import i18n from './i18n.json';
 import styles from './styles.module.css';
 
-export type RegionOption = components['schemas']['ApiRegionNameEnum'];
+export type RegionOption = components<'read'>['schemas']['ApiRegionNameEnum'];
 
 function regionKeySelector(option: RegionOption) {
     return option.key;

--- a/src/views/AccountPerForms/PerTableActions/index.tsx
+++ b/src/views/AccountPerForms/PerTableActions/index.tsx
@@ -109,6 +109,7 @@ function PerTableActions(props: Props) {
                 </>
             )}
         >
+            {/* FIXME: fix typing in server (low priority) */}
             {isDefined(phase) && phase <= PER_PHASE_WORKPLAN && (
                 <Link
                     to={getRouteUrl(phase)}

--- a/src/views/CountryAdditionalData/index.tsx
+++ b/src/views/CountryAdditionalData/index.tsx
@@ -35,7 +35,7 @@ export function Component() {
     } = useRequest({
         skip: isNotDefined(countryId),
         url: '/api/v2/country_snippet/',
-        query: { country: Number(countryId) } as never,
+        query: { country: Number(countryId) },
     });
 
     const hasCountrySnippet = countrySnippetResponse?.results

--- a/src/views/CountryRiskWatch/ReturnPeriodTable/index.tsx
+++ b/src/views/CountryRiskWatch/ReturnPeriodTable/index.tsx
@@ -19,7 +19,7 @@ import styles from './styles.module.css';
 
 type GetCountryRisk = paths['/api/v1/country-seasonal/']['get'];
 type CountryRiskResponse = GetCountryRisk['responses']['200']['content']['application/json'];
-type HazardType = components['schemas']['HazardTypeEnum'];
+type HazardType = components<'read'>['schemas']['HazardTypeEnum'];
 interface HazardTypeOption {
     hazard_type: HazardType;
     hazard_type_display: string;

--- a/src/views/CountryRiskWatch/RiskBarChart/CombinedChart/index.tsx
+++ b/src/views/CountryRiskWatch/RiskBarChart/CombinedChart/index.tsx
@@ -26,7 +26,7 @@ import {
     RiskMetricOption,
 } from '#utils/domain/risk';
 import { formatNumber } from '#utils/common';
-import type { paths, components } from '#generated/riskTypes';
+import { type components } from '#generated/riskTypes';
 import {
     CATEGORY_RISK_HIGH,
     CATEGORY_RISK_LOW,
@@ -34,14 +34,14 @@ import {
     CATEGORY_RISK_VERY_HIGH,
     CATEGORY_RISK_VERY_LOW,
 } from '#utils/constants';
+import { type RiskApiResponse } from '#utils/restRequest';
 
 import i18n from './i18n.json';
 import styles from './styles.module.css';
 
-type GetCountryRisk = paths['/api/v1/country-seasonal/']['get'];
-type CountryRiskResponse = GetCountryRisk['responses']['200']['content']['application/json'];
+type CountryRiskResponse = RiskApiResponse<'/api/v1/country-seasonal/'>;
 type RiskData = CountryRiskResponse[number];
-type HazardType = components['schemas']['HazardTypeEnum'];
+type HazardType = components<'read'>['schemas']['HazardTypeEnum'];
 
 const selectedMonths = {
     0: true,

--- a/src/views/CountryRiskWatch/RiskBarChart/FoodInsecurityChart/index.tsx
+++ b/src/views/CountryRiskWatch/RiskBarChart/FoodInsecurityChart/index.tsx
@@ -25,12 +25,11 @@ import {
     COLOR_HAZARD_FOOD_INSECURITY,
     COLOR_PRIMARY_RED,
 } from '#utils/constants';
-import { paths } from '#generated/riskTypes';
+import { type RiskApiResponse } from '#utils/restRequest';
 
 import styles from './styles.module.css';
 
-type GetCountryRisk = paths['/api/v1/country-seasonal/']['get'];
-type CountryRiskResponse = GetCountryRisk['responses']['200']['content']['application/json'];
+type CountryRiskResponse = RiskApiResponse<'/api/v1/country-seasonal/'>;
 type RiskData = CountryRiskResponse[number];
 
 const colors = [

--- a/src/views/CountryRiskWatch/RiskBarChart/index.tsx
+++ b/src/views/CountryRiskWatch/RiskBarChart/index.tsx
@@ -31,7 +31,7 @@ import type {
     RiskMetric,
     RiskMetricOption,
 } from '#utils/domain/risk';
-import type { paths } from '#generated/riskTypes';
+import { type RiskApiResponse } from '#utils/restRequest';
 
 import i18n from './i18n.json';
 import styles from './styles.module.css';
@@ -39,8 +39,7 @@ import FoodInsecurityChart from './FoodInsecurityChart';
 import WildfireChart from './WildfireChart';
 import CombinedChart from './CombinedChart';
 
-type GetCountryRisk = paths['/api/v1/country-seasonal/']['get'];
-type CountryRiskResponse = GetCountryRisk['responses']['200']['content']['application/json'];
+type CountryRiskResponse = RiskApiResponse<'/api/v1/country-seasonal/'>;
 type RiskData = CountryRiskResponse[number];
 
 interface Props {

--- a/src/views/CountryThreeWProjects/Map/index.tsx
+++ b/src/views/CountryThreeWProjects/Map/index.tsx
@@ -107,8 +107,6 @@ function getGeoJson(
         project_district_detail: Pick<
             District,
             | 'id'
-            | 'is_deprecated'
-            | 'is_enclave'
             | 'name'
         >;
     })[],

--- a/src/views/DrefApplicationForm/common.tsx
+++ b/src/views/DrefApplicationForm/common.tsx
@@ -8,8 +8,8 @@ import { type components } from '#generated/types';
 
 import { type PartialDref } from './schema';
 
-export type TypeOfDrefEnum = components['schemas']['TypeOfDrefEnum'];
-type TypeOfOnsetEnum = components['schemas']['TypeOfOnsetEnum'];
+export type TypeOfDrefEnum = components<'read'>['schemas']['TypeOfDrefEnum'];
+type TypeOfOnsetEnum = components<'read'>['schemas']['TypeOfOnsetEnum'];
 
 // export const ONSET_SLOW = 1 satisfies TypeOfOnsetEnum;
 export const ONSET_SUDDEN = 2 satisfies TypeOfOnsetEnum;

--- a/src/views/DrefApplicationForm/index.tsx
+++ b/src/views/DrefApplicationForm/index.tsx
@@ -60,7 +60,8 @@ type GetDrefResponse = GoApiResponse<'/api/v2/dref/{id}/'>;
 
 export type TabKeys = 'overview' | 'eventDetail' | 'actions' | 'operation' | 'submission';
 
-function getNextStep(current: TabKeys, direction: 1 | -1, typeOfDref: TypeOfDrefEnum | undefined) {
+// FIXME: fix typings in server (medium priority)
+function getNextStep(current: TabKeys, direction: 1 | -1, typeOfDref: TypeOfDrefEnum | '' | undefined) {
     if (typeOfDref === TYPE_LOAN && direction === 1) {
         const mapping: { [key in TabKeys]?: TabKeys } = {
             overview: 'eventDetail',

--- a/src/views/DrefFinalReportForm/common.tsx
+++ b/src/views/DrefFinalReportForm/common.tsx
@@ -8,8 +8,8 @@ import { type components } from '#generated/types';
 
 import { type PartialFinalReport } from './schema';
 
-export type TypeOfDrefEnum = components['schemas']['TypeOfDrefEnum'];
-type TypeOfOnsetEnum = components['schemas']['TypeOfOnsetEnum'];
+export type TypeOfDrefEnum = components<'read'>['schemas']['TypeOfDrefEnum'];
+type TypeOfOnsetEnum = components<'read'>['schemas']['TypeOfOnsetEnum'];
 
 // export const ONSET_SLOW = 1 satisfies TypeOfOnsetEnum;
 export const ONSET_SUDDEN = 2 satisfies TypeOfOnsetEnum;

--- a/src/views/DrefOperationalUpdateForm/common.tsx
+++ b/src/views/DrefOperationalUpdateForm/common.tsx
@@ -8,8 +8,8 @@ import { type components } from '#generated/types';
 
 import { type PartialOpsUpdate } from './schema';
 
-export type TypeOfDrefEnum = components['schemas']['TypeOfDrefEnum'];
-type TypeOfOnsetEnum = components['schemas']['TypeOfOnsetEnum'];
+export type TypeOfDrefEnum = components<'read'>['schemas']['TypeOfDrefEnum'];
+type TypeOfOnsetEnum = components<'read'>['schemas']['TypeOfOnsetEnum'];
 
 // export const ONSET_SLOW = 1 satisfies TypeOfOnsetEnum;
 export const ONSET_SUDDEN = 2 satisfies TypeOfOnsetEnum;

--- a/src/views/DrefOperationalUpdateForm/schema.ts
+++ b/src/views/DrefOperationalUpdateForm/schema.ts
@@ -47,7 +47,9 @@ function lessThanEqualToTwoImagesCondition<T>(value: T[] | undefined) {
 }
 
 export type OpsUpdateResponse = GoApiResponse<'/api/v2/dref-op-update/{id}/'>;
-export type OpsUpdateRequestBody = GoApiBody<'/api/v2/dref-op-update/{id}/', 'PUT'>;
+export type OpsUpdateRequestBody = GoApiBody<'/api/v2/dref-op-update/{id}/', 'PUT'> & {
+    operational_update_number: number | undefined;
+};
 
 type NeedIdentifiedResponse = NonNullable<OpsUpdateRequestBody['needs_identified']>[number];
 type NsActionResponse = NonNullable<OpsUpdateRequestBody['national_society_actions']>[number];
@@ -116,6 +118,8 @@ type OpsUpdateFormSchemaFields = ReturnType<OpsUpdateFormSchema['fields']>;
 const schema: OpsUpdateFormSchema = {
     fields: (formValue): OpsUpdateFormSchemaFields => {
         let formFields: OpsUpdateFormSchemaFields = {
+            operational_update_number: { forceValue: undefinedValue },
+
             // OVERVIEW
             national_society: { required: true },
             type_of_dref: { required: true },

--- a/src/views/FieldReportDetails/CovidNumericDetails/index.tsx
+++ b/src/views/FieldReportDetails/CovidNumericDetails/index.tsx
@@ -1,11 +1,11 @@
-import type { paths } from '#generated/types';
 import KeyFigure from '#components/KeyFigure';
 import useTranslation from '#hooks/useTranslation';
 import TextOutput from '#components/TextOutput';
+import { type GoApiResponse } from '#utils/restRequest';
 
 import i18n from './i18n.json';
 
-type FieldReportResponse = paths['/api/v2/field-report/{id}/']['get']['responses']['200']['content']['application/json'];
+type FieldReportResponse = GoApiResponse<'/api/v2/field-report/{id}/'>;
 
 interface Props {
     value: FieldReportResponse | undefined;

--- a/src/views/FieldReportDetails/EarlyWarningNumericDetails/index.tsx
+++ b/src/views/FieldReportDetails/EarlyWarningNumericDetails/index.tsx
@@ -1,10 +1,10 @@
-import type { paths } from '#generated/types';
 import useTranslation from '#hooks/useTranslation';
 import KeyFigure from '#components/KeyFigure';
+import { type GoApiResponse } from '#utils/restRequest';
 
 import i18n from './i18n.json';
 
-type FieldReportResponse = paths['/api/v2/field-report/{id}/']['get']['responses']['200']['content']['application/json'];
+type FieldReportResponse = GoApiResponse<'/api/v2/field-report/{id}/'>;
 
 interface Props {
     value: FieldReportResponse | undefined;

--- a/src/views/FieldReportDetails/EpidemicNumericDetails/index.tsx
+++ b/src/views/FieldReportDetails/EpidemicNumericDetails/index.tsx
@@ -1,10 +1,10 @@
 import KeyFigure from '#components/KeyFigure';
-import type { paths } from '#generated/types';
 import useTranslation from '#hooks/useTranslation';
+import { type GoApiResponse } from '#utils/restRequest';
 
 import i18n from './i18n.json';
 
-type FieldReportResponse = paths['/api/v2/field-report/{id}/']['get']['responses']['200']['content']['application/json'];
+type FieldReportResponse = GoApiResponse<'/api/v2/field-report/{id}/'>;
 
 interface Props {
     value: FieldReportResponse | undefined;

--- a/src/views/FieldReportDetails/EventNumericDetails/index.tsx
+++ b/src/views/FieldReportDetails/EventNumericDetails/index.tsx
@@ -1,10 +1,10 @@
-import type { paths } from '#generated/types';
 import KeyFigure from '#components/KeyFigure';
 import useTranslation from '#hooks/useTranslation';
+import { type GoApiResponse } from '#utils/restRequest';
 
 import i18n from './i18n.json';
 
-type FieldReportResponse = paths['/api/v2/field-report/{id}/']['get']['responses']['200']['content']['application/json'];
+type FieldReportResponse = GoApiResponse<'/api/v2/field-report/{id}/'>;
 
 interface Props {
     value: FieldReportResponse | undefined;

--- a/src/views/FieldReportDetails/index.tsx
+++ b/src/views/FieldReportDetails/index.tsx
@@ -434,7 +434,7 @@ export function Component() {
                 const categoryItems = mapToList(
                     actionsGroupedByCategory,
                     (item, key) => ({
-                        category: key as (CategoryType | ''),
+                        category: key as CategoryType,
                         actions: item,
                     }),
                 );

--- a/src/views/FlashUpdateForm/schema.ts
+++ b/src/views/FlashUpdateForm/schema.ts
@@ -4,7 +4,6 @@ import {
     type ArraySchema,
     type PurgeNull,
     ObjectSchema,
-    undefinedValue,
     emailCondition,
 } from '@togglecorp/toggle-form';
 
@@ -130,7 +129,7 @@ const finalSchema: FormSchema = {
                 keySelector: (graphic) => graphic.client_id,
                 member: (): GraphicsSchemaMember => ({
                     fields: (): GraphicSchemaFields => ({
-                        id: { defaultValue: undefinedValue },
+                        // id: { defaultValue: undefinedValue },
                         client_id: {},
                         caption: {},
                     }),
@@ -146,7 +145,7 @@ const finalSchema: FormSchema = {
                 keySelector: (mapFile) => mapFile.client_id,
                 member: (): MapsSchemaMember => ({
                     fields: (): MapSchemaFields => ({
-                        id: { defaultValue: undefinedValue },
+                        // id: { defaultValue: undefinedValue },
                         client_id: {},
                         caption: {},
                     }),
@@ -162,7 +161,7 @@ const finalSchema: FormSchema = {
                 keySelector: (reference) => reference.client_id,
                 member: (): ReferencesSchemaMember => ({
                     fields: (): ReferenceSchemaFields => ({
-                        id: { defaultValue: undefinedValue },
+                        // id: { defaultValue: undefinedValue },
                         client_id: {},
                         date: { required: true },
                         source_description: { required: true },
@@ -177,7 +176,7 @@ const finalSchema: FormSchema = {
                 keySelector: (actionTaken) => actionTaken.client_id,
                 member: (): ActionsSchemaMember => ({
                     fields: (): ActionSchemaFields => ({
-                        id: { defaultValue: undefinedValue },
+                        // id: { defaultValue: undefinedValue },
                         client_id: {},
                         organization: {},
                         actions: {},

--- a/src/views/PerAssessmentForm/AreaInput/ComponentInput/QuestionInput/index.tsx
+++ b/src/views/PerAssessmentForm/AreaInput/ComponentInput/QuestionInput/index.tsx
@@ -7,7 +7,7 @@ import { isDefined } from '@togglecorp/fujs';
 import Container from '#components/Container';
 import TextArea from '#components/TextArea';
 import RadioInput from '#components/RadioInput';
-import type { paths } from '#generated/types';
+import { type GoApiResponse } from '#utils/restRequest';
 
 import type { PartialAssessment } from '../../../schema';
 
@@ -18,7 +18,7 @@ type ComponentResponse = NonNullable<AreaResponse['component_responses']>[number
 
 type Value = NonNullable<ComponentResponse['question_responses']>[number];
 
-type PerFormQuestionResponse = paths['/api/v2/per-formquestion/']['get']['responses']['200']['content']['application/json'];
+type PerFormQuestionResponse = GoApiResponse<'/api/v2/per-formquestion/'>;
 type PerFormQuestion = NonNullable<PerFormQuestionResponse['results']>[number];
 type PerFormAnswer = PerFormQuestion['answers'][number];
 

--- a/src/views/PerAssessmentForm/schema.ts
+++ b/src/views/PerAssessmentForm/schema.ts
@@ -4,10 +4,10 @@ import {
     PurgeNull,
 } from '@togglecorp/toggle-form';
 
-import type { paths } from '#generated/types';
+import { type GoApiResponse } from '#utils/restRequest';
 import { DeepReplace } from '#utils/common';
 
-type AssessmentRequestBody = paths['/api/v2/per-assessment/{id}/']['put']['requestBody']['content']['application/json'];
+type AssessmentRequestBody = GoApiResponse<'/api/v2/per-assessment/{id}/', 'PUT'>;
 
 type AssessmentFormFields = PurgeNull<AssessmentRequestBody>
 

--- a/src/views/PerOverviewForm/index.tsx
+++ b/src/views/PerOverviewForm/index.tsx
@@ -31,9 +31,8 @@ import GoMultiFileInput from '#components/domain/GoMultiFileInput';
 import NonFieldError from '#components/NonFieldError';
 import useTranslation from '#hooks/useTranslation';
 import useAlertContext from '#hooks/useAlert';
-import { useLazyRequest, useRequest } from '#utils/restRequest';
+import { useLazyRequest, useRequest, type GoApiResponse } from '#utils/restRequest';
 import useGlobalEnums from '#hooks/domain/useGlobalEnums';
-import type { paths } from '#generated/types';
 import { PER_PHASE_OVERVIEW, PER_PHASE_ASSESSMENT } from '#utils/domain/per';
 import type { PerProcessOutletContext } from '#utils/outletContext';
 import {
@@ -52,8 +51,7 @@ import {
 import i18n from './i18n.json';
 import styles from './styles.module.css';
 
-type GetGlobalEnums = paths['/api/v2/global-enums/']['get'];
-type GlobalEnumsResponse = GetGlobalEnums['responses']['200']['content']['application/json'];
+type GlobalEnumsResponse = GoApiResponse<'/api/v2/global-enums/'>;
 type PerOverviewAssessmentMethods = NonNullable<GlobalEnumsResponse['per_overviewassessmentmethods']>[number];
 
 function perAssessmentMethodsKeySelector(option: PerOverviewAssessmentMethods) {
@@ -129,8 +127,7 @@ export function Component() {
         skip: isNotDefined(value?.country) || isDefined(value?.is_draft),
         query: {
             country_id: Number(value?.country),
-            // FIXME: typing for query not available
-        } as never,
+        },
         onSuccess: (response) => {
             const lastAssessment = response.results?.[0];
             if (lastAssessment) {

--- a/src/views/PerPrioritizationForm/schema.ts
+++ b/src/views/PerPrioritizationForm/schema.ts
@@ -3,9 +3,9 @@ import {
     PartialForm,
 } from '@togglecorp/toggle-form';
 
-import type { paths } from '#generated/types';
+import { type GoApiBody } from '#utils/restRequest';
 
-export type PrioritizationRequestBody = paths['/api/v2/per-prioritization/{id}/']['put']['requestBody']['content']['application/json'];
+export type PrioritizationRequestBody = GoApiBody<'/api/v2/per-prioritization/{id}/', 'PUT'>;
 
 type ComponentResponse = NonNullable<PrioritizationRequestBody['prioritized_action_responses']>[number];
 export type PrioritizationFormFields = Omit<PrioritizationRequestBody, 'id' | 'prioritized_action_responses'> & ({

--- a/src/views/PerWorkPlanForm/schema.ts
+++ b/src/views/PerWorkPlanForm/schema.ts
@@ -3,9 +3,9 @@ import {
     PartialForm,
     requiredStringCondition,
 } from '@togglecorp/toggle-form';
-import { paths } from '#generated/types';
+import { type GoApiBody } from '#utils/restRequest';
 
-export type WorkPlanBody = paths['/api/v2/per-work-plan/{id}/']['put']['requestBody']['content']['application/json'];
+export type WorkPlanBody = GoApiBody<'/api/v2/per-work-plan/{id}/', 'PUT'>;
 type ComponentResponse = NonNullable<WorkPlanBody['prioritized_action_responses']>[number];
 type CustomComponentResponse = NonNullable<WorkPlanBody['additional_action_responses']>[number];
 

--- a/src/views/Search/ResultTable/index.tsx
+++ b/src/views/Search/ResultTable/index.tsx
@@ -10,8 +10,9 @@ import useColumns from '../useColumns';
 
 type SearchResponse = GoApiResponse<'/api/v1/search/'>;
 
-type SearchResponseKey = keyof SearchResponse;
-// FIXME: add a note why we are using extract here
+// FIXME: Why do we need to add NonNullable on keyof
+type SearchResponseKey = NonNullable<keyof SearchResponse>;
+// FIXME: add a note why we are using exclude here
 type ResultKey = Exclude<SearchResponseKey, 'regions' | 'countries' | 'district_province_response'>;
 
 interface Props {

--- a/src/views/Search/index.tsx
+++ b/src/views/Search/index.tsx
@@ -41,7 +41,8 @@ import styles from './styles.module.css';
 type SearchResponse = GoApiResponse<'/api/v1/search/'>;
 
 const MAX_VIEW_PER_SECTION = 5;
-type SearchResponseKeys = keyof SearchResponse;
+// FIXME: Why do we need to add NonNullable on keyof
+type SearchResponseKeys = NonNullable<keyof SearchResponse>;
 
 function isListTypeResult(
     resultKey: SearchResponseKeys,

--- a/src/views/Search/useColumns/index.tsx
+++ b/src/views/Search/useColumns/index.tsx
@@ -12,13 +12,12 @@ import {
 } from '#components/Table/ColumnShortcuts';
 import SeverityIndicator from '#components/domain/SeverityIndicator';
 import useTranslation from '#hooks/useTranslation';
-import type { paths } from '#generated/types';
 import { getDuration } from '#utils/common';
+import { type GoApiResponse } from '#utils/restRequest';
 
 import i18n from './i18n.json';
 
-type GetSearch = paths['/api/v1/search/']['get'];
-type SearchResponse = GetSearch['responses']['200']['content']['application/json'];
+type SearchResponse = GoApiResponse<'/api/v1/search/'>;
 type EmergencyResult = NonNullable<SearchResponse['emergencies']>[number];
 type FieldReportResult = NonNullable<SearchResponse['reports']>[number];
 type ProjectResult = NonNullable<SearchResponse['projects']>[number];

--- a/src/views/SurgeOverview/EmergencyResponseUnitsTable/index.tsx
+++ b/src/views/SurgeOverview/EmergencyResponseUnitsTable/index.tsx
@@ -21,12 +21,12 @@ import {
 import { resolveToString } from '#utils/translation';
 import { useRequest, type GoApiResponse } from '#utils/restRequest';
 import useGlobalEnums from '#hooks/domain/useGlobalEnums';
-import { components } from '#generated/types';
+import { type components } from '#generated/types';
 
 import i18n from './i18n.json';
 import styles from './styles.module.css';
 
-type EruTypeEnum = components['schemas']['Key187Enum'];
+type EruTypeEnum = components<'read'>['schemas']['Key187Enum'];
 
 type GetEmergencyResponseUnitsResponse = GoApiResponse<'/api/v2/eru/'>;
 type EmergencyResponseUnitListItem = NonNullable<GetEmergencyResponseUnitsResponse['results']>[number];

--- a/src/views/SurgeOverview/Readiness/index.tsx
+++ b/src/views/SurgeOverview/Readiness/index.tsx
@@ -13,14 +13,14 @@ import useInputState from '#hooks/useInputState';
 import useTranslation from '#hooks/useTranslation';
 import { resolveToString } from '#utils/translation';
 import { useRequest, type GoApiResponse } from '#utils/restRequest';
-import { components } from '#generated/types';
+import { type components } from '#generated/types';
 
 import useGlobalEnums from '#hooks/domain/useGlobalEnums';
 import EmergencyResponseUnitOwnerCard from './EmergencyResponseUnitOwnerCard';
 import i18n from './i18n.json';
 import styles from './styles.module.css';
 
-type EruTypeEnum = components['schemas']['Key187Enum'];
+type EruTypeEnum = components<'read'>['schemas']['Key187Enum'];
 
 type GetERUOwnersResponse = GoApiResponse<'/api/v2/eru_owner/'>;
 type ERUOwnerListItem = NonNullable<GetERUOwnersResponse['results']>[number];

--- a/src/views/SurgeOverview/index.tsx
+++ b/src/views/SurgeOverview/index.tsx
@@ -6,7 +6,7 @@ import { useRequest } from '#utils/restRequest';
 import BarChart from '#components/BarChart';
 import TimeSeriesChart from '#components/TimeSeriesChart';
 import { getDatesSeparatedByMonths } from '#utils/chart';
-import { paths } from '#generated/types';
+import { type GoApiResponse } from '#utils/restRequest';
 import { formatDate } from '#utils/common';
 
 import SurgeMap from './SurgeMap';
@@ -17,8 +17,7 @@ import Readiness from './Readiness';
 import i18n from './i18n.json';
 import styles from './styles.module.css';
 
-type GetDeploymentsByNationalSociety = paths['/api/v2/deployment/aggregated_by_ns']['get'];
-type GetDeploymentsByNationalSocietyResponse = GetDeploymentsByNationalSociety['responses']['200']['content']['application/json'];
+type GetDeploymentsByNationalSocietyResponse = GoApiResponse<'/api/v2/deployment/aggregated_by_ns'>;
 type DeploymentsByNationalSociety = GetDeploymentsByNationalSocietyResponse[number];
 
 const timeSeriesDataKeys = ['deployments'];

--- a/src/views/ThreeWActivityForm/schema.ts
+++ b/src/views/ThreeWActivityForm/schema.ts
@@ -61,21 +61,25 @@ type ActionSupplyItem = {
     supply_value: number;
 }
 
-export type ActivityResponseBody = GoApiBody<'/api/v2/emergency-project/{id}/', 'PUT'>;
-type RawActivityItem = NonNullable<ActivityResponseBody['activities']>[number];
-type ActivityItem = NonNullable<ActivityResponseBody['activities']>[number] & {
+export type ActivityRequestBody = GoApiBody<'/api/v2/emergency-project/{id}/', 'PUT'>;
+
+export type RawActivityItem = NonNullable<ActivityRequestBody['activities']>[number];
+
+export type ActivityItem = Omit<RawActivityItem, 'points' | 'custom_supplies' | 'supplies'> & {
     client_id: string;
-    points?: (NonNullable<RawActivityItem['points']>[number] & { client_id: string })[]
+    points: (NonNullable<RawActivityItem['points']>[number] & { client_id: string })[]
     custom_supplies: CustomSupplyItem[];
     supplies: ActionSupplyItem[];
 };
+
 type ActivityFormFields = DeepReplace<
-    ActivityResponseBody,
+    ActivityRequestBody,
     RawActivityItem,
     ActivityItem
 >;
 
 export type PartialActivityItem = PartialForm<ActivityItem, 'client_id'>;
+
 export type PartialPointItem = PartialForm<NonNullable<ActivityItem['points']>[number], 'client_id'>;
 export type PartialCustomSupplyItem = PartialForm<CustomSupplyItem, 'client_id'>;
 export type PartialActionSupplyItem = PartialForm<ActionSupplyItem, 'client_id'>;
@@ -239,7 +243,7 @@ const finalSchema: FormSchema = {
                                     // If you force it as undefined type
                                     // it will not be sent to the server
                                     client_id: { forceValue: undefinedValue },
-                                    id: {},
+                                    // id: {},
                                     details: {},
                                     is_simplified_report: { defaultValue: true },
                                     sector: { required: true },
@@ -564,7 +568,7 @@ const finalSchema: FormSchema = {
                                                             client_id: {
                                                                 forceValue: undefinedValue,
                                                             },
-                                                            id: {},
+                                                            // id: {},
                                                             longitude: { required: true },
                                                             latitude: { required: true },
                                                             description: { required: true },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1398,6 +1398,11 @@ ajv@^8.0.1:
     require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
+ansi-colors@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.3.tgz#37611340eb2243e70cc604cad35d63270d48781b"
+  integrity sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==
+
 ansi-escapes@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
@@ -3675,6 +3680,17 @@ fast-glob@^3.2.7, fast-glob@^3.2.9, fast-glob@^3.3.0:
     merge2 "^1.3.0"
     micromatch "^4.0.4"
 
+fast-glob@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.1.tgz#784b4e897340f3dbbef17413b3f11acf03c874c4"
+  integrity sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.4"
+
 fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
@@ -4011,11 +4027,6 @@ globalthis@^1.0.3:
   integrity sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==
   dependencies:
     define-properties "^1.1.3"
-
-globalyzer@0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/globalyzer/-/globalyzer-0.1.0.tgz#cb76da79555669a1519d5a8edf093afaa0bf1465"
-  integrity sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==
 
 globby@^11.1.0:
   version "11.1.0"
@@ -5053,11 +5064,6 @@ mime-types@^2.1.12, mime-types@~2.1.19:
   dependencies:
     mime-db "1.52.0"
 
-mime@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-3.0.0.tgz#b374550dca3a0c18443b0c950a6a58f1931cf7a7"
-  integrity sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==
-
 mimic-fn@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
@@ -5362,17 +5368,17 @@ open@^9.1.0:
     is-inside-container "^1.0.0"
     is-wsl "^2.2.0"
 
-openapi-typescript@^5.4.0:
-  version "5.4.1"
-  resolved "https://registry.yarnpkg.com/openapi-typescript/-/openapi-typescript-5.4.1.tgz#38b4b45244acc1361f3c444537833a9e9cb03bf6"
-  integrity sha512-AGB2QiZPz4rE7zIwV3dRHtoUC/CWHhUjuzGXvtmMQN2AFV8xCTLKcZUHLcdPQmt/83i22nRE7+TxXOXkK+gf4Q==
+openapi-typescript@^6.5.5:
+  version "6.5.5"
+  resolved "https://registry.yarnpkg.com/openapi-typescript/-/openapi-typescript-6.5.5.tgz#5f30dbc60e9137e61e729e14121ac774727423fd"
+  integrity sha512-pMsA8GrMQKtNOPPjKnJbDotA2UpKsIcTHecMw2Bl3M/2eWTVs8zAYBm/cgaE9Qz5GrcVCDIru9GQX/P9vxtUFg==
   dependencies:
+    ansi-colors "^4.1.3"
+    fast-glob "^3.3.1"
     js-yaml "^4.1.0"
-    mime "^3.0.0"
-    prettier "^2.6.2"
-    tiny-glob "^0.2.9"
-    undici "^5.4.0"
-    yargs-parser "^21.0.1"
+    supports-color "^9.4.0"
+    undici "^5.23.0"
+    yargs-parser "^21.1.1"
 
 option-t@^20.0.0:
   version "20.3.1"
@@ -5944,11 +5950,6 @@ prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==
-
-prettier@^2.6.2:
-  version "2.8.8"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
-  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
 
 pretty-format@^27.5.1:
   version "27.5.1"
@@ -6966,6 +6967,11 @@ supports-color@^7.0.0, supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
+supports-color@^9.4.0:
+  version "9.4.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-9.4.0.tgz#17bfcf686288f531db3dea3215510621ccb55954"
+  integrity sha512-VL+lNrEoIXww1coLPOmiEmK/0sGigko5COxI09KzHc2VJXJsQ37UaQ+8quuxjDeA7+KnLGTWRyOXSLLR2Wb4jw==
+
 supports-hyperlinks@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/supports-hyperlinks/-/supports-hyperlinks-3.0.0.tgz#c711352a5c89070779b4dad54c05a2f14b15c94b"
@@ -7081,14 +7087,6 @@ time-zone@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/time-zone/-/time-zone-1.0.0.tgz#99c5bf55958966af6d06d83bdf3800dc82faec5d"
   integrity sha512-TIsDdtKo6+XrPtiTm1ssmMngN1sAhyKnTO2kunQWqNPWIVvCm15Wmw4SWInwTVgJ5u/Tr04+8Ei9TNcw4x4ONA==
-
-tiny-glob@^0.2.9:
-  version "0.2.9"
-  resolved "https://registry.yarnpkg.com/tiny-glob/-/tiny-glob-0.2.9.tgz#2212d441ac17928033b110f8b3640683129d31e2"
-  integrity sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==
-  dependencies:
-    globalyzer "0.1.0"
-    globrex "^0.1.2"
 
 tiny-invariant@^1.1.0:
   version "1.3.1"
@@ -7324,10 +7322,10 @@ unconfig@^0.3.7:
     defu "^6.1.2"
     jiti "^1.18.2"
 
-undici@^5.4.0:
-  version "5.22.1"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-5.22.1.tgz#877d512effef2ac8be65e695f3586922e1a57d7b"
-  integrity sha512-Ji2IJhFXZY0x/0tVBXeQwgPlLWw13GVzpsWPQ3rV50IFMMof2I55PZZxtm4P6iNq+L5znYN9nSTAq0ZyE6lSJw==
+undici@^5.23.0:
+  version "5.23.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-5.23.0.tgz#e7bdb0ed42cebe7b7aca87ced53e6eaafb8f8ca0"
+  integrity sha512-1D7w+fvRsqlQ9GscLBwcAJinqcZGHUKjbOmXdlE/v8BvEGXjeWAax+341q44EuTcHXXnfyKNbKRq4Lg7OzhMmg==
   dependencies:
     busboy "^1.6.0"
 
@@ -7805,7 +7803,7 @@ yargs-parser@^20.2.2, yargs-parser@^20.2.9:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
 
-yargs-parser@^21.0.1, yargs-parser@^21.1.1:
+yargs-parser@^21.1.1:
   version "21.1.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
   integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==


### PR DESCRIPTION
- Update openapi-typescript
- Update request typings helper when using new openapi-typescript
- Add reaonly and writeonly support in openapi-typescript
- Update injectClientId function to have a generated fallback
- Add glide_code and date_of_publication on dref ops update (@frozenhelium to confirm the change)
- Remove types that are not in the server


## This PR doesn't introduce:
- [x] typos
- [x] conflict markers
- [x] unwanted comments
- [x] temporary files, auto-generated files or secret keys
- [x] `console.log` meant for debugging
- [ ] codegen errors
