### PR TITLE
Show field report title with prefix and suffix

### DIFF
--- a/src/views/FieldReportForm/ContextFields/i18n.json
+++ b/src/views/FieldReportForm/ContextFields/i18n.json
@@ -11,7 +11,7 @@
         "emergencySelectPlaceholder": "Click here to link to an existing hazard alert (if one exists)",
 
         "titleInputPlaceholder": "Example: Cyclone Cody",
-        "titleSecondaryLabel": "Add Summary",
+        "titleSecondaryLabel": "Title",
 
         "assistanceDescription": "Indicate if the government requested international assistance.",
         "assistanceLabel": "Government requests international assistance?",

--- a/src/views/FieldReportForm/ContextFields/index.tsx
+++ b/src/views/FieldReportForm/ContextFields/index.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo } from 'react';
-import { isNotDefined } from '@togglecorp/fujs';
+import { isNotDefined, isTruthyString } from '@togglecorp/fujs';
 import {
     type Error,
     type EntriesAsList,
@@ -46,7 +46,10 @@ interface Props {
     setDistrictOptions: React.Dispatch<React.SetStateAction<DistrictItem[] | null | undefined>>;
     setEventOptions: React.Dispatch<React.SetStateAction<EventItem[] | null | undefined>>;
     disabled?: boolean;
-    titlePreview: string | undefined;
+
+    fieldReportId: string | undefined;
+    titlePrefix: string | undefined;
+    titleSuffix: string | undefined;
 }
 
 function ContextFields(props: Props) {
@@ -60,7 +63,9 @@ function ContextFields(props: Props) {
         setDistrictOptions,
         setEventOptions,
         disabled,
-        titlePreview,
+        titlePrefix,
+        titleSuffix,
+        fieldReportId,
     } = props;
 
     const strings = useTranslation(i18n);
@@ -157,6 +162,17 @@ function ContextFields(props: Props) {
         [onValueChange, value.dtype],
     );
 
+    const prefixVisible = !fieldReportId && isTruthyString(titlePrefix);
+    const summaryVisible = !value.is_covid_report;
+    const suffixVisible = !fieldReportId && isTruthyString(titleSuffix);
+
+    const preferredColumnNoForSummary = Math.max(
+        (prefixVisible ? 1 : 0)
+        + (summaryVisible ? 1 : 0)
+        + (suffixVisible ? 1 : 0),
+        1,
+    ) as 1 | 2 | 3;
+
     return (
         <Container
             heading={strings.fieldReportFormContextTitle}
@@ -181,6 +197,7 @@ function ContextFields(props: Props) {
                 />
             </InputSection>
             <InputSection
+                className={styles.hidden}
                 title={strings.covidSectionTitle}
                 withAsteriskOnTitle
             >
@@ -273,18 +290,42 @@ function ContextFields(props: Props) {
                 title={strings.summaryLabel}
                 description={strings.summaryDescription}
                 withAsteriskOnTitle
+                numPreferredColumns={preferredColumnNoForSummary}
             >
-                <TextInput
-                    label={strings.titleSecondaryLabel}
-                    placeholder={strings.titleInputPlaceholder}
-                    name="summary"
-                    value={value.summary}
-                    maxLength={256}
-                    onChange={onValueChange}
-                    error={error?.summary}
-                    disabled={disabled}
-                    hint={titlePreview}
-                />
+                {prefixVisible && (
+                    <TextInput
+                        // FIXME: use translations
+                        label={summaryVisible ? 'Prefix' : strings.titleSecondaryLabel}
+                        name={undefined}
+                        value={titlePrefix}
+                        // eslint-disable-next-line @typescript-eslint/no-empty-function
+                        onChange={() => {}}
+                    />
+                )}
+                {summaryVisible && (
+                    <TextInput
+                        label={strings.titleSecondaryLabel}
+                        placeholder={strings.titleInputPlaceholder}
+                        name="summary"
+                        value={value.summary}
+                        maxLength={256}
+                        onChange={onValueChange}
+                        error={error?.summary}
+                        disabled={disabled}
+                        withAsterisk
+                    />
+                )}
+                {suffixVisible && (
+                    <TextInput
+                        // FIXME: use translations
+                        label="Suffix"
+                        name={undefined}
+                        value={titleSuffix}
+                        // eslint-disable-next-line @typescript-eslint/no-empty-function
+                        onChange={() => {}}
+                        // readOnly
+                    />
+                )}
             </InputSection>
             <InputSection
                 title={strings.assistanceLabel}

--- a/src/views/FieldReportForm/ContextFields/styles.module.css
+++ b/src/views/FieldReportForm/ContextFields/styles.module.css
@@ -3,5 +3,9 @@
         display: flex;
         flex-direction: column;
         gap: var(--go-ui-spacing-lg);
+
+        .hidden {
+            display: none;
+        }
     }
 }

--- a/src/views/FieldReportForm/common.ts
+++ b/src/views/FieldReportForm/common.ts
@@ -271,7 +271,6 @@ export const reportSchema: FormSchema = {
             districts: { defaultValue: [] },
             dtype: { required: true },
             start_date: { required: true },
-            summary: { required: true, requiredValidation: requiredStringCondition },
             request_assistance: {},
             ns_request_assistance: {},
 
@@ -291,6 +290,25 @@ export const reportSchema: FormSchema = {
             },
             visibility: { required: true },
         });
+
+        // CONTEXT
+        baseSchema = addCondition(
+            baseSchema,
+            value,
+            ['status', 'is_covid_report', 'dtype'],
+            ['summary'],
+            (val): Pick<FormSchemaFields, 'summary'> => {
+                const reportType = getReportType(val?.status, val?.is_covid_report, val?.dtype);
+                if (reportType === 'COVID') {
+                    return {
+                        summary: { forceValue: nullValue },
+                    };
+                }
+                return {
+                    summary: { required: true, requiredValidation: requiredStringCondition },
+                };
+            },
+        );
 
         // SITUATION / RISK ANALYSIS
 

--- a/src/views/FieldReportForm/i18n.json
+++ b/src/views/FieldReportForm/i18n.json
@@ -1,10 +1,6 @@
 {
     "namespace": "fieldReportForm",
     "strings": {
-        "generatedTitleFormat": "{iso3}: {disaster} - {shortDate} - {summary} #{fieldReportNumber} ({fullDate})",
-        "generatedTitleFormatOld": "{iso3}: {disaster} - {shortDate} - {summary}",
-        "generatedTitleFormatForCovid": "{iso3}: COVID-19 #{fieldReportNumber} ({fullDate})",
-        "generatedTitleFormatForCovidOld": "{iso3}: COVID-19",
         "formRedirectMessage": "Field report updated, redirecting...",
         "formErrorLabel": "Failed to create/update!",
         "title": "IFRC GO - Field Report",

--- a/src/views/PerOverviewForm/index.tsx
+++ b/src/views/PerOverviewForm/index.tsx
@@ -75,6 +75,7 @@ export function Component() {
     const { per_overviewassessmentmethods } = useGlobalEnums();
 
     const formContentRef = useRef<ElementRef<'div'>>(null);
+    const isSettingUpProcess = useRef(false);
 
     const {
         value,
@@ -83,7 +84,11 @@ export function Component() {
         error: formError,
         setError,
         validate,
-    } = useForm(overviewSchema, { value: { assessment_method: 'per' } });
+    } = useForm(
+        overviewSchema,
+        { value: { assessment_method: 'per' } },
+        isSettingUpProcess,
+    );
 
     const [
         fileIdToUrlMap,
@@ -294,6 +299,18 @@ export function Component() {
     }, []);
 
     const handleSetupPerProcess = useCallback(() => {
+        isSettingUpProcess.current = true;
+        const handler = createSubmitHandler(
+            validate,
+            setError,
+            handleFinalSubmit,
+            handleFormError,
+        );
+        handler();
+        isSettingUpProcess.current = false;
+    }, [handleFormError, handleFinalSubmit, validate, setError]);
+
+    const handleSave = useCallback(() => {
         const handler = createSubmitHandler(
             validate,
             setError,
@@ -303,21 +320,11 @@ export function Component() {
         handler();
     }, [handleFormError, handleSubmit, validate, setError]);
 
-    const handleSave = useCallback(() => {
-        const handler = createSubmitHandler(
-            validate,
-            setError,
-            handleFinalSubmit,
-            handleFormError,
-        );
-        handler();
-    }, [handleFormError, handleFinalSubmit, validate, setError]);
-
     const error = getErrorObject(formError);
 
     const currentPerStep = statusResponse?.phase;
-    const submissionDisabled = isNotDefined(currentPerStep)
-        || currentPerStep !== PER_PHASE_OVERVIEW;
+    const submissionDisabled = isDefined(currentPerStep)
+        && currentPerStep !== PER_PHASE_OVERVIEW;
 
     const partialReadonlyMode = value?.is_draft === false;
 
@@ -356,7 +363,7 @@ export function Component() {
                     name={undefined}
                     confirmHeading={strings.submitConfirmHeading}
                     confirmMessage={strings.submitConfirmMessage}
-                    onConfirm={handleSave}
+                    onConfirm={handleSetupPerProcess}
                     disabled={submissionDisabled || savePerPending}
                 >
                     {strings.submitButtonLabel}
@@ -371,7 +378,7 @@ export function Component() {
                     <Button
                         name={undefined}
                         variant="secondary"
-                        onClick={handleSetupPerProcess}
+                        onClick={handleSave}
                         disabled={savePerPending}
                     >
                         {strings.saveButtonLabel}

--- a/src/views/ThreeWProjectForm/index.tsx
+++ b/src/views/ThreeWProjectForm/index.tsx
@@ -116,9 +116,8 @@ function calculateStatus(
 
     if (isDefined(endDate)) {
         const end = new Date(endDate);
-        // FIXME: why is this undefined?
         if (end.getTime() < now.getTime()) {
-            return undefined;
+            return PROJECT_STATUS_COMPLETED;
         }
     }
 
@@ -521,9 +520,12 @@ export function Component() {
         setValue((oldValue) => ({
             ...oldValue,
             budget_amount: newBudget,
+            // FIXME: This does not make sense
+            /*
             actual_expenditure: isNotDefined(oldValue.actual_expenditure)
                 ? newBudget
                 : oldValue.actual_expenditure,
+            */
         }), true);
     }, [setValue]);
 
@@ -531,9 +533,12 @@ export function Component() {
         setValue((oldValue) => ({
             ...oldValue,
             actual_expenditure: newExpenditure,
+            // FIXME: This does not make sense
+            /*
             budget_amount: isNotDefined(oldValue.budget_amount)
                 ? newExpenditure
                 : oldValue.budget_amount,
+            */
         }), true);
     }, [setValue]);
 


### PR DESCRIPTION
- Make date_of_assessment and type_of_assessment mandatory when setting up PER
- Remove updating budget_amount and actual_expenditure on change

## This PR doesn't introduce:
- [ ] typos
- [ ] conflict markers
- [ ] unwanted comments
- [ ] temporary files, auto-generated files or secret keys
- [ ] `console.log` meant for debugging
- [ ] codegen errors
