### PR TITLE
Wait for content original language to check for language mismatch

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -4,10 +4,10 @@
 
 ### Patch Changes
 
-- 2631a9f: Add office type and location information for IFRC delegation office
 - 1b4b6df: Add local unit form
-- 2d7a6a5: - Enable ability to start PER in IFRC supported lanugages
-  - Make PER forms readOnly in case of language mismatch
+- 2631a9f: Add office type and location information for IFRC delegation office
+- 2d7a6a5: - Enable ability to start PER in IFRC supported languages
+  - Make PER forms `readOnly` in case of language mismatch
 - e4bf098: Fix incorrect statistics for past appeals of a country
 - Updated dependencies [0ab207d]
 - Updated dependencies [66151a7]

--- a/app/src/views/PerProcessForm/index.tsx
+++ b/app/src/views/PerProcessForm/index.tsx
@@ -63,8 +63,8 @@ export function Component() {
     const contentOriginalLanguage = statusResponse
         ?.translation_module_original_language;
     const languageMismatch = isDefined(perId)
-        && currentLanguage !== contentOriginalLanguage;
-
+        && isDefined(contentOriginalLanguage)
+        && (currentLanguage !== contentOriginalLanguage);
     const shouldHideForm = isDefined(statusResponseError);
 
     const actionDivRef = useRef<HTMLDivElement>(null);


### PR DESCRIPTION
## Changes
- Detailed list or prose of changes
- Breaking changes
- Changes to configurations

## This PR doesn't introduce:
- [x] typos
- [x] conflict markers
- [x] unwanted comments
- [x] temporary files, auto-generated files or secret keys
- [x] `console.log` meant for debugging
- [x] codegen errors
