### PR TITLE
Add string translation

### DIFF
--- a/app/src/views/CountryNsOverviewCapacity/index.tsx
+++ b/app/src/views/CountryNsOverviewCapacity/index.tsx
@@ -62,6 +62,7 @@ export function Component() {
                 </Link>
             )}
         >
+            {/* Data is currently under review, it will be include in the next version */}
             {countryResponse?.region === REGION_ASIA && (
                 <CountryNsOrganisationalCapacity />
             )}

--- a/app/src/views/CountryProfileOverview/ClimateChart/i18n.json
+++ b/app/src/views/CountryProfileOverview/ClimateChart/i18n.json
@@ -1,0 +1,11 @@
+{
+    "namespace": "countryClimateChart",
+    "strings": {
+        "climateChartMax": "Max",
+        "climateChangeAverage": "Average",
+        "climateChangeMin": "Min",
+        "climateChangePrecipitation": "Precipation totals (mm)",
+        "climateChangeChart": "Climate chart (Avg. country values)",
+        "climateChartTemperature": "Average min and max temperature (°C)"
+    }
+}

--- a/app/src/views/CountryProfileOverview/ClimateChart/index.tsx
+++ b/app/src/views/CountryProfileOverview/ClimateChart/index.tsx
@@ -9,6 +9,7 @@ import {
     TextOutput,
     Tooltip,
 } from '@ifrc-go/ui';
