### PR TITLE
Fix Readonly for SegemntInput story

### DIFF
--- a/packages/go-ui-storybook/src/stories/SegmentInput.stories.tsx
+++ b/packages/go-ui-storybook/src/stories/SegmentInput.stories.tsx
@@ -93,6 +93,7 @@ export const Disabled = {
 } satisfies Story;
 
 export const Readonly: Story = {
+    render: Template,
     args: {
         ...Default.args,
         value: '2',


### PR DESCRIPTION
## Addresses:
- https://github.com/IFRCGo/go-web-app/issues/1179

## Changes
- Fix Readonly for SegemntInput story

## This PR doesn't introduce:
- [x] typos
- [x] conflict markers
- [x] unwanted comments
- [x] temporary files, auto-generated files or secret keys
- [x] `console.log` meant for debugging
- [x] codegen errors
