### PR TITLE
fix: remove duplicate `is_active` in surge alert query

### DIFF
--- a/src/views/AllSurgeAlerts/index.tsx
+++ b/src/views/AllSurgeAlerts/index.tsx
@@ -197,7 +197,7 @@ export function Component() {
                     const nowMs = new Date().getTime();
 
                     const closed = isDefined(item.end)
-                        ? new Date(item.end).getTime() < today : undefined;
+                        ? new Date(item.end).getTime() < nowMs : undefined;
 
                     if (isDefined(endDate) && closed) {
                         return endDate.toLocaleString();
@@ -250,6 +250,7 @@ export function Component() {
             ),
         ]),
         [
+            strings.surgeAlertImmediately,
             strings.surgeAlertDate,
             strings.surgeAlertDuration,
             strings.surgeAlertStartDate,

--- a/src/views/EmergencySurge/SurgeTable/index.tsx
+++ b/src/views/EmergencySurge/SurgeTable/index.tsx
@@ -65,7 +65,6 @@ export default function SurgeTable(props: Props) {
         preserveResponse: true,
         query: {
             event: Number(emergencyId),
-            is_active: true,
             limit,
             offset,
 


### PR DESCRIPTION
## This PR doesn't introduce:
- [x] typos
- [x] conflict markers
- [x] unwanted comments
- [x] temporary files, auto-generated files or secret keys
- [x] `console.log` meant for debugging
- [x] codegen errors
