### PR TITLE
Add Breadcrumbs story

### DIFF
--- a/packages/go-ui-storybook/src/stories/Breadcrumbs.stories.tsx
+++ b/packages/go-ui-storybook/src/stories/Breadcrumbs.stories.tsx
@@ -1,0 +1,30 @@
+import type {
+    Meta,
+    StoryObj,
+} from '@storybook/react';
+
+import Breadcrumbs from './Breadcrumbs';
+
+type Story = StoryObj<typeof Breadcrumbs>;
+
+const meta: Meta<typeof Breadcrumbs> = {
+    title: 'Components/Breadcrumbs',
+    component: Breadcrumbs,
+    parameters: {
+        layout: 'centered',
+        design: {
+            type: 'figma',
+            url: 'https://www.figma.com/file/myeW85ibN5p2SlnXcEpxFD/IFRC-GO---UI-Current---1?type=design&node-id=0-4957&mode=design&t=KwxbuoUQxqcLyZbG-0',
+            allowFullscreen: true,
+        },
+    },
+    tags: ['autodocs'],
+};
+
+export default meta;
+
+export const Default: Story = {
+    args: {
+        children: ['Home', 'Africa', 'Angola'],
+    },
+};

--- a/packages/go-ui-storybook/src/stories/Breadcrumbs.tsx
+++ b/packages/go-ui-storybook/src/stories/Breadcrumbs.tsx
@@ -1,0 +1,14 @@
+import {
+    Breadcrumbs as PureBreadcrumbs,
+    BreadcrumbsProps as PureBreadcrumbsProps,
+} from '@ifrc-go/ui';
+
+interface BreadcrumbsProps extends PureBreadcrumbsProps {}
+
+function WrappedBreadcrumbs(props: BreadcrumbsProps) {
+    return (
+        <PureBreadcrumbs {...props} /> // eslint-disable-line react/jsx-props-no-spreading
+    );
+}
+
+export default WrappedBreadcrumbs;

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -30,6 +30,7 @@ export { default as BooleanInput } from './components/BooleanInput';
 export type { Props as BooleanOutputProps } from './components/BooleanOutput';
 export { default as BooleanOutput } from './components/BooleanOutput';
 export { default as Breadcrumbs } from './components/Breadcrumbs';
+export type { BreadcrumbsProps } from './components/Breadcrumbs';
 export { default as ChartAxes } from './components/ChartAxes';
 export { default as ChartAxisX } from './components/ChartAxisX';
 export { default as ChartAxisY } from './components/ChartAxisY';


### PR DESCRIPTION
## Addresses:
-  https://github.com/IFRCGo/go-web-app/issues/677

## Changes
- Add Breadcrumbs story for Breadcrumbs component

## This PR doesn't introduce:
- [x] typos
- [x] conflict markers
- [x] unwanted comments
- [x] temporary files, auto-generated files or secret keys
- [x] `console.log` meant for debugging
- [x] codegen errors
