### PR TITLE
Add permission support on routes and links

### DIFF
--- a/src/App/Auth.tsx
+++ b/src/App/Auth.tsx
@@ -1,22 +1,23 @@
-import type { ReactElement } from 'react';
-import { useContext } from 'react';
+import { type ReactElement, useContext } from 'react';
 import { isNotDefined, isDefined } from '@togglecorp/fujs';
-import { Navigate } from 'react-router-dom';
+import { Navigate, useParams } from 'react-router-dom';
 
 import UserContext from '#contexts/user';
+import usePermissions from '#hooks/domain/usePermissions';
+import { type ExtendedProps } from './routes';
 
 interface Props {
     children: ReactElement,
-    context: {
-        title: string,
-        visibility: 'is-authenticated' | 'is-not-authenticated' | 'anything',
-    },
+    context: ExtendedProps,
 }
 function Auth(props: Props) {
     const {
         context,
         children,
     } = props;
+
+    const urlParams = useParams();
+    const perms = usePermissions();
 
     const { userAuth: userDetails } = useContext(UserContext);
 
@@ -29,6 +30,19 @@ function Auth(props: Props) {
         return (
             <Navigate to="/" />
         );
+    }
+
+    if (context.permissions) {
+        const hasPermission = context.permissions(perms, urlParams);
+
+        if (!hasPermission) {
+            // TODO: Add a permission denied page
+            return (
+                <div>
+                    403
+                </div>
+            );
+        }
     }
 
     return children;

--- a/src/App/routes/index.tsx
+++ b/src/App/routes/index.tsx
@@ -15,9 +15,21 @@ import { Component as RootLayout } from '#views/RootLayout';
 import Auth from '../Auth';
 import PageError from '../PageError';
 
-type ExtendedProps = {
+interface Perms {
+    isDrefRegionalCoordinator: (regionId: number | undefined) => boolean,
+    isRegionAdmin: (regionId: number | undefined) => boolean,
+    isCountryAdmin: (countryId: number | undefined) => boolean,
+    isIfrcAdmin: boolean,
+    isSuperUser: boolean,
+}
+
+export type ExtendedProps = {
     title: string,
     visibility: 'is-authenticated' | 'is-not-authenticated' | 'anything',
+    permissions?: (
+        permissions: Perms,
+        params: Record<string, number | string | undefined | null> | undefined | null,
+    ) => boolean;
 };
 interface CustomWrapRoute {
     <T>(
@@ -2194,7 +2206,8 @@ const allFlashUpdates = customWrapRoute({
     wrapperComponent: Auth,
     context: {
         title: 'All Flash Updates',
-        visibility: 'anything',
+        visibility: 'is-authenticated',
+        permissions: ({ isIfrcAdmin }) => isIfrcAdmin,
     },
 });
 
@@ -2209,6 +2222,7 @@ const flashUpdateFormNew = customWrapRoute({
     context: {
         title: 'New Flash Update',
         visibility: 'is-authenticated',
+        permissions: ({ isIfrcAdmin }) => isIfrcAdmin,
     },
 });
 
@@ -2223,6 +2237,7 @@ const flashUpdateFormEdit = customWrapRoute({
     context: {
         title: 'Flash Update Edit',
         visibility: 'is-authenticated',
+        permissions: ({ isIfrcAdmin }) => isIfrcAdmin,
     },
 });
 
@@ -2237,6 +2252,7 @@ const flashUpdateFormDetails = customWrapRoute({
     context: {
         title: 'Flash Update Details',
         visibility: 'anything',
+        permissions: ({ isIfrcAdmin }) => isIfrcAdmin,
     },
 });
 

--- a/src/components/DropdownMenu/index.tsx
+++ b/src/components/DropdownMenu/index.tsx
@@ -65,7 +65,6 @@ function DropdownMenu(props: Props) {
 
     const handleMenuClick: NonNullable<ButtonProps<undefined>['onClick']> = useCallback(
         () => {
-            // e.stopPropagation();
             setShowDropdown((prevValue) => !prevValue);
         },
         [setShowDropdown],

--- a/src/components/Link/index.tsx
+++ b/src/components/Link/index.tsx
@@ -15,6 +15,7 @@ import {
     ExternalLinkLineIcon,
 } from '@ifrc-go/icons';
 
+import usePermissions from '#hooks/domain/usePermissions';
 import UserContext from '#contexts/user';
 import RouteContext from '#contexts/route';
 import { useButtonFeatures } from '#components/Button';
@@ -62,6 +63,7 @@ export function useLink(props: {
 }) {
     const { userAuth: userDetails } = useContext(UserContext);
     const routes = useContext(RouteContext);
+    const perms = usePermissions();
 
     if (props.external) {
         if (isNotDefined(props.href)) {
@@ -83,10 +85,10 @@ export function useLink(props: {
     }
 
     return {
-    // NOTE: disabling links if authentication is required
         disabled: (
             (route.visibility === 'is-authenticated' && isNotDefined(userDetails))
             || (route.visibility === 'is-not-authenticated' && isDefined(userDetails))
+            || (route.permissions && !route.permissions(perms, props.urlParams))
         ),
         to: resolvedPath,
     };

--- a/src/components/Navbar/AuthenticatedUserDropdown/index.tsx
+++ b/src/components/Navbar/AuthenticatedUserDropdown/index.tsx
@@ -26,13 +26,6 @@ function AuthenticatedUserDropdown(props: Props) {
         window.location.reload();
     }, [removeUser]);
 
-    const handleLogoutClick = useCallback(
-        (_: undefined, e: React.MouseEvent<HTMLButtonElement>) => {
-            e.stopPropagation();
-        },
-        [],
-    );
-
     if (isNotDefined(userDetails)) {
         return null;
     }
@@ -42,6 +35,7 @@ function AuthenticatedUserDropdown(props: Props) {
             className={className}
             label={userDetails.displayName ?? 'Anonymous'}
             variant="tertiary"
+            persistent
         >
             <DropdownMenuItem
                 type="link"
@@ -52,8 +46,8 @@ function AuthenticatedUserDropdown(props: Props) {
             <DropdownMenuItem
                 name={undefined}
                 type="confirm-button"
-                onClick={handleLogoutClick}
                 onConfirm={handleLogoutConfirm}
+                persist
             >
                 {strings.userMenuLogout}
             </DropdownMenuItem>

--- a/src/components/Navbar/LanguageDropdown/index.tsx
+++ b/src/components/Navbar/LanguageDropdown/index.tsx
@@ -41,13 +41,6 @@ function LangaugeDropdown() {
         [currentLanguage],
     );
 
-    const handleLanguageChangeClick = useCallback(
-        (_: Language, e: React.MouseEvent<HTMLButtonElement>) => {
-            e.stopPropagation();
-        },
-        [],
-    );
-
     const handleLanguageConfirm = useCallback(
         (newLanguage: Language) => {
             setCurrentLanguage(newLanguage);
@@ -60,6 +53,7 @@ function LangaugeDropdown() {
         <DropdownMenu
             label={languageNameMapEn[currentLanguage]}
             variant="tertiary"
+            persistent
         >
             {languageList.map(
                 (language) => (
@@ -67,7 +61,7 @@ function LangaugeDropdown() {
                         type="confirm-button"
                         key={language.key}
                         name={language.key}
-                        onClick={handleLanguageChangeClick}
+                        persist
                         onConfirm={handleLanguageConfirm}
                         icons={(
                             <CheckFillIcon

--- a/src/components/Page/index.tsx
+++ b/src/components/Page/index.tsx
@@ -12,9 +12,12 @@ import useCurrentLanguage from '#hooks/domain/useCurrentLanguage';
 import useTranslation from '#hooks/useTranslation';
 import { resolveToString } from '#utils/translation';
 import { languageNameMapEn } from '#utils/common';
+import { components } from '#generated/types';
 
 import i18n from './i18n.json';
 import styles from './styles.module.css';
+
+type TranslationModuleOriginalLanguageEnum = components<'read'>['schemas']['TranslationModuleOriginalLanguageEnum'];
 
 interface Props {
     className?: string;
@@ -32,9 +35,7 @@ interface Props {
     withBackgroundColorInMainSection?: boolean;
     elementRef?: RefObject<ElementRef<'div'>>;
     blockingContent?: React.ReactNode;
-
-    // FIXME: Language should be used as typings here
-    contentOriginalLanguage?: string;
+    contentOriginalLanguage?: TranslationModuleOriginalLanguageEnum;
 }
 
 function Page(props: Props) {

--- a/src/components/Table/TableActions/index.tsx
+++ b/src/components/Table/TableActions/index.tsx
@@ -10,6 +10,7 @@ export interface Props {
     className?: string;
     children?: React.ReactNode;
     extraActions?: React.ReactNode;
+    persistent?: boolean;
 }
 
 function TableActions(props: Props) {
@@ -17,6 +18,7 @@ function TableActions(props: Props) {
         className,
         children,
         extraActions,
+        persistent,
     } = props;
 
     return (
@@ -27,6 +29,7 @@ function TableActions(props: Props) {
                     withoutDropdownIcon
                     variant="tertiary"
                     label={<MoreFillIcon className={styles.moreIcon} />}
+                    persistent={persistent}
                 >
                     {extraActions}
                 </DropdownMenu>

--- a/src/hooks/domain/usePermissions.ts
+++ b/src/hooks/domain/usePermissions.ts
@@ -1,0 +1,34 @@
+import { useMemo } from 'react';
+import { isDefined } from '@togglecorp/fujs';
+
+import useUserMe from '#hooks/domain/useUserMe';
+
+function usePermissions() {
+    const userMe = useUserMe();
+
+    const perms = useMemo(
+        () => {
+            const isDrefRegionalCoordinator = (regionId: number | undefined) => (
+                isDefined(regionId) && !!userMe?.is_dref_coordinator_for_regions?.includes(regionId)
+            );
+            const isCountryAdmin = (countryId: number | undefined) => (
+                isDefined(countryId) && !!userMe?.is_admin_for_countries?.includes(countryId)
+            );
+            const isRegionAdmin = (regionId: number | undefined) => (
+                isDefined(regionId) && !!userMe?.is_admin_for_regions?.includes(regionId)
+            );
+            return {
+                isDrefRegionalCoordinator,
+                isRegionAdmin,
+                isCountryAdmin,
+                isIfrcAdmin: !!userMe?.is_ifrc_admin || !!userMe?.email?.toLowerCase().endsWith('@ifrc.org'),
+                isSuperUser: !!userMe?.is_superuser,
+            };
+        },
+        [userMe],
+    );
+
+    return perms;
+}
+
+export default usePermissions;

--- a/src/hooks/useFloatPlacement.ts
+++ b/src/hooks/useFloatPlacement.ts
@@ -110,7 +110,7 @@ function useFloatPlacement(parentRef: React.RefObject<HTMLElement | undefined>) 
                 right: orientation.horizontal === 'right' ? `${window.innerWidth - x2}px` : 'unset',
             },
             pointer: {
-                left: `calc(${parentX}px + 4em)`,
+                left: `${parentCenterX}px`,
                 top: orientation.vertical === 'top' ? `${parentY + parentHeight}px` : `${parentY - VERTICAL_OFFSET}px`,
                 right: 'unset',
                 bottom: 'unset',

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -53,7 +53,7 @@ export type DeepReplace<T, A, B> = (
 )
 
 type NotNevaKeys<T> = {
-    [key in keyof T]-?: T[key] extends never ? never : key
+    [key in keyof T]-?: NonNullable<T[key]> extends never ? never : key
 }[keyof T]
 
 export type DeepNevaRemove<T> = T extends (infer Z)[]

--- a/src/utils/restRequest/error.ts
+++ b/src/utils/restRequest/error.ts
@@ -5,7 +5,8 @@ import {
 } from '@togglecorp/fujs';
 import { nonFieldError } from '@togglecorp/toggle-form';
 
-type ResponseLeafError = string[];
+// NOTE: Some leaf can also have string error
+type ResponseLeafError = string | string[];
 
 export type ResponseObjectError = {
     [key: string]: ResponseObjectError | ResponseArrayError | ResponseLeafError | undefined;
@@ -72,6 +73,9 @@ function isLeafError(
     if (isObjectError(err)) {
         return false;
     }
+    if (typeof err === 'string') {
+        return true;
+    }
     const unsafeErr: unknown[] = err;
     return Array.isArray(unsafeErr) && unsafeErr.every(
         (e: unknown) => typeof e === 'string',
@@ -95,6 +99,9 @@ function isArrayError(
 function transformLeafError(error: ResponseLeafError | undefined) {
     if (isNotDefined(error)) {
         return undefined;
+    }
+    if (typeof error === 'string') {
+        return error;
     }
     return error.join(' ');
 }

--- a/src/views/AccountDetails/index.tsx
+++ b/src/views/AccountDetails/index.tsx
@@ -70,6 +70,7 @@ export function Component() {
                         label={strings.fullNameLabel}
                         strongLabel
                         value={
+                            // FIXME: use helper from utils
                             [meResponse?.first_name, meResponse?.last_name]
                                 .filter(isTruthyString).join(' ')
                         }

--- a/src/views/AccountMyFormsDref/DrefTableActions/index.tsx
+++ b/src/views/AccountMyFormsDref/DrefTableActions/index.tsx
@@ -229,16 +229,14 @@ function DrefTableActions(props: Props) {
     }] = useBooleanState(false);
 
     const handleExportClick: NonNullable<ButtonProps<undefined>['onClick']> = useCallback(
-        (_, e) => {
-            e.stopPropagation();
+        () => {
             setShowExportModalTrue();
         },
         [setShowExportModalTrue],
     );
 
     const handleShareClick: NonNullable<ButtonProps<undefined>['onClick']> = useCallback(
-        (_, e) => {
-            e.stopPropagation();
+        () => {
             setShowShareModalTrue();
         },
         [setShowShareModalTrue],
@@ -273,13 +271,6 @@ function DrefTableActions(props: Props) {
         [fetchDref, fetchOpsUpdate, applicationType, id],
     );
 
-    const stopDropdownClickPropagation = useCallback(
-        (_: undefined, e: React.MouseEvent<HTMLButtonElement>) => {
-            e.stopPropagation();
-        },
-        [],
-    );
-
     const drefApprovalPending = publishDrefPending
         || publishOpsUpdatePending
         || publishFinalReportPending;
@@ -290,6 +281,7 @@ function DrefTableActions(props: Props) {
 
     return (
         <TableActions
+            persistent
             extraActions={(
                 <>
                     {canApprove && (
@@ -298,7 +290,7 @@ function DrefTableActions(props: Props) {
                             type="confirm-button"
                             icons={<CheckLineIcon className={styles.icon} />}
                             confirmMessage="You're about to Approve this DREF. Once approved, it can no longer be edited. Are you sure, you want to Approve?"
-                            onClick={stopDropdownClickPropagation}
+                            persist
                             onConfirm={handlePublishClick}
                         >
                             {strings.dropdownActionApproveLabel}
@@ -337,6 +329,7 @@ function DrefTableActions(props: Props) {
                         type="button"
                         icons={<ShareLineIcon className={styles.icon} />}
                         onClick={handleShareClick}
+                        persist
                     >
                         {strings.dropdownActionShareLabel}
                     </DropdownMenuItem>
@@ -345,6 +338,7 @@ function DrefTableActions(props: Props) {
                         type="button"
                         icons={<DocumentPdfLineIcon className={styles.icon} />}
                         onClick={handleExportClick}
+                        persist
                     >
                         {strings.dropdownActionExportLabel}
                     </DropdownMenuItem>

--- a/src/views/AccountNotifications/index.tsx
+++ b/src/views/AccountNotifications/index.tsx
@@ -22,6 +22,7 @@ const ITEM_PER_PAGE = 5;
 export function Component() {
     const strings = useTranslation(i18n);
 
+    // FIXME: use useFilterState
     const [page, setPage] = useState(1);
     const {
         error: subscribedEventsResponseError,

--- a/src/views/DrefApplicationForm/index.tsx
+++ b/src/views/DrefApplicationForm/index.tsx
@@ -53,6 +53,7 @@ import {
 import DrefShareModal from '#views/AccountMyFormsDref/DrefTableActions/DrefShareModal';
 
 import drefSchema, {
+    type DrefRequestPostBody,
     type DrefRequestBody,
     type DrefResponse,
 } from './schema';
@@ -255,7 +256,7 @@ export function Component() {
         trigger: updateDref,
     } = useLazyRequest({
         url: '/api/v2/dref/{id}/',
-        method: 'PUT',
+        method: 'PATCH',
         pathVariables: isDefined(drefId) ? { id: drefId } : undefined,
         body: (formFields: DrefRequestBody) => formFields,
         onSuccess: (response) => {
@@ -314,12 +315,13 @@ export function Component() {
                 },
             ));
 
-            /*
-            FIXME: this should be an array
-            if (formErrors.modified_at === 'OBSOLETE_PAYLOAD') {
+            const modifiedAtError = formErrors.modified_at;
+            if (
+                (typeof modifiedAtError === 'string' && modifiedAtError === 'OBSOLETE_PAYLOAD')
+                || (Array.isArray(modifiedAtError) && modifiedAtError.includes('OBSOLETE_PAYLOAD'))
+            ) {
                 setShowObsoletePayloadModal(true);
             }
-            */
 
             alert.show(
                 strings.formSaveRequestFailureMessage,
@@ -338,7 +340,7 @@ export function Component() {
     } = useLazyRequest({
         url: '/api/v2/dref/',
         method: 'POST',
-        body: (formFields: DrefRequestBody) => formFields,
+        body: (formFields: DrefRequestPostBody) => formFields,
         onSuccess: (responseUnsafe) => {
             const response = responseUnsafe as DrefResponse;
             alert.show(
@@ -396,13 +398,6 @@ export function Component() {
                 },
             ));
 
-            /*
-            FIXME: this should be an array
-            if (formErrors.modified_at === 'OBSOLETE_PAYLOAD') {
-                setShowObsoletePayloadModal(true);
-            }
-            */
-
             alert.show(
                 strings.formSaveRequestFailureMessage,
                 {
@@ -434,7 +429,7 @@ export function Component() {
                 createDref({
                     ...result.value,
                     modified_at: modifiedAt ?? lastModifiedAtRef.current,
-                } as DrefRequestBody);
+                } as DrefRequestPostBody);
             }
         },
         [validate, setError, updateDref, createDref, drefId],

--- a/src/views/DrefApplicationForm/schema.ts
+++ b/src/views/DrefApplicationForm/schema.ts
@@ -11,7 +11,7 @@ import {
     emailCondition,
 } from '@togglecorp/toggle-form';
 import { isDefined } from '@togglecorp/fujs';
-import { type DeepReplace, type DeepRemoveKeyPattern } from '#utils/common';
+import { type DeepReplace } from '#utils/common';
 
 import {
     positiveNumberCondition,
@@ -47,7 +47,8 @@ function lessThanEqualToTwoImagesCondition<T>(value: T[] | undefined) {
 }
 
 export type DrefResponse = GoApiResponse<'/api/v2/dref/{id}/'>;
-export type DrefRequestBody = GoApiBody<'/api/v2/dref/{id}/', 'PUT'>;
+export type DrefRequestBody = GoApiBody<'/api/v2/dref/{id}/', 'PATCH'>;
+export type DrefRequestPostBody = GoApiBody<'/api/v2/dref/{id}/', 'POST'>;
 
 type NeedIdentifiedResponse = NonNullable<DrefRequestBody['needs_identified']>[number];
 type NsActionResponse = NonNullable<DrefRequestBody['national_society_actions']>[number];
@@ -107,7 +108,7 @@ type DrefFormFields = (
 );
 
 export type PartialDref = PartialForm<
-    PurgeNull<DeepRemoveKeyPattern<DrefFormFields, '_details' | '_display'>>,
+    PurgeNull<DrefFormFields>,
     'client_id'
 >;
 
@@ -178,9 +179,6 @@ const schema: DrefFormSchema = {
             regional_focal_point_title: {},
             regional_focal_point_email: { validations: [emailCondition] },
             regional_focal_point_phone_number: {},
-
-            // government_requested_assistance_date: {}, // NOTE: Not found in the UI
-            // community_involved: {}, // NOTE: Not found in the UI
         };
 
         // OVERVIEW

--- a/src/views/DrefFinalReportForm/index.tsx
+++ b/src/views/DrefFinalReportForm/index.tsx
@@ -249,7 +249,7 @@ export function Component() {
         trigger: updateFinalReport,
     } = useLazyRequest({
         url: '/api/v2/dref-final-report/{id}/',
-        method: 'PUT',
+        method: 'PATCH',
         pathVariables: isDefined(finalReportId) ? { id: finalReportId } : undefined,
         body: (formFields: FinalReportRequestBody) => formFields,
         onSuccess: (response) => {
@@ -296,12 +296,13 @@ export function Component() {
                 },
             ));
 
-            /*
-            FIXME: this should be an array
-            if (formErrors.modified_at === 'OBSOLETE_PAYLOAD') {
+            const modifiedAtError = formErrors.modified_at;
+            if (
+                (typeof modifiedAtError === 'string' && modifiedAtError === 'OBSOLETE_PAYLOAD')
+                || (Array.isArray(modifiedAtError) && modifiedAtError.includes('OBSOLETE_PAYLOAD'))
+            ) {
                 setShowObsoletePayloadModal(true);
             }
-            */
 
             alert.show(
                 strings.formSaveRequestFailureMessage,

--- a/src/views/DrefFinalReportForm/schema.ts
+++ b/src/views/DrefFinalReportForm/schema.ts
@@ -12,7 +12,7 @@ import {
     emailCondition,
 } from '@togglecorp/toggle-form';
 import { isDefined } from '@togglecorp/fujs';
-import { type DeepReplace, type DeepRemoveKeyPattern } from '#utils/common';
+import { type DeepReplace } from '#utils/common';
 
 import {
     positiveNumberCondition,
@@ -44,7 +44,7 @@ function lessThanEqualToTwoImagesCondition<T>(value: T[] | undefined) {
 }
 
 export type FinalReportResponse = GoApiResponse<'/api/v2/dref-final-report/{id}/'>;
-export type FinalReportRequestBody = GoApiBody<'/api/v2/dref-final-report/{id}/', 'PUT'>;
+export type FinalReportRequestBody = GoApiBody<'/api/v2/dref-final-report/{id}/', 'PATCH'>;
 
 type NeedIdentifiedResponse = NonNullable<FinalReportRequestBody['needs_identified']>[number];
 type NsActionResponse = NonNullable<FinalReportRequestBody['national_society_actions']>[number];
@@ -104,7 +104,7 @@ type FinalReportFormFields = (
 );
 
 export type PartialFinalReport = PartialForm<
-    PurgeNull<DeepRemoveKeyPattern<FinalReportFormFields, '_details' | '_display'>>,
+    PurgeNull<FinalReportFormFields>,
     'client_id'
 >;
 
@@ -326,9 +326,6 @@ const schema: FinalReportFormSchema = {
             media_contact_title: {},
             media_contact_email: { validations: [emailCondition] },
             media_contact_phone_number: {},
-
-            // government_requested_assistance_date: {}, // NOTE: Not found in the UI
-            // community_involved: {}, // NOTE: Not found in the UI
         };
 
         // OVERVIEW

--- a/src/views/DrefOperationalUpdateForm/index.tsx
+++ b/src/views/DrefOperationalUpdateForm/index.tsx
@@ -335,7 +335,7 @@ export function Component() {
         trigger: updateOpsUpdate,
     } = useLazyRequest({
         url: '/api/v2/dref-op-update/{id}/',
-        method: 'PUT',
+        method: 'PATCH',
         pathVariables: isDefined(opsUpdateId) ? { id: opsUpdateId } : undefined,
         body: (formFields: OpsUpdateRequestBody) => formFields,
         onSuccess: (response) => {
@@ -387,12 +387,13 @@ export function Component() {
                 },
             ));
 
-            /*
-            FIXME: this should be an array
-            if (formErrors.modified_at === 'OBSOLETE_PAYLOAD') {
+            const modifiedAtError = formErrors.modified_at;
+            if (
+                (typeof modifiedAtError === 'string' && modifiedAtError === 'OBSOLETE_PAYLOAD')
+                || (Array.isArray(modifiedAtError) && modifiedAtError.includes('OBSOLETE_PAYLOAD'))
+            ) {
                 setShowObsoletePayloadModal(true);
             }
-            */
 
             alert.show(
                 strings.formSaveRequestFailureMessage,

--- a/src/views/Emergencies/index.tsx
+++ b/src/views/Emergencies/index.tsx
@@ -21,6 +21,7 @@ import KeyFigure from '#components/KeyFigure';
 import BarChart from '#components/BarChart';
 import Container from '#components/Container';
 import TimeSeriesChart from '#components/TimeSeriesChart';
+import usePermissions from '#hooks/domain/usePermissions';
 import useTranslation from '#hooks/useTranslation';
 import { useRequest } from '#utils/restRequest';
 import { getDatesSeparatedByMonths } from '#utils/chart';
@@ -76,6 +77,7 @@ oneYearAgo.setHours(0, 0, 0, 0);
 // eslint-disable-next-line import/prefer-default-export
 export function Component() {
     const strings = useTranslation(i18n);
+    const { isIfrcAdmin } = usePermissions();
     const {
         pending: eventsPending,
         response: eventsResponse,
@@ -283,7 +285,9 @@ export function Component() {
                 )}
                 <EmergenciesTable />
             </div>
-            <FlashUpdateTable />
+            {isIfrcAdmin && (
+                <FlashUpdateTable />
+            )}
             <FieldReportTable />
         </Page>
     );

--- a/src/views/FieldReportDetails/index.tsx
+++ b/src/views/FieldReportDetails/index.tsx
@@ -289,7 +289,6 @@ export function Component() {
                 </>
             )}
             mainSectionClassName={styles.content}
-            // FIXME: typing should be fixed in server (Language instead of string)
             contentOriginalLanguage={fieldReportResponse?.translation_module_original_language}
         >
             {fetchingFieldReport && (

--- a/src/views/FieldReportDetails/index.tsx
+++ b/src/views/FieldReportDetails/index.tsx
@@ -626,6 +626,14 @@ export function Component() {
                                                     {contact.email}
                                                 </Link>
                                             ) : undefined,
+                                            isTruthyString(contact.phone) ? (
+                                                <Link
+                                                    href={`tel:${contact.phone}`}
+                                                    external
+                                                >
+                                                    {contact.phone}
+                                                </Link>
+                                            ) : undefined,
                                         ].filter(isDefined), ', ')}
                                     </div>
                                 </div>

--- a/src/views/FlashUpdateForm/schema.ts
+++ b/src/views/FlashUpdateForm/schema.ts
@@ -9,7 +9,7 @@ import {
     undefinedValue,
 } from '@togglecorp/toggle-form';
 
-import { type DeepReplace, type DeepRemoveKeyPattern } from '#utils/common';
+import { type DeepReplace } from '#utils/common';
 import { type GoApiBody } from '#utils/restRequest';
 import { getDuplicates } from '#utils/common';
 
@@ -52,7 +52,7 @@ type FlashUpdateFormFields = (
 );
 
 export type FormType = PartialForm<
-    PurgeNull<DeepRemoveKeyPattern<FlashUpdateFormFields, '_details' | '_display'>>,
+    PurgeNull<FlashUpdateFormFields>,
     'client_id'
     >;
 

--- a/src/views/ThreeWProjectDetail/index.tsx
+++ b/src/views/ThreeWProjectDetail/index.tsx
@@ -228,8 +228,7 @@ export function Component() {
                         />
                         <TextOutput
                             label={strings.tagsTitle}
-                            // FIXME typing should be fixed in server
-                            value={(projectResponse?.secondary_sectors_display as string[] | undefined)?.join(', ')}
+                            value={projectResponse?.secondary_sectors_display?.join(', ')}
                             description={(
                                 <InfoPopup
                                     title={strings.tagsTitle}


### PR DESCRIPTION
- Add a usePermissions hook
- Use permission for flash update page and tables
- Remove usage of DeepRemoveKeyPattern
- Fix issue with photos_file in Dref Operational Update form
- Use persistent DropdownMenu
- Use PATCH instead of PUT on dref forms
- Handle obsolete payload issue
- Support string as leaf error from response
- Eagerly fetch user-/me details and reset login if token is invalid

## This PR doesn't introduce:
- [ ] typos
- [ ] conflict markers
- [ ] unwanted comments
- [ ] temporary files, auto-generated files or secret keys
- [ ] `console.log` meant for debugging
- [ ] codegen errors
