### PR TITLE
fix: hide add/edit local units in production environment

### DIFF
--- a/.changeset/happy-jeans-care.md
+++ b/.changeset/happy-jeans-care.md
@@ -1,0 +1,5 @@
+---
+"go-web-app": patch
+---
+
+Hide add/edit local units on production environmet

--- a/app/src/views/CountryNsOverviewContextAndStructure/NationalSocietyLocalUnits/LocalUnitsTable/LocalUnitTableActions/index.tsx
+++ b/app/src/views/CountryNsOverviewContextAndStructure/NationalSocietyLocalUnits/LocalUnitsTable/LocalUnitTableActions/index.tsx
@@ -7,6 +7,7 @@ import {
 import { resolveToString } from '@ifrc-go/ui/utils';
 
 import DropdownMenuItem from '#components/DropdownMenuItem';
+import { environment } from '#config';
 import usePermissions from '#hooks/domain/usePermissions';
 import useAlert from '#hooks/useAlert';
 import {
@@ -102,14 +103,16 @@ function LocalUnitsTableActions(props: Props) {
                         >
                             {strings.localUnitsView}
                         </DropdownMenuItem>
-                        <DropdownMenuItem
-                            type="button"
-                            name={localUnitId}
-                            onClick={setShowLocalUnitEditModalTrue}
-                            disabled={!hasValidatePermission}
-                        >
-                            {strings.localUnitsEdit}
-                        </DropdownMenuItem>
+                        {environment !== 'production' && (
+                            <DropdownMenuItem
+                                type="button"
+                                name={localUnitId}
+                                onClick={setShowLocalUnitEditModalTrue}
+                                disabled={!hasValidatePermission}
+                            >
+                                {strings.localUnitsEdit}
+                            </DropdownMenuItem>
+                        )}
                         <DropdownMenuItem
                             persist
                             // NOTE sending an empty post request to validate the local unit

--- a/app/src/views/CountryNsOverviewContextAndStructure/NationalSocietyLocalUnits/index.tsx
+++ b/app/src/views/CountryNsOverviewContextAndStructure/NationalSocietyLocalUnits/index.tsx
@@ -25,6 +25,7 @@ import {
     isNotDefined,
 } from '@togglecorp/fujs';
 
+import { environment } from '#config';
 import useAuth from '#hooks/domain/useAuth';
 import usePermissions from '#hooks/domain/usePermissions';
 import { CountryOutletContext } from '#utils/outletContext';
@@ -117,7 +118,8 @@ function NationalSocietyLocalUnits(props: Props) {
                         <Tab name="table">{strings.localUnitsListView}</Tab>
                     </TabList>
                 )}
-                actions={hasAddLocalUnitPermission && (
+                // NOTE: disable local units add/edit for now
+                actions={hasAddLocalUnitPermission && (environment !== 'production') && (
                     <Button
                         name={undefined}
                         variant="secondary"


### PR DESCRIPTION
## Changes
- Hide add/edit local units in production environment

## This PR doesn't introduce:
- [x] typos
- [x] conflict markers
- [x] unwanted comments
- [x] temporary files, auto-generated files or secret keys
- [x] `console.log` meant for debugging
- [x] codegen errors
