### PR TITLE
Use formatted component name and filter out parent PER components from prioritization 

### DIFF
--- a/app/src/utils/common.ts
+++ b/app/src/utils/common.ts
@@ -1,11 +1,16 @@
 import {
     compareNumber,
+    isDefined,
     isNotDefined,
+    isTruthyString,
 } from '@togglecorp/fujs';
 
+import { type components } from '#generated/types';
 import type { GoApiResponse } from '#utils/restRequest';
 
 type SearchResponse = GoApiResponse<'/api/v1/search/'>;
+
+type PerComponent = Pick<components<'read'>['schemas']['FormComponent'], 'title' | 'component_letter' | 'component_num'>;
 
 type SearchResponseKeys = keyof SearchResponse;
 // eslint-disable-next-line import/prefer-default-export
@@ -74,4 +79,12 @@ export function downloadFile(
     document.body.removeChild(a);
 
     URL.revokeObjectURL(url);
+}
+
+export function getFormattedComponentName(component: PerComponent): string {
+    const { component_num, component_letter, title } = component;
+
+    const prefix = [component_num, component_letter].filter(isDefined).join(' ').trim();
+
+    return `${prefix} : ${title}`;
 }

--- a/app/src/utils/common.ts
+++ b/app/src/utils/common.ts
@@ -1,16 +1,11 @@
 import {
     compareNumber,
-    isDefined,
     isNotDefined,
-    isTruthyString,
 } from '@togglecorp/fujs';
 
-import { type components } from '#generated/types';
 import type { GoApiResponse } from '#utils/restRequest';
 
 type SearchResponse = GoApiResponse<'/api/v1/search/'>;
-
-type PerComponent = Pick<components<'read'>['schemas']['FormComponent'], 'title' | 'component_letter' | 'component_num'>;
 
 type SearchResponseKeys = keyof SearchResponse;
 // eslint-disable-next-line import/prefer-default-export
@@ -79,12 +74,4 @@ export function downloadFile(
     document.body.removeChild(a);
 
     URL.revokeObjectURL(url);
-}
-
-export function getFormattedComponentName(component: PerComponent): string {
-    const { component_num, component_letter, title } = component;
-
-    const prefix = [component_num, component_letter].filter(isDefined).join(' ').trim();
-
-    return `${prefix} : ${title}`;
 }

--- a/app/src/utils/domain/per.ts
+++ b/app/src/utils/domain/per.ts
@@ -7,6 +7,7 @@ import { type components } from '#generated/types';
 import { type GoApiResponse } from '#utils/restRequest';
 
 type PerPhase = components<'read'>['schemas']['PhaseEnum'];
+type PerComponent = Pick<components<'read'>['schemas']['FormComponent'], 'title' | 'component_letter' | 'component_num'>;
 
 export const PER_PHASE_OVERVIEW = 1 satisfies PerPhase;
 export const PER_PHASE_ASSESSMENT = 2 satisfies PerPhase;
@@ -34,4 +35,12 @@ export function getCurrentPerProcessStep(status: PerProcessStatusResponse | unde
     }
 
     return PER_PHASE_OVERVIEW;
+}
+
+export function getFormattedComponentName(component: PerComponent): string {
+    const { component_num, component_letter, title } = component;
+
+    const prefix = [component_num, component_letter].filter(isDefined).join(' ').trim();
+
+    return `${prefix} : ${title}`;
 }

--- a/app/src/views/CountryPreparedness/PrivateCountryPreparedness/i18n.json
+++ b/app/src/views/CountryPreparedness/PrivateCountryPreparedness/i18n.json
@@ -16,7 +16,6 @@
         "highlightedTopRatedComponentHeading": "Highlighted Top Rated Components",
         "priorityComponentToBeStrengthenedHeading": "Priority Components To Be Strengthened",
         "averageComponentRatingLabel": "Average Component Rating",
-        "priorityComponentHeading": "Component {componentNumber} {componentLetter}: {componentName}",
         "componentRatingResultsHeading": "Components Rating Results",
         "componentHeading": "Component",
         "componentMessageDescription": "There was an error loading the PER data!",

