### PR TITLE
Surge alert tables styling for start date

### DIFF
--- a/src/views/AllSurgeAlerts/index.tsx
+++ b/src/views/AllSurgeAlerts/index.tsx
@@ -28,6 +28,7 @@ import useUrlSearchState from '#hooks/useUrlSearchState';
 import { SURGE_ALERT_STATUS_CLOSED } from '#utils/constants';
 
 import i18n from './i18n.json';
+import styles from './styles.module.css';
 
 type SurgeResponse = GoApiResponse<'/api/v2/surge_alert/'>;
 type SurgeListItem = NonNullable<SurgeResponse['results']>[number];
@@ -196,6 +197,7 @@ export function Component() {
                     }
                     return undefined;
                 },
+                { cellRendererClassName: styles.startColumn },
             ),
             createStringColumn<SurgeListItem, TableKey>(
                 'name',

--- a/src/views/AllSurgeAlerts/styles.module.css
+++ b/src/views/AllSurgeAlerts/styles.module.css
@@ -1,0 +1,3 @@
+.start-column {
+    min-width: 7rem;
+}

--- a/src/views/EmergencySurge/SurgeTable/index.tsx
+++ b/src/views/EmergencySurge/SurgeTable/index.tsx
@@ -18,6 +18,7 @@ import { numericIdSelector } from '#utils/selectors';
 import useFilterState from '#hooks/useFilterState';
 import { SURGE_ALERT_STATUS_CLOSED } from '#utils/constants';
 
+import styles from './styles.module.css';
 import i18n from './i18n.json';
 
 type SurgeResponse = GoApiResponse<'/api/v2/surge_alert/'>;
@@ -123,6 +124,7 @@ export default function SurgeTable(props: Props) {
                     }
                     return undefined;
                 },
+                { cellRendererClassName: styles.startColumn },
             ),
             createStringColumn<SurgeListItem, number>(
                 'name',

--- a/src/views/EmergencySurge/SurgeTable/styles.module.css
+++ b/src/views/EmergencySurge/SurgeTable/styles.module.css
@@ -1,0 +1,3 @@
+.start-column {
+    min-width: 7rem;
+}

--- a/src/views/SurgeOverview/SurgeAlertsTable/index.tsx
+++ b/src/views/SurgeOverview/SurgeAlertsTable/index.tsx
@@ -120,6 +120,7 @@ function SurgeAlertsTable() {
                 }
                 return undefined;
             },
+            { cellRendererClassName: styles.startColumn },
         ),
         createStringColumn<SurgeAlertListItem, number>(
             'name',

--- a/src/views/SurgeOverview/SurgeAlertsTable/styles.module.css
+++ b/src/views/SurgeOverview/SurgeAlertsTable/styles.module.css
@@ -2,4 +2,8 @@
     display: flex;
     flex-direction: column;
     gap: var(--go-ui-spacing-lg);
+
+    .start-column {
+        min-width: 7rem;
+    }
 }


### PR DESCRIPTION
## This PR doesn't introduce:
- [x] typos
- [x] conflict markers
- [x] unwanted comments
- [x] temporary files, auto-generated files or secret keys
- [x] `console.log` meant for debugging
- [x] codegen errors
