### PR TITLE
Add GDACS Emergency Events in Country Pages

### DIFF
--- a/src/views/CountryOngoingActivitiesEmergencies/EmergencyAlerts/i18n.json
+++ b/src/views/CountryOngoingActivitiesEmergencies/EmergencyAlerts/i18n.json
@@ -1,0 +1,13 @@
+{
+    "namespace": "emergencyAlerts",
+    "strings": {
+        "emergencyAlertsTableTitle": "Emergency Alerts In The Last 30 Days",
+        "emergencyAlertsTablePublicationDate": "Date",
+        "emergencyAlertsDisasterType": "Alert",
+        "emergencyAlertsTableDisasterDescription": "Description",
+        "emergencyAlertsTableExposedPopulation": "Exposed Population",
+        "emergencyAlertsTableExposedCountries": "Affected Countries",
+        "emergencyAlertsTableSource": "Source",
+        "emergencyAlertsTableGdacs": "GDACS"
+    }
+}

--- a/src/views/CountryOngoingActivitiesEmergencies/EmergencyAlerts/index.tsx
+++ b/src/views/CountryOngoingActivitiesEmergencies/EmergencyAlerts/index.tsx
@@ -1,0 +1,154 @@
+import { useMemo } from 'react';
+import { _cs, encodeDate, isNotDefined } from '@togglecorp/fujs';
+
+import Container from '#components/Container';
+import Link from '#components/Link';
+import Pager from '#components/Pager';
+import Table from '#components/Table';
+import useFilterState from '#hooks/useFilterState';
+import useTranslation from '#hooks/useTranslation';
+import TextOutput from '#components/TextOutput';
+import {
+    createStringColumn,
+    createDateColumn,
+    createCountryListColumn,
+} from '#components/Table/ColumnShortcuts';
+import { useRequest } from '#utils/restRequest';
+import type { GoApiResponse } from '#utils/restRequest';
+
+import i18n from './i18n.json';
+import styles from './styles.module.css';
+
+type EmergencyAlertResponse = GoApiResponse<'/api/v2/gdacs-event/'>;
+type EmergencyAlertListItem = NonNullable<EmergencyAlertResponse['results']>[number];
+
+const emergencyAlertKeySelector = (option: EmergencyAlertListItem) => option.id;
+
+// FIXME: use a separate utility
+const thirtyDaysAgo = new Date();
+thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+thirtyDaysAgo.setHours(0, 0, 0, 0);
+
+interface Props {
+    countryId: number;
+    className?: string;
+}
+
+function EmergencyAlertsTable(props: Props) {
+    const {
+        className,
+        countryId,
+    } = props;
+
+    const {
+        page,
+        setPage,
+        limit,
+        offset,
+    } = useFilterState<object>({
+        filter: {},
+        pageSize: 5,
+    });
+
+    const strings = useTranslation(i18n);
+
+    const columns = useMemo(
+        () => ([
+            createDateColumn<EmergencyAlertListItem, number>(
+                'start_date',
+                strings.emergencyAlertsTablePublicationDate,
+                (item) => item.publication_date,
+                {
+                    columnClassName: styles.pulicationDate,
+                },
+            ),
+            createStringColumn<EmergencyAlertListItem, number>(
+                'disaster_type',
+                strings.emergencyAlertsDisasterType,
+                (item) => item.disaster_type.name,
+            ),
+            createStringColumn<EmergencyAlertListItem, number>(
+                'description',
+                strings.emergencyAlertsTableDisasterDescription,
+                (item) => item.title,
+            ),
+            createStringColumn<EmergencyAlertListItem, number>(
+                'population',
+                strings.emergencyAlertsTableExposedPopulation,
+                (item) => `${item.population_value} ${item.population_unit}`,
+            ),
+            createCountryListColumn<EmergencyAlertListItem, number>(
+                'countries',
+                strings.emergencyAlertsTableExposedCountries,
+                (item) => item.countries,
+            ),
+        ]),
+        [
+            strings.emergencyAlertsTablePublicationDate,
+            strings.emergencyAlertsDisasterType,
+            strings.emergencyAlertsTableDisasterDescription,
+            strings.emergencyAlertsTableExposedPopulation,
+            strings.emergencyAlertsTableExposedCountries,
+        ],
+    );
+
+    const {
+        pending: emergencyAlertsPending,
+        response: emergencyAlertsResponse,
+    } = useRequest({
+        url: '/api/v2/gdacs-event/',
+        skip: isNotDefined(countryId),
+        preserveResponse: true,
+        query: {
+            limit,
+            offset,
+            publication_date__gte: encodeDate(thirtyDaysAgo),
+            countries: countryId ? [countryId] : undefined,
+        },
+    });
+
+    return (
+        <Container
+            className={_cs(styles.emergencyAlertsTable, className)}
+            heading={strings.emergencyAlertsTableTitle}
+            childrenContainerClassName={styles.content}
+            withGridViewInFilter
+            footerContentClassName={styles.footerContent}
+            footerContent={(
+                <TextOutput
+                    label={strings.emergencyAlertsTableSource}
+                    value={(
+                        <Link
+                            title={strings.emergencyAlertsTableGdacs}
+                            href="https://www.gdacs.org/alerts/"
+                            external
+                            variant="tertiary"
+                        >
+                            {strings.emergencyAlertsTableGdacs}
+                        </Link>
+                    )}
+                />
+            )}
+            footerActions={(
+                <Pager
+                    activePage={page}
+                    itemsCount={emergencyAlertsResponse?.count ?? 0}
+                    maxItemsPerPage={limit}
+                    onActivePageChange={setPage}
+                />
+            )}
+            contentViewType="vertical"
+        >
+            <Table
+                pending={emergencyAlertsPending}
+                className={styles.table}
+                columns={columns}
+                filtered={false}
+                keySelector={emergencyAlertKeySelector}
+                data={emergencyAlertsResponse?.results}
+            />
+        </Container>
+    );
+}
+
+export default EmergencyAlertsTable;

