### PR TITLE
Add Disaster start date in emergency table column

### DIFF
--- a/src/views/AllEmergencies/index.tsx
+++ b/src/views/AllEmergencies/index.tsx
@@ -80,9 +80,9 @@ export function Component() {
     const columns = useMemo(
         () => ([
             createDateColumn<EventListItem, number>(
-                'created_at',
+                'disaster_start_date',
                 strings.allEmergenciesDate,
-                (item) => item.created_at,
+                (item) => item.disaster_start_date,
                 {
                     sortable: true,
                     columnClassName: styles.createdAt,


### PR DESCRIPTION
## Addresses:
- https://github.com/IFRCGo/go-web-app/issues/658

## Changes
- Add disaster start date in emergency column

## This PR doesn't introduce:
- [x] typos
- [x] conflict markers
- [x] unwanted comments
- [x] temporary files, auto-generated files or secret keys
- [x] `console.log` meant for debugging
- [x] codegen errors
