### PR TITLE
Remove form-field No. of people targeted from DREF Forms

### DIFF
--- a/src/views/DrefApplicationForm/EventDetail/index.tsx
+++ b/src/views/DrefApplicationForm/EventDetail/index.tsx
@@ -53,7 +53,6 @@ function EventDetail(props: Props) {
 
     const totalPopulationRiskImminentLink = 'https://ifrcorg.sharepoint.com/sites/IFRCSharing/Shared%20Documents/Forms/AllItems.aspx?id=%2Fsites%2FIFRCSharing%2FShared%20Documents%2FDREF%2FHum%20Pop%20Definitions%20for%20DREF%20Form%5F21072022%2Epdf&parent=%2Fsites%2FIFRCSharing%2FShared%20Documents%2FDREF&p=true&ga=1';
     const totalPeopleAffectedSlowSuddenLink = 'https://ifrcorg.sharepoint.com/sites/IFRCSharing/Shared%20Documents/Forms/AllItems.aspx?id=%2Fsites%2FIFRCSharing%2FShared%20Documents%2FDREF%2FHum%20Pop%20Definitions%20for%20DREF%20Form%5F21072022%2Epdf&parent=%2Fsites%2FIFRCSharing%2FShared%20Documents%2FDREF&p=true&ga=1';
-    const peopleTargetedLink = 'https://ifrcorg.sharepoint.com/sites/IFRCSharing/Shared%20Documents/Forms/AllItems.aspx?id=%2Fsites%2FIFRCSharing%2FShared%20Documents%2FDREF%2FHum%20Pop%20Definitions%20for%20DREF%20Form%5F21072022%2Epdf&parent=%2Fsites%2FIFRCSharing%2FShared%20Documents%2FDREF&p=true&ga=1';
     const peopleInNeedLink = 'https://ifrcorg.sharepoint.com/sites/IFRCSharing/Shared%20Documents/Forms/AllItems.aspx?id=%2Fsites%2FIFRCSharing%2FShared%20Documents%2FDREF%2FHum%20Pop%20Definitions%20for%20DREF%20Form%5F21072022%2Epdf&parent=%2Fsites%2FIFRCSharing%2FShared%20Documents%2FDREF&p=true&ga=1';
 
     const {

--- a/src/views/DrefApplicationForm/EventDetail/index.tsx
+++ b/src/views/DrefApplicationForm/EventDetail/index.tsx
@@ -355,27 +355,6 @@ function EventDetail(props: Props) {
                             disabled={disabled}
                         />
                     )}
-                    <NumberInput
-                        label={(
-                            <>
-                                {/* FIXME: use string template */}
-                                {strings.drefFormPeopleTargeted}
-                                <Link
-                                    title={strings.drefFormClickEmergencyResponseFramework}
-                                    href={peopleTargetedLink}
-                                    external
-                                >
-                                    <WikiHelpSectionLineIcon />
-                                </Link>
-                            </>
-                        )}
-                        name="num_assisted"
-                        value={value?.num_assisted}
-                        onChange={setFieldValue}
-                        error={error?.num_assisted}
-                        hint={strings.drefFormPeopleTargetedDescription}
-                        disabled={disabled}
-                    />
                     {/* FIXME: use grid to fix the empty div issue */}
                     {/* NOTE: Empty div to preserve the layout */}
                     <div />

--- a/src/views/DrefApplicationForm/schema.ts
+++ b/src/views/DrefApplicationForm/schema.ts
@@ -152,7 +152,7 @@ const schema: DrefFormSchema = {
 
             // EVENT DETAILS
             num_affected: { validations: [positiveIntegerCondition] },
-            num_assisted: { validations: [positiveIntegerCondition] },
+
             // none
 
             // ACTIONS


### PR DESCRIPTION
## Addresses:
- https://github.com/toggle-corp/ifrc-go-meta/issues/502

## Changes
- Remove form-field 'No. of people targeted' from DREF Forms
- Remove schema 


## This PR doesn't introduce:
- [x] typos
- [x] conflict markers
- [x] unwanted comments
- [x] temporary files, auto-generated files or secret keys
- [x] `console.log` meant for debugging
- [x] codegen errors
