### PR TITLE
Update chromatic CI to run only when necessary

### DIFF
--- a/.github/workflows/chromatic-deploy.yml
+++ b/.github/workflows/chromatic-deploy.yml
@@ -1,0 +1,40 @@
+name: 'Chromatic Publish'
+
+on:
+  push:
+    branches:
+      - develop
+      - project/storybook
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  changed-files:
+    runs-on: ubuntu-latest
+    name: changed-files
+    outputs:
+      all_changed_files: ${{ steps.changed-files.outputs.all_changed_files }}
+      any_changed: ${{ steps.changed-files.outputs.any_changed }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v44
+        with:
+          files: |
+            packages/ui/**
+            packages/go-ui-storybook/**
+  chromatic:
+    name: Run visual tests
+    needs: [changed-files]
+    if: ${{ needs.changed-files.outputs.any_changed == 'true' }}
+    uses: ./.github/workflows/chromatic.yml
+    secrets: inherit

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,13 +1,19 @@
-name: 'Chromatic Publish'
+name: Chromatic
 
-on:
-  push:
-    branches:
-      - project/storybook
+on: workflow_call
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-chromatic
+  cancel-in-progress: true
+
+permissions:
+  actions: write
+  contents: read
 
 jobs:
   ui:
     name: Build UI Library
+    needs: [changed-files]
     environment: 'test'
     runs-on: ubuntu-latest
     defaults:
@@ -51,12 +57,13 @@ jobs:
           path: packages/ui/dist
       - name: Install dependencies
         run: yarn install --frozen-lockfile
-      #👇 Adds Chromatic as a step in the workflow
       - name: Run Chromatic
         uses: chromaui/action@v1
-        # Options required for Chromatic's GitHub Action
         with:
-          #👇 Chromatic projectToken
+          exitZeroOnChanges: true
+          exitOnceUploaded: true
+          onlyChanged: true
+          skip: "@(renovate/**|dependabot/**)"
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           token: ${{ secrets.GITHUB_TOKEN }}
           workingDir: packages/go-ui-storybook


### PR DESCRIPTION
## This PR doesn't introduce:
- [x] typos
- [x] conflict markers
- [x] unwanted comments
- [x] temporary files, auto-generated files or secret keys
- [x] `console.log` meant for debugging
- [x] codegen errors
