### PR TITLE
Unhide Ops Learning page

### DIFF
--- a/app/.unimportedrc.json
+++ b/app/.unimportedrc.json
@@ -2,13 +2,9 @@
     "entry": ["./src/index.tsx"],
     "ignorePatterns": ["**/node_modules/**", "build/**", "**/parked/**"],
     "ignoreUnimported": [
+       "src/views/CountryNsOverviewCapacity/CountryNsOrganisationalCapacity/index.tsx",
         "**/*.d.ts",
-        "**/*.test.*",
-        "src/views/CountryNsOverviewCapacity/CountryNsOrganisationalCapacity/index.tsx",
-        "src/views/OperationalLearning/*",
-        "src/views/OperationalLearning/**/*",
-        "src/hooks/domain/usePerComponent.ts",
-        "src/hooks/domain/useSecondarySector.ts"
+        "**/*.test.*"
     ],
     "ignoreUnresolved": [
         "#assets/content/operational_timeline_title.svg?react",

--- a/app/src/App/routes/index.tsx
+++ b/app/src/App/routes/index.tsx
@@ -752,9 +752,6 @@ const resources = customWrapRoute({
         visibility: 'anything',
     },
 });
-
-// TODO: unhide operational learning
-/*
 const operationalLearning = customWrapRoute({
     parent: rootLayout,
     path: 'operational-learning',
@@ -768,7 +765,6 @@ const operationalLearning = customWrapRoute({
         visibility: 'anything',
     },
 });
-*/
 
 const search = customWrapRoute({
     parent: rootLayout,
@@ -1271,8 +1267,7 @@ const wrappedRoutes = {
     perWorkPlanForm,
     threeWProjectDetail,
     termsAndConditions,
-    // TODO: unhide operational learning
-    // operationalLearning,
+    operationalLearning,
     ...regionRoutes,
     ...countryRoutes,
     ...surgeRoutes,

--- a/app/src/components/Navbar/index.tsx
+++ b/app/src/components/Navbar/index.tsx
@@ -44,10 +44,8 @@ function Navbar(props: Props) {
     type RespondOptionKey = 'emergencies' | 'early-warning' | 'dref-process' | 'surge';
     const [activeRespondOption, setActiveRespondOption] = useState<RespondOptionKey>('emergencies');
 
-    // TODO: unhide operational learning
-    // type LearnOptionKey = 'tools' | 'resources' | 'operational-learning';
-    type LearnOptionKey = 'tools' | 'resources';
-    const [activeLearnOption, setActiveLearnOption] = useState<LearnOptionKey>('tools');
+    type LearnOptionKey = 'tools' | 'resources' | 'operational-learning';
+    const [activeLearnOption, setActiveLearnOption] = useState<LearnOptionKey>('operational-learning');
 
     return (
         <nav className={_cs(styles.navbar, className)}>
@@ -416,14 +414,12 @@ function Navbar(props: Props) {
                                 className={styles.optionList}
                                 contentClassName={styles.optionListContent}
                             >
-                                {/* TODO: unhide operational learning
                                 <Tab
                                     name="operational-learning"
                                     className={styles.option}
                                 >
                                     {strings.userMenuOperationalLearning}
                                 </Tab>
-                                */}
                                 <Tab
                                     name="tools"
                                     className={styles.option}
@@ -448,7 +444,6 @@ function Navbar(props: Props) {
                                 </DropdownMenuItem>
                             </TabList>
                             <div className={styles.optionBorder} />
-                            {/* TODO: unhide operational learning
                             <TabPanel
                                 name="operational-learning"
                                 className={styles.optionDetail}
@@ -464,7 +459,6 @@ function Navbar(props: Props) {
                                     {strings.userMenuOperationalLearningDescription}
                                 </div>
                             </TabPanel>
-                            */}
                             <TabPanel
                                 name="tools"
                                 className={styles.optionDetail}

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -32,10 +32,5 @@
         "noUnusedParameters": true,
         "noFallthroughCasesInSwitch": true
     },
-    "include": ["src", "env.ts"],
-
-    /* TODO: unhide operational learning */
-    "exclude": [
-        "src/views/OperationalLearning/*"
-    ]
+    "include": ["src", "env.ts"]
 }


### PR DESCRIPTION
## Addresses:
- *We do not have an issue for this on the project board*

## Depends on:
- https://github.com/IFRCGo/go-api/pull/2227

## Changes
- Add ops learning to the routes `/operational-learning/`
- Add ops learning to navbar
- Remove ignore from tsconfig
- Remove ignore from unimported

### Questions

- Do we also remove the "Operational Learning" tab from the "Preparedness" `/preparedness/operational-learning/` ?

### Screenshots

![image](https://github.com/user-attachments/assets/bc661384-5313-449c-b94a-8545bce4d075)

## This PR doesn't introduce:
- [x] typos
- [x] conflict markers
- [x] unwanted comments
- [x] temporary files, auto-generated files or secret keys
- [x] `console.log` meant for debugging
- [x] codegen errors