### PR TITLE
Center PPP Dashboard and fix missing char in URL

### DIFF
--- a/src/views/GlobalThreeW/index.tsx
+++ b/src/views/GlobalThreeW/index.tsx
@@ -300,7 +300,7 @@ export function Component() {
                         <iframe
                             title={strings.PPPMapTitle}
                             className={styles.pppIframe}
-                            src="https://public.tableau.com/views/PPPdashboard_16805965348010/1_Overview?:showVizHome=no&:embed=true:language=en-US&:origin=viz_share_link&:display_count=yes&:toolbar=yes"
+                            src="https://public.tableau.com/views/PPPdashboard_16805965348010/1_Overview?:showVizHome=no&:embed=true&:language=en-US&:origin=viz_share_link&:display_count=no&:toolbar=yes"
                         />
                     </Container>
                 </>

--- a/src/views/GlobalThreeW/styles.module.css
+++ b/src/views/GlobalThreeW/styles.module.css
@@ -39,12 +39,14 @@
         }
 
         .iframe-content {
-            padding-right: 12%;
-            padding-left: 12%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+
             .ppp-iframe {
                 border: none;
-                width: 100%;
-                height: 54rem;
+                width: 1050px;
+                height: 850px;
             }
         }
     }

--- a/src/views/GlobalThreeW/styles.module.css
+++ b/src/views/GlobalThreeW/styles.module.css
@@ -39,6 +39,8 @@
         }
 
         .iframe-content {
+            padding-right: 12%;
+            padding-left: 12%;
             .ppp-iframe {
                 border: none;
                 width: 100%;


### PR DESCRIPTION
## Addresses:
https://github.com/IFRCGo/go-web-app/issues/429

I couldn't **center PPP dashboard** via
contentViewType="vertical" in Container and in css, inside ppp-iframe align-self: center.
If you have nicer solution, let's see.
@frozenhelium @samshara 