### PR TITLE
Rename annual_split_detail to annual_splits

### DIFF
--- a/src/components/Grid/index.tsx
+++ b/src/components/Grid/index.tsx
@@ -15,6 +15,9 @@ const spacingTypeToClassNameMap: Record<SpacingType, string> = {
     comfortable: styles.comfortableSpacing,
     relaxed: styles.relaxedSpacing,
     loose: styles.looseSpacing,
+    // FIXME: use proper styling (medium priority)
+    default: 'default',
+    condensed: 'condensed',
 };
 
 export interface Props<

--- a/src/views/ThreeWProjectDetail/index.tsx
+++ b/src/views/ThreeWProjectDetail/index.tsx
@@ -22,7 +22,7 @@ import i18n from './i18n.json';
 import styles from './styles.module.css';
 
 type ProjectItem = NonNullable<GoApiResponse<'/api/v2/project/'>['results']>[number];
-type AnnualSplitItem = NonNullable<ProjectItem['annual_split_detail']>[number];
+type AnnualSplitItem = NonNullable<ProjectItem['annual_splits']>[number];
 
 const annualSplitKeySelector = (item: AnnualSplitItem) => item.id;
 
@@ -261,9 +261,9 @@ export function Component() {
                             strongValue
                         />
                     </Container>
-                    {(projectResponse?.annual_split_detail?.length ?? 0) > 0 ? (
+                    {(projectResponse?.annual_splits?.length ?? 0) > 0 ? (
                         <List
-                            data={projectResponse?.annual_split_detail}
+                            data={projectResponse?.annual_splits}
                             className={styles.yearDetail}
                             renderer={AnnualSplitListItem}
                             rendererParams={annualSplitListRendererParams}

--- a/src/views/ThreeWProjectForm/index.tsx
+++ b/src/views/ThreeWProjectForm/index.tsx
@@ -236,8 +236,8 @@ export function Component() {
                 ...response,
                 // Set beginning is_annual_report switch according to
                 // the filled-in annual split details
-                is_annual_report: response.annual_split_detail?.length >= 1,
-                annual_split_detail: response.annual_split_detail.map((split) => ({
+                is_annual_report: (response.annual_splits ?? []).length >= 1,
+                annual_splits: response.annual_splits?.map((split) => ({
                     ...injectClientId(split),
                 })),
             });
@@ -334,8 +334,8 @@ export function Component() {
     const {
         setValue: setAnnualSplit,
         removeValue: removeAnnualSplit,
-    } = useFormArray<'annual_split_detail', PartialAnnualType>(
-        'annual_split_detail',
+    } = useFormArray<'annual_splits', PartialAnnualType>(
+        'annual_splits',
         setFieldValue,
     );
 
@@ -348,7 +348,7 @@ export function Component() {
             (oldValue: PartialAnnualType[] | undefined) => (
                 [...(oldValue ?? []), newAnnualSplit]
             ),
-            'annual_split_detail' as const,
+            'annual_splits' as const,
         );
         setFieldValue(true, 'is_annual_report');
     }, [setFieldValue]);
@@ -366,7 +366,7 @@ export function Component() {
     }, [setValue]);
 
     const annualSplitErrors = useMemo(
-        () => getErrorObject(error?.annual_split_detail),
+        () => getErrorObject(error?.annual_splits),
         [error],
     );
 
@@ -932,7 +932,7 @@ export function Component() {
                                     + strings.projectFormAnnually
                                 }
                             >
-                                {value?.annual_split_detail?.map((annual_split, i) => (
+                                {value?.annual_splits?.map((annual_split, i) => (
                                     <AnnualSplitInput
                                         key={annual_split.client_id}
                                         index={i}

--- a/src/views/ThreeWProjectForm/schema.ts
+++ b/src/views/ThreeWProjectForm/schema.ts
@@ -24,7 +24,7 @@ import { type GoApiBody } from '#utils/restRequest';
 
 export type ProjectResponseBody = GoApiBody<'/api/v2/project/{id}/', 'PUT'>;
 
-type AnnualSplitRaw = ProjectResponseBody['annual_split_detail'][number];
+type AnnualSplitRaw = NonNullable<ProjectResponseBody['annual_splits']>[number];
 type AnnualSplit = AnnualSplitRaw & { client_id: string };
 type ProjectFormFields = DeepReplace<ProjectResponseBody, AnnualSplitRaw, AnnualSplit>;
 
@@ -33,7 +33,7 @@ export type FormType = PartialForm<ProjectFormFields & {
     is_annual_report: boolean;
 }, 'client_id'>;
 
-export type PartialAnnualType = NonNullable<FormType['annual_split_detail']>[number];
+export type PartialAnnualType = NonNullable<FormType['annual_splits']>[number];
 
 type FormSchema = ObjectSchema<FormType>;
 type FormSchemaFields = ReturnType<FormSchema['fields']>;
@@ -129,9 +129,9 @@ const finalSchema: FormSchema = {
             schema,
             value,
             ['is_annual_report'] as const,
-            ['annual_split_detail'] as const,
+            ['annual_splits'] as const,
             (props) => (props?.is_annual_report ? {
-                annual_split_detail: {
+                annual_splits: {
                     keySelector: (split) => split.client_id,
                     member: (): AnnualSplitsSchemaMember => ({
                         fields: (): AnnualSplitSchemaFields => ({
@@ -140,7 +140,7 @@ const finalSchema: FormSchema = {
                             year: {
                                 validations: [requiredCondition, positiveIntegerCondition],
                             },
-                            id: {}, // can arrive from db, useful for update
+                            // id: {},
                             budget_amount: { validations: [positiveNumberCondition] },
                             target_male: { validations: [positiveIntegerCondition] },
                             target_female: { validations: [positiveIntegerCondition] },
@@ -158,7 +158,7 @@ const finalSchema: FormSchema = {
                     }),
                 },
             } : {
-                annual_split_detail: {
+                annual_splits: {
                     forceValue: nullValue,
                 },
             }),


### PR DESCRIPTION
## This PR doesn't introduce:
- [x] typos
- [x] conflict markers
- [x] unwanted comments
- [x] temporary files, auto-generated files or secret keys
- [x] `console.log` meant for debugging
- [x] codegen errors
