### PR TITLE
Remove filter that only shows Alerts for less than 30 days ago

### DIFF
--- a/src/views/SurgeOverview/SurgeAlertsTable/index.tsx
+++ b/src/views/SurgeOverview/SurgeAlertsTable/index.tsx
@@ -73,7 +73,6 @@ function SurgeAlertsTable() {
         query: {
             limit,
             offset,
-            created_at__gte: aMonthAgo.toISOString(),
             ordering,
 
             // NOTE: following filters are required


### PR DESCRIPTION
## Addresses:
-  https://github.com/IFRCGo/go-web-app/issues/513

## Changes
- Remove filter that only shows Alerts that have been created less than 30 days ago in Surge Global Overview page

## This PR doesn't introduce:
- [x] typos
- [x] conflict markers
- [x] unwanted comments
- [x] temporary files, auto-generated files or secret keys
- [x] `console.log` meant for debugging
- [x] codegen errors
