### PR TITLE
Add button at end to collapse the component without scrolling up

### DIFF
--- a/src/components/ExpandableContainer/index.tsx
+++ b/src/components/ExpandableContainer/index.tsx
@@ -86,6 +86,22 @@ function ExpandableContainer(props: Props) {
                 </>
             )}
             actionsContainerClassName={styles.actionsContainer}
+            footerActions={expanded && (
+                <Button
+                    variant="tertiary"
+                    name={undefined}
+                    onClick={toggleExpanded}
+                    title={expanded
+                        ? strings.expandableContainerCollapse
+                        : strings.expandableContainerExpand}
+                >
+                    {expanded ? (
+                        <ChevronUpLineIcon className={styles.icon} />
+                    ) : (
+                        <ChevronDownLineIcon className={styles.icon} />
+                    )}
+                </Button>
+            )}
         >
             {expanded && children}
         </Container>

--- a/src/components/ExpandableContainer/index.tsx
+++ b/src/components/ExpandableContainer/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef, useCallback } from 'react';
 import { _cs } from '@togglecorp/fujs';
 import { ChevronDownLineIcon, ChevronUpLineIcon } from '@ifrc-go/icons';
 
@@ -13,6 +13,7 @@ import styles from './styles.module.css';
 export interface Props extends Omit<ContainerProps, 'withInternalPadding' | 'withoutWrapInHeading'> {
     initiallyExpanded?: boolean;
     onExpansionChange?: (isExpanded: boolean) => void;
+    showExpandButtonAtBottom?: boolean;
     componentRef?: React.MutableRefObject<{
         setIsExpanded: React.Dispatch<React.SetStateAction<boolean>>;
     } | null>;
@@ -29,9 +30,11 @@ function ExpandableContainer(props: Props) {
         childrenContainerClassName,
         onExpansionChange,
         withHeaderBorder,
+        showExpandButtonAtBottom,
         ...otherProps
     } = props;
 
+    const containerRef = useRef<HTMLDivElement>(null);
     const strings = useTranslation(i18n);
 
     const [
@@ -56,10 +59,17 @@ function ExpandableContainer(props: Props) {
         }
     }, [componentRef, setExpanded]);
 
+    const handleExpansionToggle = useCallback(() => {
+        toggleExpanded();
+        if (containerRef) {
+            containerRef.current?.scrollIntoView();
+        }
+    }, [toggleExpanded]);
     return (
         <Container
             // eslint-disable-next-line react/jsx-props-no-spreading
             {...otherProps}
+            containerRef={containerRef}
             className={_cs(styles.expandableContainer, className)}
             headerClassName={_cs(styles.header, headerClassName)}
             childrenContainerClassName={_cs(styles.content, childrenContainerClassName)}
@@ -86,11 +96,11 @@ function ExpandableContainer(props: Props) {
                 </>
             )}
             actionsContainerClassName={styles.actionsContainer}
-            footerActions={expanded && (
+            footerActions={showExpandButtonAtBottom && expanded && (
                 <Button
                     variant="tertiary"
                     name={undefined}
-                    onClick={toggleExpanded}
+                    onClick={handleExpansionToggle}
                     title={expanded
                         ? strings.expandableContainerCollapse
                         : strings.expandableContainerExpand}

--- a/src/views/PerAssessmentForm/AreaInput/ComponentInput/index.tsx
+++ b/src/views/PerAssessmentForm/AreaInput/ComponentInput/index.tsx
@@ -146,6 +146,7 @@ function ComponentInput(props: Props) {
                     labelSelector={ratingLabelSelector}
                 />
             )}
+            showExpandButtonAtBottom
             initiallyExpanded
         >
             <NonFieldError error={error} />

--- a/src/views/PerAssessmentForm/index.tsx
+++ b/src/views/PerAssessmentForm/index.tsx
@@ -235,7 +235,7 @@ export function Component() {
             if (isNotDefined(assessmentId) || isNotDefined(perId)) {
                 // TODO: show proper error message to user
                 // eslint-disable-next-line no-console
-                console.error('assesment id not defined');
+                console.error('assessment id not defined');
                 return;
             }
             formContentRef.current?.scrollIntoView();


### PR DESCRIPTION
## Addresses:
- https://github.com/IFRCGo/go-web-app/issues/452

## Changes
- Add button at footer to collapse the component.
- Display the button only when component is expanded.

## This PR doesn't introduce:
- [X] typos
- [X] conflict markers
- [X] unwanted comments
- [X] temporary files, auto-generated files or secret keys
- [X] `console.log` meant for debugging
- [X] codegen errors
