### PR TITLE
 Add Input error storybook

### DIFF
--- a/packages/go-ui-storybook/src/stories/InputError.stories.tsx
+++ b/packages/go-ui-storybook/src/stories/InputError.stories.tsx
@@ -1,0 +1,39 @@
+import { InputErrorProps } from '@ifrc-go/ui';
+import type {
+    Meta,
+    StoryObj,
+} from '@storybook/react';
+
+import InputError from './InputError';
+
+type InputErrorSpecificProps = InputErrorProps;
+type Story = StoryObj<InputErrorSpecificProps>;
+
+const meta: Meta<typeof InputError> = {
+    title: 'Components/InputError',
+    component: InputError,
+    parameters: {
+        layout: 'centered',
+        design: {
+            type: 'figma',
+            url: 'https://www.figma.com/file/myeW85ibN5p2SlnXcEpxFD/IFRC-GO---UI-Current---1?type=design&node-id=0-4957&mode=design&t=KwxbuoUQxqcLyZbG-0',
+        },
+    },
+    tags: ['autodocs'],
+};
+
+export default meta;
+
+export const Default: Story = {
+    args: {
+        children: 'This is an error',
+        className: 'error',
+    },
+};
+export const Disabled: Story = {
+    args: {
+        children: 'This is an error ',
+        className: 'Error',
+        disabled: true,
+    },
+};

--- a/packages/go-ui-storybook/src/stories/InputError.tsx
+++ b/packages/go-ui-storybook/src/stories/InputError.tsx
@@ -1,0 +1,14 @@
+import {
+    InputError as PureInputError,
+    InputErrorProps as PureInputErrorProps,
+} from '@ifrc-go/ui';
+
+interface InputErrorProps extends PureInputErrorProps {}
+
+function WrappedInputError(props: InputErrorProps) {
+    return (
+        <PureInputError {...props} />// eslint-disable-line react/jsx-props-no-spreading
+    );
+}
+
+export default WrappedInputError;


### PR DESCRIPTION
## Addresses:
-   https://github.com/IFRCGo/go-web-app/issues/979


## Changes
-Add InputError Story for InputError Component

## This PR doesn't introduce:
- [x] typos
- [x] conflict markers
- [x] unwanted comments
- [x] temporary files, auto-generated files or secret keys
- [x] `console.log` meant for debugging
- [x] codegen errors