+import { useTranslation } from '@ifrc-go/ui/hooks';
 import {
     maxSafe,
     minSafe,
@@ -22,6 +23,7 @@ import {
 import useTemporalChartData from '#hooks/useTemporalChartData';
 import { GoApiResponse } from '#utils/restRequest';
 
+import i18n from './i18n.json';
 import styles from './styles.module.css';
 
 const NUM_Y_AXIS_TICKS = 5;
@@ -34,6 +36,8 @@ function ClimateChart(props: Props) {
     const {
         data,
     } = props;
+
+    const strings = useTranslation(i18n);
 
     const temperatureContainerRef = useRef<HTMLDivElement>(null);
     const precipitationContainerRef = useRef<HTMLDivElement>(null);
@@ -127,20 +131,17 @@ function ClimateChart(props: Props) {
                     description={(
                         <>
                             <TextOutput
-                                // FIXME: use translation
-                                label="Max"
+                                label={strings.climateChartMax}
                                 value={currentData.max_temp}
                                 valueType="number"
                             />
                             <TextOutput
-                                // FIXME: use translation
-                                label="Average"
+                                label={strings.climateChangeAverage}
                                 value={currentData.avg_temp}
                                 valueType="number"
                             />
                             <TextOutput
-                                // FIXME: use translation
-                                label="Min"
+                                label={strings.climateChangeMin}
                                 value={currentData.min_temp}
                                 valueType="number"
                             />
@@ -149,7 +150,12 @@ function ClimateChart(props: Props) {
                 />
             );
         },
-        [dataByMonth],
+        [
+            dataByMonth,
+            strings.climateChartMax,
+            strings.climateChangeAverage,
+            strings.climateChangeMin,
+        ],
     );
 
     const precipitationTooltipSelector = useCallback(
@@ -170,8 +176,7 @@ function ClimateChart(props: Props) {
                     title={currentData.month_display}
                     description={(
                         <TextOutput
-                            // FIXME: use translation
-                            label="Precipitation"
+                            label={strings.climateChangePrecipitation}
                             value={currentData.precipitation}
                             valueType="number"
                         />
@@ -179,7 +184,7 @@ function ClimateChart(props: Props) {
                 />
             );
         },
-        [dataByMonth],
+        [dataByMonth, strings.climateChangePrecipitation],
     );
 
     const barWidth = bound(
@@ -191,14 +196,12 @@ function ClimateChart(props: Props) {
     return (
         <Container
             className={styles.climateChart}
-            // FIXME: use translation
-            heading="Climate chart"
+            heading={strings.climateChangeChart}
             contentViewType="vertical"
             withHeaderBorder
         >
             <Container
-                // FIXME: use translation
-                heading="Temperature"
+                heading={strings.climateChartTemperature}
                 headingLevel={5}
             >
                 <div
@@ -233,8 +236,7 @@ function ClimateChart(props: Props) {
                 </div>
             </Container>
             <Container
-                // FIXME: use translation
-                heading="Precipitation"
+                heading={strings.climateChangePrecipitation}
                 headingLevel={5}
             >
                 <div
@@ -257,8 +259,8 @@ function ClimateChart(props: Props) {
                                     height={(
                                         Math.max(
                                             precipitationChartData.dataAreaSize.height
-                                                - chartPoint.y
-                                                + precipitationChartData.dataAreaOffset.top,
+                                            - chartPoint.y
+                                            + precipitationChartData.dataAreaOffset.top,
                                             0,
                                         )
                                     )}

--- a/app/src/views/CountryProfileOverview/PopulationMap/i18n.json
+++ b/app/src/views/CountryProfileOverview/PopulationMap/i18n.json
@@ -1,0 +1,6 @@
+{
+    "namespace": "populationMap",
+    "strings": {
+        "populationMapTitle": "Population Map"
+    }
+}

--- a/app/src/views/CountryProfileOverview/PopulationMap/index.tsx
+++ b/app/src/views/CountryProfileOverview/PopulationMap/index.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { Container } from '@ifrc-go/ui';
+import { useTranslation } from '@ifrc-go/ui/hooks';
 import { maxSafe } from '@ifrc-go/ui/utils';
 import {
     isDefined,
@@ -30,6 +31,7 @@ import {
 } from '#utils/constants';
 import { GoApiResponse } from '#utils/restRequest';
 
+import i18n from './i18n.json';
 import styles from './styles.module.css';
 
 const DEFAULT_MAX_POPULATION = 1000000;
@@ -40,6 +42,8 @@ interface Props {
 
 function PopulatioMap(props: Props) {
     const { data } = props;
+    const strings = useTranslation(i18n);
+
     const countryData = useCountry({ id: data?.id ?? -1 });
 
     const bounds = (isDefined(countryData) && isDefined(countryData.bbox))
@@ -209,8 +213,7 @@ function PopulatioMap(props: Props) {
 
     return (
         <Container
-            // FIXME: use translation
-            heading="Population Map"
+            heading={strings.populationMapTitle}
             className={styles.populationMap}
             withHeaderBorder
         >

--- a/app/src/views/CountryProfileOverview/i18n.json
+++ b/app/src/views/CountryProfileOverview/i18n.json
@@ -19,6 +19,7 @@
         "seasonalCalendarTooltipEventLabel": "Event",
         "seasonalCalendarTooltipEventTypeLabel": "Event type",
         "seasonalCalendarTooltipMonthsLabel": "Months",
-        "seasonalCalendarTooltipSourceLabel": "Source"
+        "seasonalCalendarTooltipSourceLabel": "Source",
+        "seasonalCalenderDataNotAvailable": "Data is not available!"
     }
 }

--- a/app/src/views/CountryProfileOverview/index.tsx
+++ b/app/src/views/CountryProfileOverview/index.tsx
@@ -371,8 +371,7 @@ export function Component() {
                     </div>
                     {(isNotDefined(eventTypeGroupedData) || eventTypeGroupedData.length === 0) && (
                         <Message
-                            // FIXME: use translation
-                            title="Data is not available!"
+                            title={strings.seasonalCalenderDataNotAvailable}
                         />
                     )}
                     {eventTypeGroupedData?.map(

--- a/app/src/views/CountryProfilePreviousEvents/EmergenciesOverMonth/i18n.json
+++ b/app/src/views/CountryProfilePreviousEvents/EmergenciesOverMonth/i18n.json
@@ -1,0 +1,6 @@
+{
+    "namespace": "emergenciesOverMonth",
+    "strings": {
+        "emergenciesOverMonthTargetedPopulation": "Targeted population"
+    }
+}

--- a/app/src/views/CountryProfilePreviousEvents/EmergenciesOverMonth/index.tsx
+++ b/app/src/views/CountryProfilePreviousEvents/EmergenciesOverMonth/index.tsx
@@ -9,11 +9,13 @@ import {
     TextOutput,
     Tooltip,
 } from '@ifrc-go/ui';
+import { useTranslation } from '@ifrc-go/ui/hooks';
 import { isNotDefined } from '@togglecorp/fujs';
 
 import useTemporalChartData from '#hooks/useTemporalChartData';
 import { useRequest } from '#utils/restRequest';
 
+import i18n from './i18n.json';
 import styles from './styles.module.css';
 
 interface Props {
@@ -28,6 +30,8 @@ function EmergenciesOverMonth(props: Props) {
         endDate,
         countryId,
     } = props;
+
+    const strings = useTranslation(i18n);
 
     const containerRef = useRef<ElementRef<'div'>>(null);
 
@@ -78,8 +82,7 @@ function EmergenciesOverMonth(props: Props) {
                                     <>
                                         <DateOutput value={dataPoint.originalData.date} />
                                         <TextOutput
-                                            // FIXME: use translation
-                                            label="Targeted population"
+                                            label={strings.emergenciesOverMonthTargetedPopulation}
                                             value={dataPoint.originalData.targeted_population}
                                             valueType="number"
                                         />

--- a/app/src/views/CountryProfilePreviousEvents/PastEventsChart/i18n.json
+++ b/app/src/views/CountryProfilePreviousEvents/PastEventsChart/i18n.json
@@ -1,0 +1,10 @@
+{
+    "namespace": "pastEventsChart",
+    "strings": {
+        "pastEventsChartEvents": "Past events",
+        "pastEventsPeopleExposed": "People Exposed / Affected",
+        "pastEventsTargetedPopulation": "Targeted population",
+        "pastEventsAmountRequested": "Amount requested",
+        "pastEventsAmountFunded": "Amount funded"
+    }
+}

--- a/app/src/views/CountryProfilePreviousEvents/PastEventsChart/index.tsx
+++ b/app/src/views/CountryProfilePreviousEvents/PastEventsChart/index.tsx
@@ -10,6 +10,7 @@ import {
     TextOutput,
     Tooltip,
 } from '@ifrc-go/ui';
+import { useTranslation } from '@ifrc-go/ui/hooks';
 import { getPercentage } from '@ifrc-go/ui/utils';
 import {
     _cs,
@@ -20,6 +21,7 @@ import useTemporalChartData from '#hooks/useTemporalChartData';
 import { DEFAULT_Y_AXIS_WIDTH_WITH_LABEL } from '#utils/constants';
 import { useRequest } from '#utils/restRequest';
 
+import i18n from './i18n.json';
 import styles from './styles.module.css';
 
 interface Props {
@@ -37,6 +39,7 @@ function PastEventsChart(props: Props) {
         endDate,
     } = props;
 
+    const strings = useTranslation(i18n);
     const containerRef = useRef<ElementRef<'div'>>(null);
 
     const {
@@ -68,8 +71,7 @@ function PastEventsChart(props: Props) {
 
     return (
         <Container
-            // FIXME: use translations
-            heading="Past events"
+            heading={strings.pastEventsChartEvents}
             className={_cs(styles.pastEventsChart, className)}
             withHeaderBorder
         >
@@ -80,7 +82,7 @@ function PastEventsChart(props: Props) {
                 <svg className={styles.svg}>
                     <ChartAxes
                         chartData={chartData}
-                        yAxisLabel="People Exposed / Affected"
+                        yAxisLabel={strings.pastEventsPeopleExposed}
                     />
                     {chartData.chartPoints.map(
                         (chartPoint) => (
@@ -100,20 +102,17 @@ function PastEventsChart(props: Props) {
                                                 format="yyyy MMM"
                                             />
                                             <TextOutput
-                                                // FIXME: use translations
-                                                label="Targeted population"
+                                                label={strings.pastEventsTargetedPopulation}
                                                 value={chartPoint.originalData.targeted_population}
                                                 valueType="number"
                                             />
                                             <TextOutput
-                                                // FIXME: use translations
-                                                label="Amount requested"
+                                                label={strings.pastEventsAmountRequested}
                                                 value={chartPoint.originalData.amount_requested}
                                                 valueType="number"
                                             />
                                             <TextOutput
-                                                // FIXME: use translations
-                                                label="Amount funded"
+                                                label={strings.pastEventsAmountFunded}
                                                 value={getPercentage(
                                                     chartPoint.originalData.amount_funded,
                                                     chartPoint.originalData.amount_requested,

--- a/app/src/views/CountryProfileRiskWatch/RiskBarChart/CombinedChart/i18n.json
+++ b/app/src/views/CountryProfileRiskWatch/RiskBarChart/CombinedChart/i18n.json
@@ -6,6 +6,7 @@
         "riskBarChartLowLabel": "Low",
         "riskBarChartMediumLabel": "Medium",
         "riskBarChartHighLabel": "High",
-        "riskBarChartVeryHighLabel": "Very high"
+        "riskVeryHighLabel": "Very high",
+        "riskScoreLabel": "Risk score"
     }
 }

--- a/app/src/views/CountryProfileRiskWatch/RiskBarChart/CombinedChart/index.tsx
+++ b/app/src/views/CountryProfileRiskWatch/RiskBarChart/CombinedChart/index.tsx
@@ -90,14 +90,14 @@ function CombinedChart(props: Props) {
             [CATEGORY_RISK_LOW]: strings.riskBarChartLowLabel,
             [CATEGORY_RISK_MEDIUM]: strings.riskBarChartMediumLabel,
             [CATEGORY_RISK_HIGH]: strings.riskBarChartHighLabel,
-            [CATEGORY_RISK_VERY_HIGH]: strings.riskBarChartVeryHighLabel,
+            [CATEGORY_RISK_VERY_HIGH]: strings.riskVeryHighLabel,
         }),
         [
             strings.riskBarChartVeryLowLabel,
             strings.riskBarChartLowLabel,
             strings.riskBarChartMediumLabel,
             strings.riskBarChartHighLabel,
-            strings.riskBarChartVeryHighLabel,
+            strings.riskVeryHighLabel,
         ],
     );
 
@@ -309,8 +309,7 @@ function CombinedChart(props: Props) {
                                                         {datum.originalData.date.toLocaleDateString('default', { month: 'long' })}
                                                         {selectedRiskMetricDetail.key === 'riskScore' ? (
                                                             <TextOutput
-                                                                // FIXME: use strings
-                                                                label="Risk score"
+                                                                label={strings.riskScoreLabel}
                                                                 // eslint-disable-next-line max-len
                                                                 value={riskCategoryToLabelMap[value]}
                                                                 strongValue

--- a/app/src/views/CountryProfileRiskWatch/RiskBarChart/FoodInsecurityChart/i18n.json
+++ b/app/src/views/CountryProfileRiskWatch/RiskBarChart/FoodInsecurityChart/i18n.json
@@ -1,0 +1,8 @@
+{
+    "namespace": "foodInsecurityChart",
+    "strings": {
+        "foodInsecurityChartAverage": "Average for",
+        "foodInsecurityAnalysisDate": "Analysis date",
+        "foodInsecurityPeopleExposed": "People Exposed"
+    }
+}

--- a/app/src/views/CountryProfileRiskWatch/RiskBarChart/FoodInsecurityChart/index.tsx
+++ b/app/src/views/CountryProfileRiskWatch/RiskBarChart/FoodInsecurityChart/index.tsx
@@ -8,6 +8,7 @@ import {
     TextOutput,
     Tooltip,
 } from '@ifrc-go/ui';
+import { useTranslation } from '@ifrc-go/ui/hooks';
 import {
     avgSafe,
     getDiscretePathDataList,
@@ -23,6 +24,7 @@ import useTemporalChartData from '#hooks/useTemporalChartData';
 import { getPrioritizedIpcData } from '#utils/domain/risk';
 import { type RiskApiResponse } from '#utils/restRequest';
 
+import i18n from './i18n.json';
 import styles from './styles.module.css';
 
 type CountryRiskResponse = RiskApiResponse<'/api/v1/country-seasonal/'>;
@@ -62,6 +64,7 @@ function FiChartPoint(props: FiChartPointProps) {
             originalData,
         },
     } = props;
+    const strings = useTranslation(i18n);
 
     const title = useMemo(
         () => {
@@ -85,10 +88,9 @@ function FiChartPoint(props: FiChartPointProps) {
                 { month: 'long' },
             );
 
-            // FIXME: use translations
-            return `Average for ${formattedMonth}`;
+            return `${strings.foodInsecurityChartAverage} ${formattedMonth}`;
         },
-        [originalData],
+        [originalData, strings.foodInsecurityChartAverage],
     );
 
     return (
@@ -103,15 +105,13 @@ function FiChartPoint(props: FiChartPointProps) {
                     <>
                         {isDefined(originalData.analysis_date) && (
                             <TextOutput
-                                // FIXME: use translations
-                                label="Analysis date"
+                                label={strings.foodInsecurityAnalysisDate}
                                 value={originalData.analysis_date}
                                 valueType="date"
                             />
                         )}
                         <TextOutput
-                            // FIXME: use translations
-                            label="People Exposed"
+                            label={strings.foodInsecurityPeopleExposed}
                             value={originalData.total_displacement}
                             valueType="number"
                             maximumFractionDigits={0}

--- a/app/src/views/FieldReportForm/ContextFields/i18n.json
+++ b/app/src/views/FieldReportForm/ContextFields/i18n.json
@@ -32,7 +32,9 @@
         "summaryLabel": "Title",
         "fieldReportFormContextTitle": "Context",
         "fieldReportFormSearchTitle": "Search for existing emergency",
-        "fieldReportFormSearchDescription": "Type the name of the country you want to report on in the box above to begin the search."
+        "fieldReportFormSearchDescription": "Type the name of the country you want to report on in the box above to begin the search.",
+        "fieldPrefix": "Prefix",
+        "fieldReportFormSuffix": "Suffix"
     }
 }
 

--- a/app/src/views/FieldReportForm/ContextFields/index.tsx
+++ b/app/src/views/FieldReportForm/ContextFields/index.tsx
@@ -303,8 +303,7 @@ function ContextFields(props: Props) {
             >
                 {prefixVisible && (
                     <TextInput
-                        // FIXME: use translations
-                        label={summaryVisible ? 'Prefix' : strings.titleSecondaryLabel}
+                        label={summaryVisible ? strings.fieldPrefix : strings.titleSecondaryLabel}
                         name={undefined}
                         value={titlePrefix}
                         // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -326,8 +325,7 @@ function ContextFields(props: Props) {
                 )}
                 {suffixVisible && (
                     <TextInput
-                        // FIXME: use translations
-                        label="Suffix"
+                        label={strings.fieldReportFormSuffix}
                         name={undefined}
                         value={titleSuffix}
                         // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/app/src/views/FlashUpdateForm/ContextTab/i18n.json
+++ b/app/src/views/FlashUpdateForm/ContextTab/i18n.json
@@ -19,6 +19,7 @@
         "flashUpdateFormContextReferenceAddButtonLabel":"Add Reference",
         "flashUpdateFormGenerateButtonLabel":"Generate",
         "flashUpdateFormContextSituationalDescription":"Brief overview of the current situation and the anticipated disaster.",
-        "flashUpdateUpload": "Upload"
+        "flashUpdateUpload": "Upload",
+        "flashUpdateDisasterType": "Disaster Type"
     }
 }

--- a/app/src/views/FlashUpdateForm/ContextTab/index.tsx
+++ b/app/src/views/FlashUpdateForm/ContextTab/index.tsx
@@ -187,7 +187,7 @@ function ContextTab(props: Props) {
                     name="hazard_type"
                     value={value.hazard_type}
                     // FIXME: use translations
-                    label="Disaster Type"
+                    label={strings.flashUpdateDisasterType}
                     onChange={onValueChange}
                     disabled={disabled}
                     // withAsterisk


### PR DESCRIPTION
## Addresses:
- https://github.com/IFRCGo/go-web-app/issues/604#issue-2133603889
- https://github.com/IFRCGo/go-web-app/issues/732#issue-2168292699

## Changes
- Hide Organisation Capacity 
- Add strings translation in country pages

## This PR doesn't introduce:
- [x] typos
- [x] conflict markers
- [x] unwanted comments
- [x] temporary files, auto-generated files or secret keys
- [x] `console.log` meant for debugging
- [x] codegen errors
