### PR TITLE
Hide form field to upload document based on Disaster Category

### DIFF
--- a/src/views/DrefApplicationForm/Overview/index.tsx
+++ b/src/views/DrefApplicationForm/Overview/index.tsx
@@ -310,7 +310,7 @@ function Overview(props: Props) {
                     {(
                         value?.disaster_category === 1
                         || value?.disaster_category === 2)
-                        ? (
+                        && (
                             <InputSection title={strings.drefFormUploadCrisisDocument}>
                                 <GoSingleFileInput
                                     name="disaster_category_analysis"
@@ -327,8 +327,6 @@ function Overview(props: Props) {
                                     {strings.drefFormUploadDocumentButtonLabel}
                                 </GoSingleFileInput>
                             </InputSection>
-                        ) : (
-                            <div />
                         )}
                 </Container>
                 <InputSection

--- a/src/views/DrefApplicationForm/Overview/index.tsx
+++ b/src/views/DrefApplicationForm/Overview/index.tsx
@@ -307,22 +307,29 @@ function Overview(props: Props) {
                             disabled={disabled}
                         />
                     </InputSection>
-                    <InputSection title={strings.drefFormUploadCrisisDocument}>
-                        <GoSingleFileInput
-                            name="disaster_category_analysis"
-                            accept=".pdf, .docx, .pptx"
-                            fileIdToUrlMap={fileIdToUrlMap}
-                            onChange={setFieldValue}
-                            url="/api/v2/dref-files/"
-                            value={value.disaster_category_analysis}
-                            error={error?.disaster_category_analysis}
-                            setFileIdToUrlMap={setFileIdToUrlMap}
-                            clearable
-                            disabled={disabled}
-                        >
-                            {strings.drefFormUploadDocumentButtonLabel}
-                        </GoSingleFileInput>
-                    </InputSection>
+                    {(
+                        value?.disaster_category === 1
+                        || value?.disaster_category === 2)
+                        ? (
+                            <InputSection title={strings.drefFormUploadCrisisDocument}>
+                                <GoSingleFileInput
+                                    name="disaster_category_analysis"
+                                    accept=".pdf, .docx, .pptx"
+                                    fileIdToUrlMap={fileIdToUrlMap}
+                                    onChange={setFieldValue}
+                                    url="/api/v2/dref-files/"
+                                    value={value.disaster_category_analysis}
+                                    error={error?.disaster_category_analysis}
+                                    setFileIdToUrlMap={setFileIdToUrlMap}
+                                    clearable
+                                    disabled={disabled}
+                                >
+                                    {strings.drefFormUploadDocumentButtonLabel}
+                                </GoSingleFileInput>
+                            </InputSection>
+                        ) : (
+                            <div />
+                        )}
                 </Container>
                 <InputSection
                     title={

--- a/src/views/DrefApplicationForm/Overview/index.tsx
+++ b/src/views/DrefApplicationForm/Overview/index.tsx
@@ -41,6 +41,10 @@ import DistrictSearchMultiSelectInput, {
 import UserItem from '#components/domain/DrefShareModal/UserItem';
 import GoSingleFileInput from '#components/domain/GoSingleFileInput';
 import useDisasterType from '#hooks/domain/useDisasterType';
+import {
+    DISASTER_CATEGORY_ORANGE,
+    DISASTER_CATEGORY_RED,
+} from '#utils/constants';
 
 import {
     DISASTER_FIRE,
@@ -308,8 +312,8 @@ function Overview(props: Props) {
                         />
                     </InputSection>
                     {(
-                        value?.disaster_category === 1
-                        || value?.disaster_category === 2)
+                        value?.disaster_category === DISASTER_CATEGORY_ORANGE
+                        || value?.disaster_category === DISASTER_CATEGORY_RED)
                         && (
                             <InputSection title={strings.drefFormUploadCrisisDocument}>
                                 <GoSingleFileInput


### PR DESCRIPTION
## Addresses:

- https://github.com/toggle-corp/ifrc-go-meta/issues/501

## Changes
- Hide field 'If available please upload crisis categorization analysis'
- The field appears if options 'Orange' or 'Red' are selected.

## This PR doesn't introduce:
- [x] typos
- [x] conflict markers
- [x] unwanted comments
- [x] temporary files, auto-generated files or secret keys
- [x] `console.log` meant for debugging
- [x] codegen errors
