### PR TITLE
Support alpha-* format for environments

### DIFF
--- a/app/env.ts
+++ b/app/env.ts
@@ -2,7 +2,14 @@ import { defineConfig, Schema } from '@julr/vite-plugin-validate-env';
 
 export default defineConfig({
     APP_TITLE: Schema.string(),
-    APP_ENVIRONMENT: Schema.enum(['development', 'testing', 'staging', 'production'] as const),
+    APP_ENVIRONMENT: (key, value) => {
+        const regex = /^production|staging|testing|alpha-\d+|development$/;
+        const valid = !!value && (value.match(regex) !== null);
+        if (!valid) {
+            throw new Error(`Value for environment variable "${key}" must match regex "${regex}", instead received "${value}"`);
+        }
+        return value as ('production' | 'staging' | 'testing' | `alpha-${number}` | 'development');
+    },
     APP_API_ENDPOINT: Schema.string({ format: 'url', protocol: true, tld: false }),
     APP_ADMIN_URL: Schema.string.optional({ format: 'url', protocol: true }),
     APP_SHOW_ENV_BANNER: Schema.boolean.optional(),

--- a/app/src/views/RootLayout/index.tsx
+++ b/app/src/views/RootLayout/index.tsx
@@ -352,7 +352,9 @@ export function Component() {
         ],
     );
 
-    const environmentTexts = {
+    const environmentTexts: {
+        [key in typeof environment]?: string;
+    } = {
         production: strings.environmentTextProduction,
         development: strings.environmentTextDevelopment,
         staging: strings.environmentTextStaging,
@@ -378,7 +380,8 @@ export function Component() {
                 <AlertContainer />
                 {environment !== 'production' && (
                     <div className={styles.banner}>
-                        {environmentTexts[environment]}
+                        {/* NOTE: We are not translating alpha server names */}
+                        {environmentTexts[environment] ?? environment}
                     </div>
                 )}
             </div>


### PR DESCRIPTION
## Changes
- Updated the format to support defining alpha environments

## This PR doesn't introduce:
- [x] typos
- [x] conflict markers
- [x] unwanted comments
- [x] temporary files, auto-generated files or secret keys
- [x] `console.log` meant for debugging
- [x] codegen errors
