### PR TITLE
Fix nginx template config env variable for nginx-serve

### DIFF
--- a/nginx-serve/nginx.conf.template
+++ b/nginx-serve/nginx.conf.template
@@ -12,7 +12,7 @@ server {
         application/xml+rss text/javascript;
 
     location / {
-        alias $DESTINATION_DIRECTORY;
+        alias $APPLY_CONFIG__DESTINATION_DIRECTORY;
         try_files $uri /index.html;
     }
 }


### PR DESCRIPTION
## Addresses:
- nginx config template issue from https://github.com/IFRCGo/go-web-app/pull/1447

## Changes
- Fix nginx config environment variable name

## This PR doesn't introduce:
- [x] typos
- [x] conflict markers
- [x] unwanted comments
- [x] temporary files, auto-generated files or secret keys
- [x] `console.log` meant for debugging
- [x] codegen errors