### PR TITLE
Remove source in presence of partner of country page

### DIFF
--- a/.changeset/beige-zoos-flow.md
+++ b/.changeset/beige-zoos-flow.md
@@ -1,0 +1,5 @@
+---
+"go-web-app": patch
+---
+
+Hide contact information from IFRC Presence

--- a/app/src/views/CountryNsOverviewSupportingPartners/Presence/index.tsx
+++ b/app/src/views/CountryNsOverviewSupportingPartners/Presence/index.tsx
@@ -27,7 +27,7 @@ const legalStatusLink = 'https://fednet.ifrc.org/en/support/legal/legal/legal-st
 
 interface DelegationInformationProps {
     name: string | null | undefined;
-    contact: string | null | undefined;
+    // contact: string | null | undefined;
     delegationOfficeType: string;
     address: string;
 }
@@ -40,7 +40,7 @@ const countryDelegationKeySelector = (countryDelegation: CountryDelgation) => (
 function DelegationInformation(props: DelegationInformationProps) {
     const {
         name,
-        contact,
+        // contact,
         delegationOfficeType,
         address,
     } = props;
@@ -57,11 +57,14 @@ function DelegationInformation(props: DelegationInformationProps) {
                 value={name}
                 strongValue
             />
+            {/* NOTE: Hide it for now, not sure if we can publish or not */}
+            {/*
             <TextOutput
                 label={strings.countryIFRCContact}
                 value={contact}
                 strongValue
             />
+              */}
             <TextOutput
                 label={strings.countryIFRCDelegationType}
                 value={delegationOfficeType}
@@ -110,21 +113,22 @@ function Presence() {
             <Container
                 className={styles.presenceCard}
                 heading={strings.countryIFRCPresenceTitle}
-                footerActions={(
-                    <TextOutput
-                        label={strings.source}
-                        value={(
-                            <Link
-                                variant="tertiary"
-                                href="https://data.ifrc.org/fdrs/ifrc-secretariat/"
-                                external
-                                withUnderline
-                            >
-                                {strings.fdrs}
-                            </Link>
-                        )}
-                    />
-                )}
+                // NOTE: Hide it for now, not sure if we can publish or not
+                // footerActions={(
+                //     <TextOutput
+                //         label={strings.source}
+                //         value={(
+                //             <Link
+                //                 variant="tertiary"
+                //                 href="https://data.ifrc.org/fdrs/ifrc-secretariat/"
+                //                 external
+                //                 withUnderline
+                //             >
+                //                 {strings.fdrs}
+                //             </Link>
+                //         )}
+                //     />
+                // )}
                 withHeaderBorder
                 withInternalPadding
                 childrenContainerClassName={styles.content}


### PR DESCRIPTION
## Addresses:
- #1009 

## Changes
- Remove source and contact information from presence

## This PR doesn't introduce:
- [x] typos
- [x] conflict markers
- [x] unwanted comments
- [x] temporary files, auto-generated files or secret keys
- [x] `console.log` meant for debugging
- [x] codegen errors
