### PR TITLE
Change start date from immediately to closed date of closed alert in surge

### DIFF
--- a/src/views/AllSurgeAlerts/i18n.json
+++ b/src/views/AllSurgeAlerts/i18n.json
@@ -17,6 +17,7 @@
         "surgeAlertStatus": "Status",
         "surgeAlertOpen": "Open",
         "surgeAlertClosed": "Closed",
-        "surgeAlertStoodDown": "Stood down"
+        "surgeAlertStoodDown": "Stood down",
+        "surgeAlertImmediately": "Immediately"
     }
 }

--- a/src/views/AllSurgeAlerts/i18n.json
+++ b/src/views/AllSurgeAlerts/i18n.json
@@ -17,7 +17,6 @@
         "surgeAlertStatus": "Status",
         "surgeAlertOpen": "Open",
         "surgeAlertClosed": "Closed",
-        "surgeAlertStoodDown": "Stood down",
-        "surgeAlertImmediately": "Immediately"
+        "surgeAlertStoodDown": "Stood down"
     }
 }

--- a/src/views/AllSurgeAlerts/index.tsx
+++ b/src/views/AllSurgeAlerts/index.tsx
@@ -188,7 +188,7 @@ export function Component() {
                     return duration;
                 },
             ),
-            createStringColumn<SurgeListItem, TableKey>(
+            createDateColumn<SurgeListItem, TableKey>(
                 'start',
                 strings.surgeAlertStartDate,
                 (item) => {
@@ -200,7 +200,7 @@ export function Component() {
                     const nowMs = new Date().getTime();
 
                     const duration = startDate.getTime() < nowMs
-                        ? strings.surgeAlertImmediately
+                        ? item.closes
                         : startDate.toLocaleString();
 
                     return duration;
@@ -243,7 +243,6 @@ export function Component() {
             ),
         ]),
         [
-            strings.surgeAlertImmediately,
             strings.surgeAlertDate,
             strings.surgeAlertDuration,
             strings.surgeAlertStartDate,

--- a/src/views/AllSurgeAlerts/index.tsx
+++ b/src/views/AllSurgeAlerts/index.tsx
@@ -192,18 +192,25 @@ export function Component() {
                 'start',
                 strings.surgeAlertStartDate,
                 (item) => {
-                    if (isNotDefined(item.start)) {
-                        return undefined;
-                    }
-
-                    const startDate = new Date(item.start);
+                    const startDate = isDefined(item.start) ? new Date(item.start) : undefined;
+                    const endDate = isDefined(item.end) ? new Date(item.end) : undefined;
                     const nowMs = new Date().getTime();
 
-                    const duration = startDate.getTime() < nowMs
-                        ? item.closes
-                        : startDate.toLocaleString();
+                    const closed = isDefined(item.end)
+                        ? new Date(item.end).getTime() < today : undefined;
 
-                    return duration;
+                    if (isDefined(endDate) && closed) {
+                        return endDate.toLocaleString();
+                    }
+
+                    if (isDefined(startDate)) {
+                        const dateStarted = startDate.getTime() < nowMs
+                            ? strings.surgeAlertImmediately
+                            : startDate.toLocaleString();
+
+                        return dateStarted;
+                    }
+                    return undefined;
                 },
             ),
             createStringColumn<SurgeListItem, TableKey>(

--- a/src/views/EmergencySurge/SurgeTable/index.tsx
+++ b/src/views/EmergencySurge/SurgeTable/index.tsx
@@ -65,6 +65,7 @@ export default function SurgeTable(props: Props) {
         preserveResponse: true,
         query: {
             event: Number(emergencyId),
+            is_active: true,
             limit,
             offset,
 
@@ -122,18 +123,25 @@ export default function SurgeTable(props: Props) {
                 'start',
                 strings.surgeAlertStartDate,
                 (item) => {
-                    if (isNotDefined(item.start)) {
-                        return undefined;
-                    }
-
-                    const startDate = new Date(item.start);
+                    const startDate = isDefined(item.start) ? new Date(item.start) : undefined;
+                    const endDate = isDefined(item.end) ? new Date(item.end) : undefined;
                     const nowMs = new Date().getTime();
 
-                    const start = startDate.getTime() < nowMs
-                        ? strings.emergencySurgeImmediately
-                        : startDate.toLocaleString();
+                    const closed = isDefined(item.end)
+                        ? new Date(item.end).getTime() < today : undefined;
 
-                    return start;
+                    if (isDefined(endDate) && closed) {
+                        return endDate.toLocaleString();
+                    }
+
+                    if (isDefined(startDate)) {
+                        const dateStarted = startDate.getTime() < nowMs
+                            ? strings.emergencySurgeImmediately
+                            : startDate.toLocaleString();
+
+                        return dateStarted;
+                    }
+                    return undefined;
                 },
             ),
             createStringColumn<SurgeListItem, number>(


### PR DESCRIPTION
## Addresses:
- https://github.com/IFRCGo/go-web-app/issues/512

## Changes
- When Alerts are "Closed" , changed the start date from "Immediately" to the day the alert was closed 

## This PR doesn't introduce:
- [x] typos
- [x] conflict markers
- [x] unwanted comments
- [x] temporary files, auto-generated files or secret keys
- [x] `console.log` meant for debugging
- [x] codegen errors
