### PR TITLE
Add IFRC GO Wiki link, remove Twitter link, and add link version number to release notes on GitHub

### DIFF
--- a/.changeset/chatty-toes-thank.md
+++ b/.changeset/chatty-toes-thank.md
@@ -1,0 +1,5 @@
+---
+"go-ui-storybook": patch
+---
+
+Link version number to release notes on GitHub

--- a/app/package.json
+++ b/app/package.json
@@ -3,6 +3,12 @@
     "version": "7.4.0",
     "type": "module",
     "private": true,
+    "license": "MIT",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/IFRCGo/go-web-app.git",
+        "directory": "app"
+    },
     "scripts": {
         "translatte": "tsx scripts/translatte/main.ts",
         "translatte:generate": "yarn translatte generate-migration ../translationMigrations ./src/**/i18n.json ../packages/ui/src/**/i18n.json",

--- a/app/src/components/GlobalFooter/i18n.json
+++ b/app/src/components/GlobalFooter/i18n.json
@@ -8,6 +8,7 @@
         "footerOpenSourceCode":"Open Source Code",
         "footerApiDocumentation":"API Documentation",
         "footerOtherResources":"Other Resources",
+        "footerGoWiki":"Go-Wiki",
         "footerContactUs":"Contact Us",
         "footerIFRC":"© IFRC {year} v{appVersion}",
         "globalFindOut": "Find Out More",

--- a/app/src/components/GlobalFooter/i18n.json
+++ b/app/src/components/GlobalFooter/i18n.json
@@ -8,7 +8,7 @@
         "footerOpenSourceCode":"Open Source Code",
         "footerApiDocumentation":"API Documentation",
         "footerOtherResources":"Other Resources",
-        "footerGoWiki":"Go-Wiki",
+        "footerGoWiki":"GO Wiki",
         "footerContactUs":"Contact Us",
         "footerIFRC":"© IFRC {year} v{appVersion}",
         "globalFindOut": "Find Out More",

--- a/app/src/components/GlobalFooter/index.tsx
+++ b/app/src/components/GlobalFooter/index.tsx
@@ -15,6 +15,8 @@ import Link from '#components/Link';
 import {
     api,
     appCommitHash,
+    appPackageName,
+    appRepositoryUrl,
     appVersion,
 } from '#config';
 import { resolveUrl } from '#utils/resolveUrl';
@@ -35,8 +37,8 @@ function GlobalFooter(props: Props) {
     } = props;
 
     const strings = useTranslation(i18n);
-    const versionTag = `go-web-app@${appVersion}`;
-    const versionUrl = `https://github.com/IFRCGo/go-web-app/releases/tag/${versionTag}`;
+    const versionTag = `${appPackageName}@${appVersion}`;
+    const versionUrl = `${appRepositoryUrl}/releases/tag/${versionTag}`;
     const copyrightText = resolveToComponent(
         strings.footerIFRC,
         {

--- a/app/src/components/GlobalFooter/index.tsx
+++ b/app/src/components/GlobalFooter/index.tsx
@@ -1,7 +1,6 @@
 import {
     SocialFacebookIcon,
     SocialMediumIcon,
-    SocialTwitterIcon,
     SocialYoutubeIcon,
 } from '@ifrc-go/icons';
 import {
@@ -36,14 +35,20 @@ function GlobalFooter(props: Props) {
     } = props;
 
     const strings = useTranslation(i18n);
+    const versionTag = `go-web-app@${appVersion}`;
+    const versionUrl = `https://github.com/IFRCGo/go-web-app/releases/tag/${versionTag}`;
     const copyrightText = resolveToComponent(
         strings.footerIFRC,
         {
             year,
             appVersion: (
-                <span title={appCommitHash}>
+                <Link
+                    href={versionUrl}
+                    title={appCommitHash}
+                    external
+                >
                     {appVersion}
-                </span>
+                </Link>
             ),
         },
     );
@@ -112,6 +117,12 @@ function GlobalFooter(props: Props) {
                     >
                         {strings.footerOtherResources}
                     </Link>
+                    <Link
+                        href="https://go-wiki.ifrc.org"
+                        external
+                    >
+                        {strings.footerGoWiki}
+                    </Link>
                 </div>
             </div>
             <div className={styles.section}>
@@ -139,13 +150,6 @@ function GlobalFooter(props: Props) {
                         external
                     >
                         <SocialFacebookIcon />
-                    </Link>
-                    <Link
-                        className={styles.socialIcon}
-                        href="https://twitter.com/ifrcgo"
-                        external
-                    >
-                        <SocialTwitterIcon />
                     </Link>
                     <Link
                         className={styles.socialIcon}

--- a/app/src/config.ts
+++ b/app/src/config.ts
@@ -13,6 +13,8 @@ const {
     APP_SENTRY_REPLAYS_ON_ERROR_SAMPLE_RATE,
     APP_COMMIT_HASH,
     APP_VERSION,
+    APP_PACKAGE_NAME,
+    APP_REPOSITORY_URL,
 } = import.meta.env;
 
 export const environment = APP_ENVIRONMENT;
@@ -20,6 +22,8 @@ export const environment = APP_ENVIRONMENT;
 export const appTitle = APP_TITLE;
 export const appCommitHash = APP_COMMIT_HASH;
 export const appVersion = APP_VERSION;
+export const appPackageName = APP_PACKAGE_NAME;
+export const appRepositoryUrl = APP_REPOSITORY_URL;
 
 export const api = APP_API_ENDPOINT;
 export const adminUrl = APP_ADMIN_URL ?? api;

--- a/app/src/declarations/env.d.ts
+++ b/app/src/declarations/env.d.ts
@@ -8,6 +8,8 @@ interface ImportMetaEnv extends ImportMetaEnvAugmented {
     // The custom environment variables that are passed through the vite
     APP_COMMIT_HASH: string;
     APP_VERSION: string;
+    APP_PACKAGE_NAME: string;
+    APP_REPOSITORY_URL: string;
 }
 
 interface ImportMeta {

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -9,6 +9,7 @@ import checker from 'vite-plugin-checker';
 import { compression } from 'vite-plugin-compression2';
 import { VitePluginRadar } from 'vite-plugin-radar';
 import svgr from 'vite-plugin-svgr';
+import pkg from './package.json';
 
 import envConfig from './env';
 
@@ -23,6 +24,8 @@ export default defineConfig(({ mode }) => {
         define: {
             'import.meta.env.APP_COMMIT_HASH': JSON.stringify(commitHash),
             'import.meta.env.APP_VERSION': JSON.stringify(env.npm_package_version),
+            'import.meta.env.APP_PACKAGE_NAME': JSON.stringify(env.npm_package_name),
+            'import.meta.env.APP_REPOSITORY_URL': JSON.stringify(pkg.repository.url.match(/https:\/\/github\.com\/[^ ]+/)?.[0].replace(/\.git$/, '')),
         },
         plugins: [
             isProd ? checker({

--- a/package.json
+++ b/package.json
@@ -2,6 +2,11 @@
     "name": "go-web-app-workspace",
     "version": "1.0.0",
     "type": "module",
+    "license": "MIT",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/IFRCGo/go-web-app.git"
+    },
     "private": true,
     "scripts": {
         "postinstall": "patch-package",

--- a/packages/go-ui-storybook/package.json
+++ b/packages/go-ui-storybook/package.json
@@ -1,8 +1,14 @@
 {
     "name": "go-ui-storybook",
-    "private": true,
     "version": "1.0.0",
+    "private": true,
     "type": "module",
+    "license": "MIT",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/IFRCGo/go-web-app.git",
+        "directory": "packages/go-ui-storybook"
+    },
     "scripts": {
         "dev": "vite",
         "build": "tsc && vite build",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,12 +1,14 @@
 {
     "name": "@ifrc-go/ui",
+    "description": "IFRC-GO UI Components Library",
     "version": "1.1.5",
     "type": "module",
     "license": "MIT",
-    "author": {
-        "name": "ifrc"
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/IFRCGo/go-web-app.git",
+        "directory": "packages/ui"
     },
-    "description": "IFRC-GO UI Components Library",
     "keywords": [
         "ifrc-go",
         "ui",


### PR DESCRIPTION
## Addresses:
- https://github.com/IFRCGo/go-web-app/issues/1004#event-13758777891

## Changes
- Add go-wiki link
- remove twitter link
- link version number to release notes 

## This PR doesn't introduce:
- [x] typos
- [x] conflict markers
- [x] unwanted comments
- [x] temporary files, auto-generated files or secret keys
- [x] `console.log` meant for debugging
- [x] codegen errors
