### PR TITLE
Fix  typing for event_details in appeal table for operational learning

### DIFF
--- a/.changeset/silly-hornets-trade.md
+++ b/.changeset/silly-hornets-trade.md
@@ -1,0 +1,5 @@
+---
+"go-web-app": patch
+---
+
+Fix null event in appeal for operational learning

--- a/app/src/views/OperationalLearning/Sources/AllExtractsModal/index.tsx
+++ b/app/src/views/OperationalLearning/Sources/AllExtractsModal/index.tsx
@@ -73,8 +73,8 @@ function AllExtractsModal(props: Props) {
 
     const extractsRendererParams = (_: number, learning: OpsLearning) => ({
         countryName: countries.find((country) => country.id === learning.appeal?.country)?.name,
-        emergencyId: learning.appeal?.event_details.id,
-        emergencyName: learning.appeal?.event_details.name,
+        emergencyId: learning.appeal?.event_details?.id,
+        emergencyName: learning.appeal?.event_details?.name,
         appealDocumentURL: learning.document_url,
         extract: learning.learning_validated,
         extractCreatedAt: learning.created_at,


### PR DESCRIPTION
## This PR doesn't introduce:
- [x] typos
- [x] conflict markers
- [x] unwanted comments
- [x] temporary files, auto-generated files or secret keys
- [x] `console.log` meant for debugging
- [x] codegen errors
