### PR TITLE
[Hotfix 1] - Hide WFPAdam in RiskWatch on production

### DIFF
--- a/.changeset/swift-humans-occur.md
+++ b/.changeset/swift-humans-occur.md
@@ -1,0 +1,8 @@
+---
+"go-web-app": patch
+---
+
+Update Imminent Events
+
+- Hide WFP ADAM temporarily from list sources
+- Show exposure control for cyclones from GDACS only

--- a/.changeset/swift-humans-occur.md
+++ b/.changeset/swift-humans-occur.md
@@ -1,8 +1,0 @@
----
-"go-web-app": patch
----
-
-Update Imminent Events
-
-- Hide WFP ADAM temporarily from list sources
-- Show exposure control for cyclones from GDACS only

--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -1,5 +1,14 @@
 # go-web-app
 
+## 7.6.4
+
+### Patch Changes
+
+- d85f64d: Update Imminent Events
+
+  - Hide WFP ADAM temporarily from list sources
+  - Show exposure control for cyclones from GDACS only
+
 ## 7.6.3
 
 ### Patch Changes

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
     "name": "go-web-app",
-    "version": "7.6.3",
+    "version": "7.6.4",
     "type": "module",
     "private": true,
     "license": "MIT",

--- a/app/src/components/domain/RiskImminentEventMap/LayerOptions/index.tsx
+++ b/app/src/components/domain/RiskImminentEventMap/LayerOptions/index.tsx
@@ -43,10 +43,13 @@ function colorSelector(item: SeverityLegendItem) {
 interface Props {
     value: LayerOptionsValue;
     onChange: React.Dispatch<React.SetStateAction<LayerOptionsValue>>;
+
+    exposureAreaControlHidden?: boolean;
 }
 
 function LayerOptions(props: Props) {
     const {
+        exposureAreaControlHidden,
         value,
         onChange,
     } = props;
@@ -92,28 +95,30 @@ function LayerOptions(props: Props) {
                 withBackground
                 withInvertedView
             />
-            <div className={styles.exposedAreaInputWrapper}>
-                <Switch
-                    // FIXME: use strings
-                    label="Exposed area to tropical storm or cyclone strength wind"
-                    name="showExposedArea"
-                    value={value.showExposedArea}
-                    onChange={setFieldValue}
-                    withInvertedView
-                />
-                {value.showExposedArea && (
-                    <Legend
-                        className={styles.exposedAreaLegend}
+            {!exposureAreaControlHidden && (
+                <div className={styles.exposedAreaInputWrapper}>
+                    <Switch
                         // FIXME: use strings
-                        label="Severity:"
-                        items={severityLegendItems}
-                        keySelector={severitySelector}
-                        labelSelector={labelSelector}
-                        colorSelector={colorSelector}
-                        labelClassName={styles.legendLabel}
+                        label="Exposed area to tropical storm or cyclone strength wind"
+                        name="showExposedArea"
+                        value={value.showExposedArea}
+                        onChange={setFieldValue}
+                        withInvertedView
                     />
-                )}
-            </div>
+                    {value.showExposedArea && (
+                        <Legend
+                            className={styles.exposedAreaLegend}
+                            // FIXME: use strings
+                            label="Severity:"
+                            items={severityLegendItems}
+                            keySelector={severitySelector}
+                            labelSelector={labelSelector}
+                            colorSelector={colorSelector}
+                            labelClassName={styles.legendLabel}
+                        />
+                    )}
+                </div>
+            )}
             <Switch
                 // FIXME: use strings
                 label="Storm track"

--- a/app/src/components/domain/RiskImminentEventMap/index.tsx
+++ b/app/src/components/domain/RiskImminentEventMap/index.tsx
@@ -99,7 +99,11 @@ export interface RiskEventDetailProps<EVENT, EXPOSURE> {
 
 type Footprint = GeoJSON.FeatureCollection<GeoJSON.Geometry, RiskLayerProperties> | undefined;
 
+// FIXME: read this from common type
+export type ImminentEventSource = 'pdc' | 'wfpAdam' | 'gdacs' | 'meteoSwiss';
+
 interface Props<EVENT, EXPOSURE, KEY extends string | number> {
+    source: ImminentEventSource;
     events: EVENT[] | undefined;
     keySelector: (event: EVENT) => KEY;
     hazardTypeSelector: (event: EVENT) => HazardType | '' | undefined;
@@ -134,6 +138,7 @@ function RiskImminentEventMap<
         bbox,
         onActiveEventChange,
         activeEventExposurePending,
+        source,
     } = props;
 
     const strings = useTranslation(i18n);
@@ -473,6 +478,8 @@ function RiskImminentEventMap<
                         {hazardTypeSelector(activeEvent) === 'TC' && (
                             <LayerOptions
                                 value={layerOptions}
+                                // NOTE: Currently the information is only visible in gdacas
+                                exposureAreaControlHidden={source !== 'gdacs'}
                                 onChange={setLayerOptions}
                             />
                         )}

--- a/app/src/components/domain/RiskImminentEvents/Gdacs/index.tsx
+++ b/app/src/components/domain/RiskImminentEvents/Gdacs/index.tsx
@@ -265,6 +265,7 @@ function Gdacs(props: Props) {
 
     return (
         <RiskImminentEventMap
+            source="gdacs"
             events={countryRiskResponse?.results}
             pointFeatureSelector={pointFeatureSelector}
             keySelector={numericIdSelector}

--- a/app/src/components/domain/RiskImminentEvents/MeteoSwiss/index.tsx
+++ b/app/src/components/domain/RiskImminentEvents/MeteoSwiss/index.tsx
@@ -209,6 +209,7 @@ function MeteoSwiss(props: Props) {
 
     return (
         <RiskImminentEventMap
+            source="meteoSwiss"
             events={countryRiskResponse?.results}
             pointFeatureSelector={pointFeatureSelector}
             keySelector={numericIdSelector}

--- a/app/src/components/domain/RiskImminentEvents/Pdc/index.tsx
+++ b/app/src/components/domain/RiskImminentEvents/Pdc/index.tsx
@@ -246,6 +246,7 @@ function Pdc(props: Props) {
 
     return (
         <RiskImminentEventMap
+            source="pdc"
             events={countryRiskResponse?.results}
             pointFeatureSelector={pointFeatureSelector}
             keySelector={numericIdSelector}

--- a/app/src/components/domain/RiskImminentEvents/WfpAdam/index.tsx
+++ b/app/src/components/domain/RiskImminentEvents/WfpAdam/index.tsx
@@ -216,6 +216,7 @@ function WfpAdam(props: Props) {
 
     return (
         <RiskImminentEventMap
+            source="wfpAdam"
             events={countryRiskResponse?.results}
             pointFeatureSelector={pointFeatureSelector}
             keySelector={numericIdSelector}

--- a/app/src/components/domain/RiskImminentEvents/index.tsx
+++ b/app/src/components/domain/RiskImminentEvents/index.tsx
@@ -195,33 +195,35 @@ function RiskImminentEvents(props: Props) {
                             />
                         )}
                     />
-                    <Radio
-                        name="wfpAdam"
-                        value={activeView === 'wfpAdam'}
-                        onClick={handleRadioClick}
-                        label={strings.imminentEventsSourceWfpAdamLabel}
-                        actions={(
-                            <InfoPopup
-                                title={strings.wfpAdamTitle}
-                                popupClassName={styles.popup}
-                                descriptionClassName={styles.description}
-                                description={resolveToComponent(
-                                    strings.wfpAdamDescription,
-                                    {
-                                        here: (
-                                            <Link
-                                                href="https://gis.wfp.org/adam/"
-                                                variant="tertiary"
-                                                external
-                                            >
-                                                {strings.here}
-                                            </Link>
-                                        ),
-                                    },
-                                )}
-                            />
-                        )}
-                    />
+                    {environment !== 'production' && (
+                        <Radio
+                            name="wfpAdam"
+                            value={activeView === 'wfpAdam'}
+                            onClick={handleRadioClick}
+                            label={strings.imminentEventsSourceWfpAdamLabel}
+                            actions={(
+                                <InfoPopup
+                                    title={strings.wfpAdamTitle}
+                                    popupClassName={styles.popup}
+                                    descriptionClassName={styles.description}
+                                    description={resolveToComponent(
+                                        strings.wfpAdamDescription,
+                                        {
+                                            here: (
+                                                <Link
+                                                    href="https://gis.wfp.org/adam/"
+                                                    variant="tertiary"
+                                                    external
+                                                >
+                                                    {strings.here}
+                                                </Link>
+                                            ),
+                                        },
+                                    )}
+                                />
+                            )}
+                        />
+                    )}
                     <Radio
                         name="gdacs"
                         value={activeView === 'gdacs'}


### PR DESCRIPTION
## Important

This is a hotfix branch, do not merge this!!!

## Addresses:

No existing issue.

## Changes
- Show exposure control only for GDACs source
- Hide WFP Adman in Risk Watch Imminent page (on production)

## This PR doesn't introduce:
- [x] typos
- [x] conflict markers
- [x] unwanted comments
- [x] temporary files, auto-generated files or secret keys
- [x] `console.log` meant for debugging
- [x] codegen errors