--- a/app/src/views/CountryPreparedness/PrivateCountryPreparedness/index.tsx
+++ b/app/src/views/CountryPreparedness/PrivateCountryPreparedness/index.tsx
@@ -32,7 +32,6 @@ import {
 import {
     numericCountSelector,
     numericIdSelector,
-    resolveToString,
     stringLabelSelector,
     stringTitleSelector,
     sumSafe,
@@ -51,6 +50,7 @@ import GoSingleFileInput from '#components/domain/GoSingleFileInput';
 import PerExportModal from '#components/PerExportModal';
 import WikiLink from '#components/WikiLink';
 import useRouting from '#hooks/useRouting';
+import { getFormattedComponentName } from '#utils/common';
 import {
     type GoApiResponse,
     useRequest,
@@ -606,10 +606,10 @@ function PrivateCountryPreparedness() {
                                 key={priorityComponent.id}
                             >
                                 <Heading level={5} className={styles.heading}>
-                                    {resolveToString(strings.priorityComponentHeading, {
-                                        componentNumber: priorityComponent.num,
-                                        componentLetter: priorityComponent.letter,
-                                        componentName: priorityComponent.label,
+                                    {getFormattedComponentName({
+                                        component_num: priorityComponent.num,
+                                        component_letter: priorityComponent.letter,
+                                        title: priorityComponent.label,
                                     })}
                                 </Heading>
                                 <ProgressBar
@@ -635,11 +635,7 @@ function PrivateCountryPreparedness() {
                                 key={`${component.details.id}-${component.details.component_num}-${component.details.component_letter}`}
                             >
                                 <Heading level={5}>
-                                    {resolveToString(strings.priorityComponentHeading, {
-                                        componentNumber: component.details.component_num,
-                                        componentLetter: component.details.component_letter ?? '',
-                                        componentName: component.details.title,
-                                    })}
+                                    {getFormattedComponentName(component.details)}
                                 </Heading>
                                 <ProgressBar
                                     value={component.rating?.value ?? 0}

--- a/app/src/views/CountryPreparedness/PrivateCountryPreparedness/index.tsx
+++ b/app/src/views/CountryPreparedness/PrivateCountryPreparedness/index.tsx
@@ -50,7 +50,7 @@ import GoSingleFileInput from '#components/domain/GoSingleFileInput';
 import PerExportModal from '#components/PerExportModal';
 import WikiLink from '#components/WikiLink';
 import useRouting from '#hooks/useRouting';
-import { getFormattedComponentName } from '#utils/common';
+import { getFormattedComponentName } from '#utils/domain/per';
 import {
     type GoApiResponse,
     useRequest,

--- a/app/src/views/CountryPreparedness/PublicCountryPreparedness/i18n.json
+++ b/app/src/views/CountryPreparedness/PublicCountryPreparedness/i18n.json
@@ -4,7 +4,6 @@
         "nsPreparednessAndResponseCapacityHeading": "NS Preparedness and Response Capacity",
         "publicHighlightedTopRatedComponentHeading": "Highlighted Top Rated Components",
         "publicPriorityComponentToBeStrengthenedHeading": "Priority Components To Be Strengthened",
-        "publicPriorityComponentHeading": "Component {componentNumber} {componentLetter}: {componentName}",
         "startDateLabel": "Start Date",
         "perPhaseLabel": "PER Phase",
         "perCycleLabel": "PER Cycle",

--- a/app/src/views/CountryPreparedness/PublicCountryPreparedness/index.tsx
+++ b/app/src/views/CountryPreparedness/PublicCountryPreparedness/index.tsx
@@ -23,7 +23,7 @@ import {
 import Link from '#components/Link';
 import WikiLink from '#components/WikiLink';
 import useRouting from '#hooks/useRouting';
-import { getFormattedComponentName } from '#utils/common';
+import { getFormattedComponentName } from '#utils/domain/per';
 import { useRequest } from '#utils/restRequest';
 
 import i18n from './i18n.json';

--- a/app/src/views/CountryPreparedness/PublicCountryPreparedness/index.tsx
+++ b/app/src/views/CountryPreparedness/PublicCountryPreparedness/index.tsx
@@ -14,7 +14,6 @@ import {
     TextOutput,
 } from '@ifrc-go/ui';
 import { useTranslation } from '@ifrc-go/ui/hooks';
-import { resolveToString } from '@ifrc-go/ui/utils';
 import {
     compareNumber,
     isDefined,
@@ -24,6 +23,7 @@ import {
 import Link from '#components/Link';
 import WikiLink from '#components/WikiLink';
 import useRouting from '#hooks/useRouting';
+import { getFormattedComponentName } from '#utils/common';
 import { useRequest } from '#utils/restRequest';
 
 import i18n from './i18n.json';
@@ -251,10 +251,10 @@ function PublicCountryPreparedness() {
                                     className={styles.heading}
                                     level={5}
                                 >
-                                    {resolveToString(strings.publicPriorityComponentHeading, {
-                                        componentNumber: priorityComponent.componentNumber,
-                                        componentLetter: priorityComponent.componentLetter,
-                                        componentName: priorityComponent.label,
+                                    {getFormattedComponentName({
+                                        component_num: priorityComponent.componentNumber,
+                                        component_letter: priorityComponent.componentLetter,
+                                        title: priorityComponent.label,
                                     })}
                                 </Heading>
                             </Fragment>

--- a/app/src/views/PerExport/i18n.json
+++ b/app/src/views/PerExport/i18n.json
@@ -17,7 +17,6 @@
         "perNSResponseHeading":"NS Response Mechanism Performance",
         "perHighlightedTopRatedComponentHeading": "Highlighted Top Rated Components",
         "perComponentRatingResultsHeading": "Components Rating Results",
-        "perPriorityComponentHeading": "Component {componentNumber} {componentLetter}: {componentName}",
         "perComponentNotReviewed": "0 - Not reviewed"
     }
 }

--- a/app/src/views/PerExport/index.tsx
+++ b/app/src/views/PerExport/index.tsx
@@ -19,7 +19,6 @@ import {
 import {
     numericCountSelector,
     numericIdSelector,
-    resolveToString,
     stringLabelSelector,
     stringTitleSelector,
     sumSafe,
@@ -35,6 +34,7 @@ import {
 } from '@togglecorp/fujs';
 
 import ifrcLogo from '#assets/icons/ifrc-square.png';
+import { getFormattedComponentName } from '#utils/common';
 import { useRequest } from '#utils/restRequest';
 
 import PreviousAssessmentCharts from '../CountryPreparedness/PreviousAssessmentChart';
@@ -491,7 +491,7 @@ export function Component() {
                                     {component.rating?.title}
                                 </div>
                                 <div>
-                                    {`${component.details.component_num}${component.details.component_letter}: ${component.details.title}`}
+                                    {getFormattedComponentName(component.details)}
                                 </div>
                             </div>
                         ),
@@ -512,12 +512,7 @@ export function Component() {
                                 className={styles.ratedComponent}
                             >
                                 <div className={styles.label}>
-                                    {resolveToString(strings.perPriorityComponentHeading, {
-                                        componentNumber: component.details.component_num,
-                                        componentLetter: component.details.component_letter
-                                            ?? '',
-                                        componentName: component.details.title,
-                                    })}
+                                    {getFormattedComponentName(component.details)}
                                 </div>
                                 <ProgressBar
                                     value={component.rating?.value ?? 0}

--- a/app/src/views/PerExport/index.tsx
+++ b/app/src/views/PerExport/index.tsx
@@ -34,7 +34,7 @@ import {
 } from '@togglecorp/fujs';
 
 import ifrcLogo from '#assets/icons/ifrc-square.png';
-import { getFormattedComponentName } from '#utils/common';
+import { getFormattedComponentName } from '#utils/domain/per';
 import { useRequest } from '#utils/restRequest';
 
 import PreviousAssessmentCharts from '../CountryPreparedness/PreviousAssessmentChart';

--- a/app/src/views/PerPrioritizationForm/index.tsx
+++ b/app/src/views/PerPrioritizationForm/index.tsx
@@ -340,7 +340,10 @@ export function Component() {
 
     const sortedFormComponents = useMemo(
         () => (
-            [...formComponentResponse?.results ?? []].sort(
+            [...formComponentResponse?.results?.filter(
+                // NOTE:  filter out parent components
+                (formComponent) => !formComponent.is_parent,
+            ) ?? []].sort(
                 (a, b) => {
                     if (sortBy === 'rating') {
                         const ratingA = assessmentComponentResponseMap


### PR DESCRIPTION
## This PR doesn't introduce:
- [x] typos
- [x] conflict markers
- [x] unwanted comments
- [x] temporary files, auto-generated files or secret keys
- [x] `console.log` meant for debugging
- [x] codegen errors
