### PR TITLE
Remove inactive Map export button 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "go-web-app",
-    "version": "7.0.17",
+    "version": "7.0.18",
     "type": "module",
     "scripts": {
         "initialize:type": "mkdir -p generated/ && yarn initialize:type:go-api && yarn initialize:type:risk-api",

--- a/src/views/AccountMyFormsDref/ActiveDrefTable/index.tsx
+++ b/src/views/AccountMyFormsDref/ActiveDrefTable/index.tsx
@@ -234,7 +234,7 @@ function ActiveDrefTable(props: Props) {
                                 || (has_ops_update && unpublished_op_update_count === 0)
                         );
 
-                    const drefRegion = country_details.region;
+                    const drefRegion = country_details?.region;
                     const isRegionCoordinator = isDefined(drefRegion)
                         ? userRegionCoordinatorMap?.[drefRegion] ?? false
                         : false;


### PR DESCRIPTION
## Addresses:
- https://github.com/IFRCGo/go-web-app/issues/313



## Changes
- Remove inactive Map export button from emergencies details

## This PR doesn't introduce:
- [x] typos
- [x] conflict markers
- [x ] unwanted comments
- [x ] temporary files, auto-generated files or secret keys
- [x] `console.log` meant for debugging
- [x ] codegen errors
