### PR TITLE
Population information in Population map tooltip

### DIFF
--- a/app/src/views/CountryProfileOverview/PopulationMap/i18n.json
+++ b/app/src/views/CountryProfileOverview/PopulationMap/i18n.json
@@ -4,6 +4,7 @@
         "populationMapTitle": "Population Map",
         "source": "Source",
         "worldBank": "The World Bank",
-        "populationLegendLabel": "Population"
+        "populationLegendLabel": "Population",
+        "populationPopupYearLabel": "Year"
     }
 }


### PR DESCRIPTION
## Addresses:
- #792 

## Changes
- Add tooltip with population information in population map
- Add hovered feature in map

## This PR doesn't introduce:
- [x] typos
- [x] conflict markers
- [x] unwanted comments
- [x] temporary files, auto-generated files or secret keys
- [x] `console.log` meant for debugging
- [x] codegen errors
