### PR TITLE
Add  input label story

### DIFF
--- a/packages/go-ui-storybook/src/stories/InputLabel.stories.ts
+++ b/packages/go-ui-storybook/src/stories/InputLabel.stories.ts
@@ -1,0 +1,43 @@
+import type {
+    Meta,
+    StoryObj,
+} from '@storybook/react';
+
+import InputLabel from './InputLabel';
+
+const meta = {
+    title: 'Components/InputLabel',
+    component: InputLabel,
+    parameters: {
+        layout: 'centered',
+        design: {
+            type: 'figma',
+            url: 'https://www.figma.com/file/myeW85ibN5p2SlnXcEpxFD/IFRC-GO---UI-Current---1?type=design&node-id=0-4957&mode=design&t=KwxbuoUQxqcLyZbG-0',
+        },
+    },
+    tags: ['autodocs'],
+    argTypes: {},
+} satisfies Meta<typeof InputLabel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    args: {
+        children: 'This is a   Default Input-label',
+    },
+};
+
+export const Disabled :Story = {
+    args: {
+        children: 'This is a disabled label',
+        disabled: true,
+    },
+};
+
+export const Required : Story = {
+    args: {
+        children: 'This is a required label',
+        required: true,
+    },
+};

--- a/packages/go-ui-storybook/src/stories/InputLabel.tsx
+++ b/packages/go-ui-storybook/src/stories/InputLabel.tsx
@@ -1,0 +1,14 @@
+import {
+    InputLabel as PureInputLabel,
+    InputLabelProps as PureInputLabelProps,
+} from '@ifrc-go/ui';
+
+interface InputLabelProps extends PureInputLabelProps {}
+
+function WrappedInputLabel(props: InputLabelProps) {
+    return (
+        <PureInputLabel {...props} /> // eslint-disable-line react/jsx-props-no-spreading
+    );
+}
+
+export default WrappedInputLabel;


### PR DESCRIPTION
## Addresses:
- https://github.com/IFRCGo/go-web-app/issues/599#event-11824599058

## Changes
- Add Inputlabel story for inputlabel component

## This PR doesn't introduce:
- [x] typos
- [x] conflict markers
- [x] unwanted comments
- [x] temporary files, auto-generated files or secret keys
- [x] `console.log` meant for debugging
- [x] codegen errors
