### PR TITLE
Add PasswordInput story 

### DIFF
--- a/packages/go-ui-storybook/src/stories/PasswordInput.stories.tsx
+++ b/packages/go-ui-storybook/src/stories/PasswordInput.stories.tsx
@@ -1,0 +1,87 @@
+import { useArgs } from '@storybook/preview-api';
+import type {
+    Meta,
+    StoryObj,
+} from '@storybook/react';
+
+import PasswordInput from './PasswordInput';
+
+type Story =StoryObj<typeof PasswordInput>;
+
+const meta: Meta<typeof PasswordInput> = {
+    title: 'Components/PasswordInput',
+    component: PasswordInput,
+    parameters: {
+        layout: 'centered',
+        design: {
+            type: 'figma',
+            url: ' https://www.figma.com/file/myeW85ibN5p2SlnXcEpxFD/IFRC-GO---UI-Current---1?type=design&node-id=0-4957&mode=design&t=KwxbuoUQxqcLyZbG-0',
+        },
+    },
+    tags: ['autodocs'],
+    decorators: [
+        function Component(_, ctx) {
+            const [
+                { value },
+                setArgs,
+            ] = useArgs<{ value: string }>();
+            const onChange = (val:string | undefined, name: string) => {
+                setArgs({ value: val });
+                ctx.args.onChange(val, name);
+            };
+
+            return (
+                <PasswordInput
+                // eslint-disable-next-line react/jsx-props-no-spreading
+                    {...ctx.args}
+                    onChange={onChange}
+                    value={value}
+                    name="PasswordInput"
+                />
+            );
+        },
+    ],
+};
+
+export default meta;
+
+export const Default: Story = {
+    args: {
+        label: 'Password',
+    },
+};
+export const Disabled: Story = {
+    args: {
+        label: 'Password',
+        value: 'password',
+        disabled: true,
+    },
+};
+
+export const ReadOnly: Story = {
+    args: {
+        label: 'Password',
+        value: 'password',
+        readOnly: true,
+    },
+};
+
+export const WithPlaceholder: Story = {
+    args: {
+        label: 'Password',
+        placeholder: 'Enter your password',
+    },
+};
+
+export const WithError: Story = {
+    args: {
+        label: 'Password',
+        error: <p>This field is required</p>,
+    },
+};
+export const WithAsterisk: Story = {
+    args: {
+        label: 'Password',
+        withAsterisk: true,
+    },
+};

--- a/packages/go-ui-storybook/src/stories/PasswordInput.tsx
+++ b/packages/go-ui-storybook/src/stories/PasswordInput.tsx
@@ -1,0 +1,14 @@
+import {
+    PasswordInput as PurePasswordInput,
+    PasswordInputProps as PurePasswordInputProps,
+} from '@ifrc-go/ui';
+
+interface PasswordInputProps<T> extends PurePasswordInputProps<T> {}
+
+function WrappedPasswordInput<const T>(props: PasswordInputProps<T>) {
+    return (
+        <PurePasswordInput {...props} />// eslint-disable-line react/jsx-props-no-spreading
+    );
+}
+
+export default WrappedPasswordInput;


### PR DESCRIPTION
## Addresses:
-  https://github.com/IFRCGo/go-web-app/issues/695

## Changes
- Add PasswordInput story for PasswordInput component

## This PR doesn't introduce:
- [x] typos
- [x] conflict markers
- [x] unwanted comments
- [x] temporary files, auto-generated files or secret keys
- [x] `console.log` meant for debugging
- [x] codegen errors
