### PR TITLE
Set district options when copying from field report

### DIFF
--- a/src/views/Country/index.tsx
+++ b/src/views/Country/index.tsx
@@ -222,7 +222,7 @@ export function Component() {
             actions={isAuthenticated && (
                 <Link
                     external
-                    href={resolveUrl(adminUrl, `${adminUrl}api/country/${countryId}/change/`)}
+                    href={resolveUrl(adminUrl, `api/country/${countryId}/change/`)}
                     variant="secondary"
                     icons={<PencilFillIcon />}
                 >

--- a/src/views/DrefApplicationForm/Overview/CopyFieldReportSection/index.tsx
+++ b/src/views/DrefApplicationForm/Overview/CopyFieldReportSection/index.tsx
@@ -1,6 +1,7 @@
 import {
-    useState,
     useCallback,
+    type SetStateAction,
+    type Dispatch,
 } from 'react';
 import {
     unique,
@@ -23,6 +24,7 @@ import {
     useLazyRequest,
 } from '#utils/restRequest';
 import useTranslation from '#hooks/useTranslation';
+import { type DistrictItem } from '#components/domain/DistrictSearchMultiSelectInput';
 
 import { type PartialDref } from '../../schema';
 
@@ -34,6 +36,9 @@ interface Props {
     value: Value;
     setFieldValue: (...entries: EntriesAsList<PartialDref>) => void;
     disabled?: boolean;
+    setDistrictOptions: Dispatch<SetStateAction<DistrictItem[] | null | undefined>>;
+    fieldReportOptions: FieldReportSearchItem[] | null | undefined;
+    setFieldReportOptions: Dispatch<SetStateAction<FieldReportSearchItem[] | null | undefined>>;
 }
 
 function CopyFieldReportSection(props: Props) {
@@ -41,6 +46,9 @@ function CopyFieldReportSection(props: Props) {
         value,
         setFieldValue,
         disabled,
+        setDistrictOptions,
+        fieldReportOptions,
+        setFieldReportOptions,
     } = props;
 
     const strings = useTranslation(i18n);
@@ -49,9 +57,6 @@ function CopyFieldReportSection(props: Props) {
     const [fieldReport, setFieldReport] = useInputState<number | undefined | null>(
         value?.field_report,
     );
-    const [fieldReportOptions, setFieldReportOptions] = useState<
-        FieldReportSearchItem[] | undefined | null
-    >([]);
 
     useRequest({
         skip: isNotDefined(value.field_report),
@@ -96,6 +101,14 @@ function CopyFieldReportSection(props: Props) {
             const district = (value.district && value.district.length > 0)
                 ? value.district
                 : fieldReportResponse.districts;
+
+            setDistrictOptions(((existingOptions) => {
+                const safeOptions = existingOptions ?? [];
+                return unique(
+                    [...safeOptions, ...(fieldReportResponse.districts_details ?? [])],
+                    (item) => item.id,
+                );
+            }));
 
             const num_affected = value?.num_affected
                 ?? fieldReportResponse.num_affected
@@ -198,6 +211,8 @@ function CopyFieldReportSection(props: Props) {
             setFieldValue(partner_national_society, 'partner_national_society');
             setFieldValue(ifrc, 'ifrc');
             setFieldValue(icrc, 'icrc');
+
+            // set field_report_option and districts
 
             alert.show(
                 strings.drefFormCopyFRSuccessMessage,

--- a/src/views/DrefApplicationForm/Overview/index.tsx
+++ b/src/views/DrefApplicationForm/Overview/index.tsx
@@ -14,6 +14,7 @@ import {
     isNotDefined,
 } from '@togglecorp/fujs';
 
+import { type FieldReportItem as FieldReportSearchItem } from '#components/domain/FieldReportSearchSelectInput';
 import Container from '#components/Container';
 import InputSection from '#components/InputSection';
 import Link from '#components/Link';
@@ -81,6 +82,9 @@ interface Props {
     setFileIdToUrlMap?: React.Dispatch<React.SetStateAction<Record<number, string>>>;
     districtOptions: DistrictItem[] | null | undefined;
     setDistrictOptions: Dispatch<SetStateAction<DistrictItem[] | null | undefined>>;
+
+    fieldReportOptions: FieldReportSearchItem[] | null | undefined;
+    setFieldReportOptions: Dispatch<SetStateAction<FieldReportSearchItem[] | null | undefined>>;
 }
 
 function Overview(props: Props) {
@@ -93,6 +97,8 @@ function Overview(props: Props) {
         disabled,
         districtOptions,
         setDistrictOptions,
+        fieldReportOptions,
+        setFieldReportOptions,
     } = props;
 
     const strings = useTranslation(i18n);
@@ -170,6 +176,9 @@ function Overview(props: Props) {
                     value={value}
                     setFieldValue={setFieldValue}
                     disabled={disabled}
+                    setDistrictOptions={setDistrictOptions}
+                    fieldReportOptions={fieldReportOptions}
+                    setFieldReportOptions={setFieldReportOptions}
                 />
             )}
             <InputSection

--- a/src/views/DrefApplicationForm/index.tsx
+++ b/src/views/DrefApplicationForm/index.tsx
@@ -18,6 +18,7 @@ import {
     isTruthyString,
 } from '@togglecorp/fujs';
 
+import { type FieldReportItem as FieldReportSearchItem } from '#components/domain/FieldReportSearchSelectInput';
 import useRouting from '#hooks/useRouting';
 import Page from '#components/Page';
 import Tab from '#components/Tabs/Tab';
@@ -132,8 +133,12 @@ export function Component() {
         setFalse: setShowShareModalFalse,
     }] = useBooleanState(false);
     const lastModifiedAtRef = useRef<string | undefined>();
+
     const [districtOptions, setDistrictOptions] = useState<
         DistrictItem[] | undefined | null
+    >([]);
+    const [fieldReportOptions, setFieldReportOptions] = useState<
+        FieldReportSearchItem[] | undefined | null
     >([]);
 
     const {
@@ -586,6 +591,8 @@ export function Component() {
                                 disabled={disabled}
                                 districtOptions={districtOptions}
                                 setDistrictOptions={setDistrictOptions}
+                                fieldReportOptions={fieldReportOptions}
+                                setFieldReportOptions={setFieldReportOptions}
                             />
                         </TabPanel>
                         <TabPanel name="eventDetail">


### PR DESCRIPTION
- Fix issue with the country edit link to admin page
- Move field report options to root form

## This PR doesn't introduce:
- [ ] typos
- [ ] conflict markers
- [ ] unwanted comments
- [ ] temporary files, auto-generated files or secret keys
- [ ] `console.log` meant for debugging
- [ ] codegen errors