--- a/src/views/CountryOngoingActivitiesEmergencies/EmergencyAlerts/styles.module.css
+++ b/src/views/CountryOngoingActivitiesEmergencies/EmergencyAlerts/styles.module.css
@@ -1,0 +1,15 @@
+.emergency-alerts-table {
+    .table {
+        min-height: 0;
+
+        .publication-date {
+            width: 0%;
+            min-width: 9rem;
+        }
+    }
+
+    .footer-content {
+        display: flex;
+        justify-content: flex-end;
+    }
+}

--- a/src/views/CountryOngoingActivitiesEmergencies/index.tsx
+++ b/src/views/CountryOngoingActivitiesEmergencies/index.tsx
@@ -25,6 +25,7 @@ import { useRequest } from '#utils/restRequest';
 
 import i18n from './i18n.json';
 import styles from './styles.module.css';
+import EmergencyAlertsTable from './EmergencyAlerts';
 
 // eslint-disable-next-line import/prefer-default-export
 export function Component() {
@@ -125,6 +126,11 @@ export function Component() {
             {isDefined(countryId) && (
                 <AppealsTable
                     variant="country"
+                    countryId={Number(countryId)}
+                />
+            )}
+            {isDefined(countryId) && (
+                <EmergencyAlertsTable
                     countryId={Number(countryId)}
                 />
             )}


### PR DESCRIPTION
## Addresses:
- https://github.com/toggle-corp/ifrc-go-meta/issues/344

## Changes
- Fetch GDACS events from last 30 days and show in country pages ongoing emergencies section

## This PR doesn't introduce:
- [x] typos
- [x] conflict markers
- [x] unwanted comments
- [x] temporary files, auto-generated files or secret keys
- [x] `console.log` meant for debugging
- [x] codegen errors
