### PR TITLE
Show `start` date when alert is closed in surge table

### DIFF
--- a/src/views/AllSurgeAlerts/index.tsx
+++ b/src/views/AllSurgeAlerts/index.tsx
@@ -193,16 +193,14 @@ export function Component() {
                 strings.surgeAlertStartDate,
                 (item) => {
                     const startDate = isDefined(item.start) ? new Date(item.start) : undefined;
-                    const endDate = isDefined(item.end) ? new Date(item.end) : undefined;
-
                     const closed = isDefined(item.end)
                         ? new Date(item.end).getTime() < nowTimestamp : undefined;
 
-                    if (isDefined(endDate) && closed) {
-                        return endDate.toLocaleString();
-                    }
-
                     if (isDefined(startDate)) {
+                        if (closed) {
+                            return startDate.toLocaleString();
+                        }
+
                         const dateStarted = startDate.getTime() < nowTimestamp
                             ? strings.surgeAlertImmediately
                             : startDate.toLocaleString();

--- a/src/views/EmergencySurge/SurgeTable/index.tsx
+++ b/src/views/EmergencySurge/SurgeTable/index.tsx
@@ -123,16 +123,15 @@ export default function SurgeTable(props: Props) {
                 strings.surgeAlertStartDate,
                 (item) => {
                     const startDate = isDefined(item.start) ? new Date(item.start) : undefined;
-                    const endDate = isDefined(item.end) ? new Date(item.end) : undefined;
 
                     const closed = isDefined(item.end)
                         ? new Date(item.end).getTime() < nowTimestamp : undefined;
 
-                    if (isDefined(endDate) && closed) {
-                        return endDate.toLocaleString();
-                    }
-
                     if (isDefined(startDate)) {
+                        if (closed) {
+                            return startDate.toLocaleString();
+                        }
+
                         const dateStarted = startDate.getTime() < nowTimestamp
                             ? strings.emergencySurgeImmediately
                             : startDate.toLocaleString();

--- a/src/views/SurgeOverview/SurgeAlertsTable/index.tsx
+++ b/src/views/SurgeOverview/SurgeAlertsTable/index.tsx
@@ -119,16 +119,14 @@ function SurgeAlertsTable() {
             (surgeAlert) => {
                 const startDate = isDefined(surgeAlert.start)
                     ? new Date(surgeAlert.start) : undefined;
-                const endDate = isDefined(surgeAlert.end) ? new Date(surgeAlert.end) : undefined;
-
                 const closed = isDefined(surgeAlert.end)
                     ? new Date(surgeAlert.end).getTime() < todayTimestamp : undefined;
 
-                if (isDefined(endDate) && closed) {
-                    return endDate.toLocaleString();
-                }
-
                 if (isDefined(startDate)) {
+                    if (closed) {
+                        return startDate.toLocaleString();
+                    }
+
                     const dateStarted = startDate.getTime() < todayTimestamp
                         ? strings.surgeAlertImmediately
                         : startDate.toLocaleString();


### PR DESCRIPTION
## Addresses:
- https://github.com/IFRCGo/go-web-app/issues/555

## This PR doesn't introduce:
- [x] typos
- [x] conflict markers
- [x] unwanted comments
- [x] temporary files, auto-generated files or secret keys
- [x] `console.log` meant for debugging
- [x] codegen errors
