### PR TITLE
Update labels for Risk Map

### DIFF
--- a/app/src/components/MapContainerWithDisclaimer/i18n.json
+++ b/app/src/components/MapContainerWithDisclaimer/i18n.json
@@ -1,14 +1,14 @@
 {
     "namespace": "common",
     "strings": {
-        "infoLabel": "Map Sources: ICRC, UN CODs",
+        "infoLabel": "Sources: ICRC, UN CODs",
         "mapDisclaimer":"The maps used do not imply the expression of any opinion on the part of the International Federation of Red Cross and Red Crescent Societies or National Society concerning the legal status of a territory or of its authorities.",
         "copyrightMapbox":"© Mapbox",
         "copyrightOSM":"© OpenStreetMap",
         "downloadButtonTitle":"Download",
         "failureToDownloadMessage":"Failed to download map. Try again.",
         "improveMapLabel": "Improve this map",
-        "mapSourcesLabel": "Map Sources: ICRC, {uncodsLink}",
+        "mapSourcesLabel": "Sources: ICRC, {uncodsLink}",
         "mapSourceUNCODsLabel": "UNCODs",
         "feedbackAriaLabel" : "Map feedback",
         "mapContainerMapbox": "Mapbox",

--- a/app/src/components/domain/RiskImminentEventMap/LayerOptions/index.tsx
+++ b/app/src/components/domain/RiskImminentEventMap/LayerOptions/index.tsx
@@ -95,7 +95,7 @@ function LayerOptions(props: Props) {
             <div className={styles.exposedAreaInputWrapper}>
                 <Switch
                     // FIXME: use strings
-                    label="Exposed area"
+                    label="Exposed area to tropical storm or cyclone strength wind"
                     name="showExposedArea"
                     value={value.showExposedArea}
                     onChange={setFieldValue}

--- a/app/src/components/domain/RiskImminentEvents/Gdacs/EventDetails/i18n.json
+++ b/app/src/components/domain/RiskImminentEvents/Gdacs/EventDetails/i18n.json
@@ -3,7 +3,7 @@
     "strings": {
         "eventStartOnLabel": "Started on",
         "eventMoreDetailsLink": "More Details",
-        "eventSourceLabel": "Source",
+        "eventSourceLabel": "Forecast provider",
         "eventDeathLabel": "Estimated deaths",
         "eventDisplacedLabel": "Estimated number of people displaced",
         "eventPopulationLabel": "Population exposed",


### PR DESCRIPTION
## Addresses:
- https://github.com/IFRCGo/go-web-app/issues/1265 review fixes (based on Justin and Mariam's review on 30.10.2024)

## Changes
- Update labels for Risk Map

## This PR doesn't introduce:
- [x] typos
- [x] conflict markers
- [x] unwanted comments
- [x] temporary files, auto-generated files or secret keys
- [x] `console.log` meant for debugging
- [x] codegen errors
