### PR TITLE
Fix/dref event date export

### DIFF
--- a/src/views/DrefApplicationExport/index.tsx
+++ b/src/views/DrefApplicationExport/index.tsx
@@ -497,7 +497,7 @@ export function Component() {
                             />
                         </Container>
                     )}
-                    {isDefined(drefResponse?.end_date) && (
+                    {isDefined(drefResponse?.event_date) && (
                         <Container
                             heading={drefResponse?.type_of_dref !== DREF_TYPE_IMMINENT
                                 && strings.dateWhenTheTriggerWasMetHeading}

--- a/src/views/DrefApplicationForm/EventDetail/index.tsx
+++ b/src/views/DrefApplicationForm/EventDetail/index.tsx
@@ -28,7 +28,6 @@ import {
     TYPE_ASSESSMENT,
     TYPE_IMMINENT,
     TYPE_LOAN,
-    TYPE_RESPONSE,
 } from '../common';
 import { type PartialDref } from '../schema';
 

--- a/src/views/DrefApplicationForm/EventDetail/index.tsx
+++ b/src/views/DrefApplicationForm/EventDetail/index.tsx
@@ -253,7 +253,7 @@ function EventDetail(props: Props) {
             <Container
                 heading={strings.drefFormDescriptionEvent}
             >
-                {value.type_of_dref === TYPE_IMMINENT || value.type_of_dref === TYPE_RESPONSE ? (
+                {value.type_of_dref === TYPE_IMMINENT ? (
                     <InputSection
                         title={strings.drefFormApproximateDateOfImpact}
                     >

--- a/src/views/DrefApplicationForm/common.tsx
+++ b/src/views/DrefApplicationForm/common.tsx
@@ -16,7 +16,7 @@ export const ONSET_SUDDEN = 2 satisfies TypeOfOnsetEnum;
 
 export const TYPE_IMMINENT = 0 satisfies TypeOfDrefEnum;
 export const TYPE_ASSESSMENT = 1 satisfies TypeOfDrefEnum;
-export const TYPE_RESPONSE = 2 satisfies TypeOfDrefEnum;
+// export const TYPE_RESPONSE = 2 satisfies TypeOfDrefEnum;
 export const TYPE_LOAN = 3 satisfies TypeOfDrefEnum;
 
 // FIXME: identify a way to store disaster


### PR DESCRIPTION
Show `event_date` on export for `response` type `DREF`

## This PR doesn't introduce:
- [x] typos
- [x] conflict markers
- [x] unwanted comments
- [x] temporary files, auto-generated files or secret keys
- [x] `console.log` meant for debugging
- [x] codegen errors
