### PR TITLE
Value error on tool-tip over national society income chart

### DIFF
--- a/app/src/views/CountryNsOverviewContextAndStructure/NationalSocietyIncomeOverTime/index.tsx
+++ b/app/src/views/CountryNsOverviewContextAndStructure/NationalSocietyIncomeOverTime/index.tsx
@@ -103,7 +103,7 @@ function NationalSocietyIncomeOverTime(props: Props) {
                 description={(
                     <TextOutput
                         label={strings.nsIncomeOverTimeTooltipTotalLabel}
-                        value={incomeByYear?.[Number(year)].value}
+                        value={incomeByYear?.[Number(year)]?.value}
                         suffix=" CHF"
                         valueType="number"
                         strongValue


### PR DESCRIPTION
## This PR doesn't introduce:
- [x] typos
- [x] conflict markers
- [x] unwanted comments
- [x] temporary files, auto-generated files or secret keys
- [x] `console.log` meant for debugging
- [x] codegen errors
