### PR TITLE
fixes weirdly jumping Key Figures in Emergency Surge tab on Safari

### DIFF
--- a/src/views/EmergencySurge/styles.module.css
+++ b/src/views/EmergencySurge/styles.module.css
@@ -14,7 +14,6 @@
         .key-figure {
             border-radius: var(--go-ui-border-radius-lg);
             box-shadow: var(--go-ui-box-shadow-md);
-            height: 100%;
         }
     }
 }


### PR DESCRIPTION

## Addresses:
https://github.com/IFRCGo/go-frontend/issues/2911

The Key Figures in the surge tab were jumping weirdly on Safari. Removing height: 100% on the keyfigures element fixes this. I tested on Chrome and Firefox and could not see any issues with this and also some reading up on the internet about weird issues with CSS Grid and Safari seemed to suggest height: 100% might be the problem. If we do need the height: 100% there for some reason, another approach would be to try height: auto;


## Changes

 - Remove height: 100% from Key Figures in Surge tab on Emergency page
 - 
## This PR doesn't introduce:
- [x] typos
- [x] conflict markers
- [x] unwanted comments
- [x] temporary files, auto-generated files or secret keys
- [x] `console.log` meant for debugging
- [x] codegen errors

cc @frozenhelium