### PR TITLE
[Hotfix 2] - Fix issues on dref import and imminent risk map

### DIFF
--- a/.changeset/cool-eggs-judge.md
+++ b/.changeset/cool-eggs-judge.md
@@ -1,0 +1,8 @@
+---
+"go-web-app": patch
+---
+
+Update labels for severity control in Imminent Risk Map.
+Update navigation for the events in Imminent Risk Map.
+Fix issue displayed when opening a DREF import template.
+Fix submission issue when importing a DREF import file.

--- a/app/scripts/translatte/main.ts
+++ b/app/scripts/translatte/main.ts
@@ -112,7 +112,6 @@ yargs(hideBin(process.argv))
             });
         },
         async (argv) => {
-            console.warn(argv);
             await applyMigrations(
                 currentDir,
                 argv.SOURCE_FILE as string,

--- a/app/src/components/domain/RiskImminentEventMap/LayerOptions/index.tsx
+++ b/app/src/components/domain/RiskImminentEventMap/LayerOptions/index.tsx
@@ -57,20 +57,22 @@ function LayerOptions(props: Props) {
     const setFieldValue = useSetFieldValue(onChange);
 
     // FIXME: use strings
+    // FIXME: These are hard-coded for Gdacs source.
+    // Currently we are only showing severity control for Gdacs
     const severityLegendItems = useMemo<SeverityLegendItem[]>(() => ([
         {
             severity: 'green',
-            label: 'Green',
+            label: '60 km/h',
             color: COLOR_GREEN,
         },
         {
             severity: 'orange',
-            label: 'Orange',
+            label: '90 km/h',
             color: COLOR_ORANGE,
         },
         {
             severity: 'red',
-            label: 'Red',
+            label: '120 km/h',
             color: COLOR_RED,
         },
         {

--- a/app/src/components/domain/RiskImminentEventMap/i18n.json
+++ b/app/src/components/domain/RiskImminentEventMap/i18n.json
@@ -2,7 +2,6 @@
     "namespace": "common",
     "strings": {
         "riskImminentEventsMap": "Risk Imminent Events Map",
-        "backToEventsLabel": "Back to events",
         "emptyImminentEventMessage": "No imminent event forecasted"
     }
 }

--- a/app/src/components/domain/RiskImminentEventMap/index.tsx
+++ b/app/src/components/domain/RiskImminentEventMap/index.tsx
@@ -3,9 +3,7 @@ import {
     useMemo,
     useState,
 } from 'react';
-import { ChevronLeftLineIcon } from '@ifrc-go/icons';
 import {
-    Button,
     Container,
     List,
 } from '@ifrc-go/ui';
@@ -86,8 +84,10 @@ export type EventPointFeature = GeoJSON.Feature<GeoJSON.Point, EventPointPropert
 
 export interface RiskEventListItemProps<EVENT> {
     data: EVENT;
+    expanded: boolean;
     onExpandClick: (eventId: number | string) => void;
     className?: string;
+    children?: React.ReactNode;
 }
 
 export interface RiskEventDetailProps<EVENT, EXPOSURE> {
@@ -243,10 +243,15 @@ function RiskImminentEventMap<
         (eventId: string | number | undefined) => {
             const eventIdSafe = eventId as KEY | undefined;
 
-            setActiveEventId(eventIdSafe);
-            onActiveEventChange(eventIdSafe);
+            if (activeEventId === eventIdSafe) {
+                setActiveEventId(undefined);
+                onActiveEventChange(undefined);
+            } else {
+                setActiveEventId(eventIdSafe);
+                onActiveEventChange(eventIdSafe);
+            }
         },
-        [onActiveEventChange],
+        [onActiveEventChange, activeEventId],
     );
 
     const handlePointClick = useCallback(
@@ -258,16 +263,43 @@ function RiskImminentEventMap<
         [setActiveEventIdSafe],
     );
 
+    const DetailComponent = detailRenderer;
+
     const eventListRendererParams = useCallback(
         (_: string | number, event: EVENT): RiskEventListItemProps<EVENT> => ({
             data: event,
             onExpandClick: setActiveEventIdSafe,
+            expanded: activeEventId === keySelector(event),
             className: styles.riskEventListItem,
+            children: activeEventId === keySelector(event) && (
+                <DetailComponent
+                    data={event}
+                    exposure={activeEventExposure}
+                    pending={activeEventExposurePending}
+                >
+                    {hazardTypeSelector(event) === 'TC' && (
+                        <LayerOptions
+                            value={layerOptions}
+                            // NOTE: Currently the information is only visible in gdacas
+                            exposureAreaControlHidden={source !== 'gdacs'}
+                            onChange={setLayerOptions}
+                        />
+                    )}
+                </DetailComponent>
+            ),
         }),
-        [setActiveEventIdSafe],
+        [
+            setActiveEventIdSafe,
+            activeEventExposure,
+            activeEventExposurePending,
+            layerOptions,
+            hazardTypeSelector,
+            DetailComponent,
+            activeEventId,
+            keySelector,
+            source,
+        ],
     );
-
-    const DetailComponent = detailRenderer;
 
     const [loadedIcons, setLoadedIcons] = useState<Record<string, boolean>>({});
 
@@ -443,48 +475,18 @@ function RiskImminentEventMap<
                 withInternalPadding
                 childrenContainerClassName={styles.content}
                 spacing="cozy"
-                actions={isDefined(activeEventId) && (
-                    <Button
-                        name={undefined}
-                        onClick={setActiveEventIdSafe}
-                        variant="tertiary"
-                        icons={(
-                            <ChevronLeftLineIcon className={styles.icon} />
-                        )}
-                    >
-                        {strings.backToEventsLabel}
-                    </Button>
-                )}
             >
-                {isNotDefined(activeEventId) && (
-                    <List
-                        className={styles.eventList}
-                        filtered={false}
-                        pending={pending}
-                        errored={false}
-                        data={events}
-                        keySelector={keySelector}
-                        renderer={listItemRenderer}
-                        rendererParams={eventListRendererParams}
-                        emptyMessage={strings.emptyImminentEventMessage}
-                    />
-                )}
-                {isDefined(activeEvent) && (
-                    <DetailComponent
-                        data={activeEvent}
-                        exposure={activeEventExposure}
-                        pending={activeEventExposurePending}
-                    >
-                        {hazardTypeSelector(activeEvent) === 'TC' && (
-                            <LayerOptions
-                                value={layerOptions}
-                                // NOTE: Currently the information is only visible in gdacas
-                                exposureAreaControlHidden={source !== 'gdacs'}
-                                onChange={setLayerOptions}
-                            />
-                        )}
-                    </DetailComponent>
-                )}
+                <List
+                    className={styles.eventList}
+                    filtered={false}
+                    pending={pending}
+                    errored={false}
+                    data={events}
+                    keySelector={keySelector}
+                    renderer={listItemRenderer}
+                    rendererParams={eventListRendererParams}
+                    emptyMessage={strings.emptyImminentEventMessage}
+                />
             </Container>
         </div>
     );

--- a/app/src/components/domain/RiskImminentEvents/Gdacs/EventDetails/i18n.json
+++ b/app/src/components/domain/RiskImminentEvents/Gdacs/EventDetails/i18n.json
@@ -1,7 +1,6 @@
 {
     "namespace": "common",
     "strings": {
-        "eventStartOnLabel": "Started on",
         "eventMoreDetailsLink": "More Details",
         "eventSourceLabel": "Forecast provider",
         "eventDeathLabel": "Estimated deaths",

--- a/app/src/components/domain/RiskImminentEvents/Gdacs/EventDetails/index.tsx
+++ b/app/src/components/domain/RiskImminentEvents/Gdacs/EventDetails/index.tsx
@@ -70,8 +70,6 @@ type Props = RiskEventDetailProps<GdacsItem, GdacsExposure | undefined>;
 function EventDetails(props: Props) {
     const {
         data: {
-            hazard_name,
-            start_date,
             event_details,
         },
         exposure,
@@ -87,16 +85,7 @@ function EventDetails(props: Props) {
     return (
         <Container
             contentViewType="vertical"
-            heading={hazard_name}
-            headingLevel={5}
             spacing="cozy"
-            headerDescription={(
-                <TextOutput
-                    label={strings.eventStartOnLabel}
-                    value={start_date}
-                    valueType="date"
-                />
-            )}
             withBorderAndHeaderBackground
             pending={pending}
         >

--- a/app/src/components/domain/RiskImminentEvents/Gdacs/EventListItem/i18n.json
+++ b/app/src/components/domain/RiskImminentEvents/Gdacs/EventListItem/i18n.json
@@ -1,7 +1,7 @@
 {
     "namespace": "common",
     "strings": {
-        "gdacsEventViewDetails": "View Details",
+        "gdacsEventViewDetails": "View / Hide Details",
         "gdacsEventStartedOn": "Started On"
     }
 }

--- a/app/src/components/domain/RiskImminentEvents/Gdacs/EventListItem/index.tsx
+++ b/app/src/components/domain/RiskImminentEvents/Gdacs/EventListItem/index.tsx
@@ -1,4 +1,11 @@
-import { ChevronRightLineIcon } from '@ifrc-go/icons';
+import {
+    useEffect,
+    useRef,
+} from 'react';
+import {
+    ChevronDownLineIcon,
+    ChevronUpLineIcon,
+} from '@ifrc-go/icons';
 import {
     Button,
     Header,
@@ -25,35 +32,62 @@ function EventListItem(props: Props) {
             hazard_name,
             start_date,
         },
+        expanded,
         onExpandClick,
         className,
+        children,
     } = props;
 
     const strings = useTranslation(i18n);
 
+    const elementRef = useRef<HTMLDivElement>(null);
+
+    useEffect(
+        () => {
+            if (expanded && elementRef.current) {
+                const y = window.scrollY;
+                const x = window.scrollX;
+                elementRef.current.scrollIntoView({
+                    behavior: 'instant',
+                    block: 'start',
+                });
+                // NOTE: We need to scroll back because scrollIntoView also
+                // scrolls the parent container
+                window.scroll(x, y);
+            }
+        },
+        [expanded],
+    );
+
     return (
-        <Header
-            className={_cs(styles.eventListItem, className)}
-            heading={hazard_name ?? '--'}
-            headingLevel={5}
-            actions={(
-                <Button
-                    name={id}
-                    onClick={onExpandClick}
-                    variant="tertiary"
-                    title={strings.gdacsEventViewDetails}
-                >
-                    <ChevronRightLineIcon className={styles.icon} />
-                </Button>
-            )}
-            spacing="cozy"
-        >
-            <TextOutput
-                label={strings.gdacsEventStartedOn}
-                value={start_date}
-                valueType="date"
-            />
-        </Header>
+        <>
+            <Header
+                elementRef={elementRef}
+                className={_cs(styles.eventListItem, className)}
+                heading={hazard_name ?? '--'}
+                headingLevel={5}
+                actions={(
+                    <Button
+                        name={id}
+                        onClick={onExpandClick}
+                        variant="tertiary"
+                        title={strings.gdacsEventViewDetails}
+                    >
+                        {expanded
+                            ? <ChevronUpLineIcon className={styles.icon} />
+                            : <ChevronDownLineIcon className={styles.icon} />}
+                    </Button>
+                )}
+                spacing="cozy"
+            >
+                <TextOutput
+                    label={strings.gdacsEventStartedOn}
+                    value={start_date}
+                    valueType="date"
+                />
+            </Header>
+            {children}
+        </>
     );
 }
 

--- a/app/src/components/domain/RiskImminentEvents/MeteoSwiss/EventDetails/i18n.json
+++ b/app/src/components/domain/RiskImminentEvents/MeteoSwiss/EventDetails/i18n.json
@@ -9,8 +9,6 @@
         "meteoSwissAuthoritativeMessage": "Please also consider {link} and classification of {classificationLink}.",
         "meteoSwissAuthoritativeLinkLabel": "authoritative information about the hazard",
         "meteoSwissTropicalStorm": "tropical storm",
-        "meteoSwissEventDetailsStartedOnLabel": "Started on",
-        "meteoSwissEventDetailsUpdatedAtLabel": "Updated at",
         "meteoSwissHazardName": "{hazardType} - {hazardName}",
         "meteoSwissImpactValue": "{value} ({fivePercent} - {ninetyFivePercent}) {unit}",
         "beta": "beta",

--- a/app/src/components/domain/RiskImminentEvents/MeteoSwiss/EventDetails/index.tsx
+++ b/app/src/components/domain/RiskImminentEvents/MeteoSwiss/EventDetails/index.tsx
@@ -41,8 +41,6 @@ interface Props {
 function EventDetails(props: Props) {
     const {
         data: {
-            // id,
-            hazard_type_display,
             country_details,
             start_date,
             updated_at,
@@ -54,14 +52,6 @@ function EventDetails(props: Props) {
     } = props;
 
     const strings = useTranslation(i18n);
-
-    const hazardName = resolveToString(
-        strings.meteoSwissHazardName,
-        {
-            hazardType: hazard_type_display,
-            hazardName: country_details?.name ?? hazard_name,
-        },
-    );
 
     const getSaffirSimpsonScaleDescription = useCallback((windspeed: number) => {
         if (windspeed < 33) {
@@ -179,25 +169,6 @@ function EventDetails(props: Props) {
         <Container
             className={styles.eventDetails}
             childrenContainerClassName={styles.content}
-            heading={hazardName}
-            headingLevel={4}
-            headerDescription={(
-                <>
-                    <TextOutput
-                        label={strings.meteoSwissEventDetailsStartedOnLabel}
-                        value={start_date}
-                        valueType="date"
-                        strongValue
-                    />
-                    <TextOutput
-                        label={strings.meteoSwissEventDetailsUpdatedAtLabel}
-                        value={updated_at}
-                        valueType="date"
-                        format={UPDATED_AT_FORMAT}
-                        strongValue
-                    />
-                </>
-            )}
             contentViewType="vertical"
         >
             {pending && <BlockLoading />}

--- a/app/src/components/domain/RiskImminentEvents/MeteoSwiss/EventListItem/i18n.json
+++ b/app/src/components/domain/RiskImminentEvents/MeteoSwiss/EventListItem/i18n.json
@@ -1,7 +1,7 @@
 {
     "namespace": "common",
     "strings": {
-        "meteoSwissEventListViewDetails": "View Details",
+        "meteoSwissEventListViewDetails": "View / Hide Details",
         "meteoSwissEventListStartedOn": "Started On"
     }
 }

--- a/app/src/components/domain/RiskImminentEvents/MeteoSwiss/EventListItem/index.tsx
+++ b/app/src/components/domain/RiskImminentEvents/MeteoSwiss/EventListItem/index.tsx
@@ -1,4 +1,11 @@
-import { ChevronRightLineIcon } from '@ifrc-go/icons';
+import {
+    useEffect,
+    useRef,
+} from 'react';
+import {
+    ChevronDownLineIcon,
+    ChevronUpLineIcon,
+} from '@ifrc-go/icons';
 import {
     Button,
     Header,
@@ -27,37 +34,64 @@ function EventListItem(props: Props) {
             start_date,
             hazard_name,
         },
+        expanded,
         onExpandClick,
         className,
+        children,
     } = props;
 
     const strings = useTranslation(i18n);
 
     const hazardName = `${hazard_type_display} - ${country_details?.name ?? hazard_name}`;
 
+    const elementRef = useRef<HTMLDivElement>(null);
+
+    useEffect(
+        () => {
+            if (expanded && elementRef.current) {
+                const y = window.scrollY;
+                const x = window.scrollX;
+                elementRef.current.scrollIntoView({
+                    behavior: 'instant',
+                    block: 'start',
+                });
+                // NOTE: We need to scroll back because scrollIntoView also
+                // scrolls the parent container
+                window.scroll(x, y);
+            }
+        },
+        [expanded],
+    );
+
     return (
-        <Header
-            className={_cs(styles.eventListItem, className)}
-            heading={hazardName ?? '--'}
-            headingLevel={5}
-            actions={(
-                <Button
-                    name={id}
-                    onClick={onExpandClick}
-                    variant="tertiary"
-                    title={strings.meteoSwissEventListViewDetails}
-                >
-                    <ChevronRightLineIcon className={styles.icon} />
-                </Button>
-            )}
-            spacing="condensed"
-        >
-            <TextOutput
-                label={strings.meteoSwissEventListStartedOn}
-                value={start_date}
-                valueType="date"
-            />
-        </Header>
+        <>
+            <Header
+                elementRef={elementRef}
+                className={_cs(styles.eventListItem, className)}
+                heading={hazardName ?? '--'}
+                headingLevel={5}
+                actions={(
+                    <Button
+                        name={id}
+                        onClick={onExpandClick}
+                        variant="tertiary"
+                        title={strings.meteoSwissEventListViewDetails}
+                    >
+                        {expanded
+                            ? <ChevronUpLineIcon className={styles.icon} />
+                            : <ChevronDownLineIcon className={styles.icon} />}
+                    </Button>
+                )}
+                spacing="condensed"
+            >
+                <TextOutput
+                    label={strings.meteoSwissEventListStartedOn}
+                    value={start_date}
+                    valueType="date"
+                />
+            </Header>
+            {children}
+        </>
     );
 }
 

--- a/app/src/components/domain/RiskImminentEvents/Pdc/EventDetails/i18n.json
+++ b/app/src/components/domain/RiskImminentEvents/Pdc/EventDetails/i18n.json
@@ -1,7 +1,6 @@
 {
     "namespace": "common",
     "strings": {
-        "eventDetailsStartedOn": "Started on",
         "eventDetailsCreatedOn": "Created on",
         "eventDetailsUpdatedOn": "Updated on",
         "eventDetailsPeopleExposed": "People exposed / Potentially affected",

--- a/app/src/components/domain/RiskImminentEvents/Pdc/EventDetails/index.tsx
+++ b/app/src/components/domain/RiskImminentEvents/Pdc/EventDetails/index.tsx
@@ -18,8 +18,6 @@ type Props = RiskEventDetailProps<PdcEventItem, PdcExposure | undefined>;
 function EventDetails(props: Props) {
     const {
         data: {
-            hazard_name,
-            start_date,
             pdc_created_at,
             pdc_updated_at,
             description,
@@ -53,16 +51,7 @@ function EventDetails(props: Props) {
     return (
         <Container
             contentViewType="vertical"
-            heading={hazard_name}
-            headingLevel={5}
             spacing="cozy"
-            headerDescription={(
-                <TextOutput
-                    label={strings.eventDetailsStartedOn}
-                    value={start_date}
-                    valueType="date"
-                />
-            )}
             withBorderAndHeaderBackground
             pending={pending}
         >

--- a/app/src/components/domain/RiskImminentEvents/Pdc/EventListItem/i18n.json
+++ b/app/src/components/domain/RiskImminentEvents/Pdc/EventListItem/i18n.json
@@ -1,7 +1,7 @@
 {
     "namespace": "common",
     "strings": {
-        "eventListViewDetails": "View Details",
+        "eventListViewDetails": "View / Hide Details",
         "eventListStartedOn": "Started on"
     }
 }

--- a/app/src/components/domain/RiskImminentEvents/Pdc/EventListItem/index.tsx
+++ b/app/src/components/domain/RiskImminentEvents/Pdc/EventListItem/index.tsx
@@ -1,4 +1,11 @@
-import { ChevronRightLineIcon } from '@ifrc-go/icons';
+import {
+    useEffect,
+    useRef,
+} from 'react';
+import {
+    ChevronDownLineIcon,
+    ChevronUpLineIcon,
+} from '@ifrc-go/icons';
 import {
     Button,
     Header,
@@ -25,35 +32,62 @@ function EventListItem(props: Props) {
             hazard_name,
             start_date,
         },
+        expanded,
         onExpandClick,
         className,
+        children,
     } = props;
 
     const strings = useTranslation(i18n);
 
+    const elementRef = useRef<HTMLDivElement>(null);
+
+    useEffect(
+        () => {
+            if (expanded && elementRef.current) {
+                const y = window.scrollY;
+                const x = window.scrollX;
+                elementRef.current.scrollIntoView({
+                    behavior: 'instant',
+                    block: 'start',
+                });
+                // NOTE: We need to scroll back because scrollIntoView also
+                // scrolls the parent container
+                window.scroll(x, y);
+            }
+        },
+        [expanded],
+    );
+
     return (
-        <Header
-            className={_cs(styles.eventListItem, className)}
-            heading={hazard_name ?? '--'}
-            headingLevel={5}
-            actions={(
-                <Button
-                    name={id}
-                    onClick={onExpandClick}
-                    variant="tertiary"
-                    title={strings.eventListViewDetails}
-                >
-                    <ChevronRightLineIcon className={styles.icon} />
-                </Button>
-            )}
-            spacing="cozy"
-        >
-            <TextOutput
-                label={strings.eventListStartedOn}
-                value={start_date}
-                valueType="date"
-            />
-        </Header>
+        <>
+            <Header
+                elementRef={elementRef}
+                className={_cs(styles.eventListItem, className)}
+                heading={hazard_name ?? '--'}
+                headingLevel={5}
+                actions={(
+                    <Button
+                        name={id}
+                        onClick={onExpandClick}
+                        variant="tertiary"
+                        title={strings.eventListViewDetails}
+                    >
+                        {expanded
+                            ? <ChevronUpLineIcon className={styles.icon} />
+                            : <ChevronDownLineIcon className={styles.icon} />}
+                    </Button>
+                )}
+                spacing="cozy"
+            >
+                <TextOutput
+                    label={strings.eventListStartedOn}
+                    value={start_date}
+                    valueType="date"
+                />
+            </Header>
+            {children}
+        </>
     );
 }
 

--- a/app/src/components/domain/RiskImminentEvents/WfpAdam/EventDetails/i18n.json
+++ b/app/src/components/domain/RiskImminentEvents/WfpAdam/EventDetails/i18n.json
@@ -1,7 +1,6 @@
 {
     "namespace": "common",
     "strings": {
-        "wfpEventDetailsPublishedOn": "Published on",
         "wfpEventDetailsKm": "{point} Km/h on {pointDate}",
         "wfpUsefulLinks": "Useful Links:",
         "wfpDashboard": "Dashboard",

--- a/app/src/components/domain/RiskImminentEvents/WfpAdam/EventDetails/index.tsx
+++ b/app/src/components/domain/RiskImminentEvents/WfpAdam/EventDetails/index.tsx
@@ -84,8 +84,6 @@ type Props = RiskEventDetailProps<WfpAdamItem, WfpAdamExposure | undefined>;
 function EventDetails(props: Props) {
     const {
         data: {
-            title,
-            publish_date,
             event_details,
         },
         exposure,
@@ -162,17 +160,7 @@ function EventDetails(props: Props) {
             className={styles.eventDetails}
             contentViewType="vertical"
             childrenContainerClassName={styles.content}
-            heading={title}
-            headingLevel={5}
             spacing="cozy"
-            headerDescription={(
-                <TextOutput
-                    label={strings.wfpEventDetailsPublishedOn}
-                    value={publish_date}
-                    valueType="date"
-                    strongValue
-                />
-            )}
             pending={pending}
         >
             {stormPoints && stormPoints.length > 0 && isDefined(maxWindSpeed) && (

--- a/app/src/components/domain/RiskImminentEvents/WfpAdam/EventListItem/i18n.json
+++ b/app/src/components/domain/RiskImminentEvents/WfpAdam/EventListItem/i18n.json
@@ -1,7 +1,7 @@
 {
     "namespace": "common",
     "strings": {
-        "wfpEventListViewDetails": "View Details",
+        "wfpEventListViewDetails": "View / Hide Details",
         "wfpEventListPublishedOn": "Published on"
     }
 }

--- a/app/src/components/domain/RiskImminentEvents/WfpAdam/EventListItem/index.tsx
+++ b/app/src/components/domain/RiskImminentEvents/WfpAdam/EventListItem/index.tsx
@@ -1,4 +1,11 @@
-import { ChevronRightLineIcon } from '@ifrc-go/icons';
+import {
+    useEffect,
+    useRef,
+} from 'react';
+import {
+    ChevronDownLineIcon,
+    ChevronUpLineIcon,
+} from '@ifrc-go/icons';
 import {
     Button,
     Header,
@@ -25,35 +32,62 @@ function EventListItem(props: Props) {
             publish_date,
             title,
         },
+        expanded,
         onExpandClick,
         className,
+        children,
     } = props;
 
     const strings = useTranslation(i18n);
 
+    const elementRef = useRef<HTMLDivElement>(null);
+
+    useEffect(
+        () => {
+            if (expanded && elementRef.current) {
+                const y = window.scrollY;
+                const x = window.scrollX;
+                elementRef.current.scrollIntoView({
+                    behavior: 'instant',
+                    block: 'start',
+                });
+                // NOTE: We need to scroll back because scrollIntoView also
+                // scrolls the parent container
+                window.scroll(x, y);
+            }
+        },
+        [expanded],
+    );
+
     return (
-        <Header
-            className={_cs(styles.eventListItem, className)}
-            heading={title ?? '--'}
-            headingLevel={5}
-            actions={(
-                <Button
-                    name={id}
-                    onClick={onExpandClick}
-                    variant="tertiary"
-                    title={strings.wfpEventListViewDetails}
-                >
-                    <ChevronRightLineIcon className={styles.icon} />
-                </Button>
-            )}
-            spacing="cozy"
-        >
-            <TextOutput
-                label={strings.wfpEventListPublishedOn}
-                value={publish_date}
-                valueType="date"
-            />
-        </Header>
+        <>
+            <Header
+                elementRef={elementRef}
+                className={_cs(styles.eventListItem, className)}
+                heading={title ?? '--'}
+                headingLevel={5}
+                actions={(
+                    <Button
+                        name={id}
+                        onClick={onExpandClick}
+                        variant="tertiary"
+                        title={strings.wfpEventListViewDetails}
+                    >
+                        {expanded
+                            ? <ChevronUpLineIcon className={styles.icon} />
+                            : <ChevronDownLineIcon className={styles.icon} />}
+                    </Button>
+                )}
+                spacing="cozy"
+            >
+                <TextOutput
+                    label={strings.wfpEventListPublishedOn}
+                    value={publish_date}
+                    valueType="date"
+                />
+            </Header>
+            {children}
+        </>
     );
 }
 

--- a/app/src/utils/importTemplate.ts
+++ b/app/src/utils/importTemplate.ts
@@ -300,7 +300,7 @@ export function createImportTemplate<
 }
 
 function addClientId(item: object): object {
-    return { ...item, clientId: randomString() };
+    return { ...item, client_id: randomString() };
 }
 
 export function getValueFromImportTemplate<
@@ -311,7 +311,7 @@ export function getValueFromImportTemplate<
     optionsMap: OPTIONS_MAPPING,
     formValues: Record<string, string | number | boolean>,
     fieldName: string | undefined = undefined,
-    transformListObject: (item: object) => object = addClientId,
+    transformListObject: ((item: object) => object) = addClientId,
 ): unknown {
     const optionsReverseMap = mapToMap(
         optionsMap,
@@ -374,7 +374,7 @@ export function getValueFromImportTemplate<
             if (schema.keyFieldName) {
                 return {
                     [schema.keyFieldName]: option.key,
-                    ...value,
+                    ...transformListObject(value),
                 };
             }
             return transformListObject(value);

--- a/app/src/utils/richText.ts
+++ b/app/src/utils/richText.ts
@@ -102,9 +102,11 @@ export function parsePseudoHtml(
                 (acc, plugin) => plugin.transformer(token, acc),
                 { text: token },
             );
+        if (richTextItem.text === '') {
+            return undefined;
+        }
         return richTextItem;
     }).filter(isDefined);
 
-    // TODO: Check correctness to check that stack is empty
     return { richText };
 }

--- a/app/src/views/AccountMyFormsDref/DownloadImportTemplateButton/DownloadImportTemplateModal/useImportTemplateSchema.ts
+++ b/app/src/views/AccountMyFormsDref/DownloadImportTemplateButton/DownloadImportTemplateModal/useImportTemplateSchema.ts
@@ -234,7 +234,7 @@ function useImportTemplateSchema() {
                 optionsKey: '__boolean',
                 validation: 'boolean',
                 description: (
-                    'Indicate only if there was a similar event affecting the same area in the last 3 years.\n'
+                    'Indicate only if it affected the same population groups\n'
                     + 'Otherwise, leave the box empty.'
                 ),
             },
@@ -245,7 +245,7 @@ function useImportTemplateSchema() {
                 optionsKey: '__boolean',
                 validation: 'boolean',
                 description: (
-                    'Indicate only if there was a similar event affecting the same area in the last 3 years.\n'
+                    'Indicate only if the national society responded\n'
                     + 'Otherwise, leave the box empty.'
                 ),
             },
@@ -255,7 +255,7 @@ function useImportTemplateSchema() {
                 label: '<i>If yes, please specify which operations</i>',
                 validation: 'string',
                 description: (
-                    'Indicate only if there was a similar event affecting the same area in the last 3 years.\n'
+                    'Indicate only if the national society requested funding from DREF for that event(s).\n'
                     + 'Otherwise, leave the box empty.'
                 ),
             },
@@ -462,6 +462,17 @@ function useImportTemplateSchema() {
                     '- Inform on the inter-agency / inter-governmental coordination that has been formally or informally set up.\n'
                     + '- If possible, include the methods of coordination / information sharing.\n'
                     + '- If possible, include brief information how task / locations / etc. are coordinated and divided.\n'
+                ),
+            },
+
+            major_coordination_mechanism: {
+                type: 'input',
+                validation: 'textArea',
+                label: 'Major coordination mechanism',
+                description: (
+                    'List coordination mechanisms/platform in place at local/district and national level. Indicate the lead authorities/agencies. How the National Society is involved/positioned in this coordination. Does the NS in any lead/co-lead role? Any identified gap/overlap in the coordination (e.g., sector missing…)?\n'
+                    + 'Indicate only if there are major coordination mechanism in place\n'
+                    + 'Otherwise, leave the box empty.'
                 ),
             },
 

--- a/app/src/views/ThreeWProjectForm/DistrictMap/DistrictMapModal/index.tsx
+++ b/app/src/views/ThreeWProjectForm/DistrictMap/DistrictMapModal/index.tsx
@@ -360,7 +360,6 @@ function DistrictMap<const NAME, const ADMIN2_NAME>(props: Props<NAME, ADMIN2_NA
     );
 
     const handleDistrictClick = useCallback((clickedFeature: MapboxGeoJSONFeature) => {
-        // console.log('single click register', new Date().getTime());
         const properties = clickedFeature.properties as {
             country_id?: number;
             district_id?: number;
@@ -395,7 +394,6 @@ function DistrictMap<const NAME, const ADMIN2_NAME>(props: Props<NAME, ADMIN2_NA
                     );
                 });
                 handleDistrictChange((oldVal = []) => {
-                    // console.log('single click call', new Date().getTime());
                     const index = oldVal?.indexOf(id);
                     if (isNotDefined(index) || index === -1) {
                         return [
@@ -422,7 +420,6 @@ function DistrictMap<const NAME, const ADMIN2_NAME>(props: Props<NAME, ADMIN2_NA
     ]);
 
     const handleDistrictDoubleClick = useCallback((clickedFeature: MapboxGeoJSONFeature) => {
-        // console.log('double click call', new Date().getTime());
         const properties = clickedFeature?.properties as {
             country_id?: number;
             district_id?: number;


### PR DESCRIPTION
## Addresses:
- Imminent risk watch
  - Update labels for severity control
    - Green -> 60 km/h
    - Orange -> 90 km/h
    - Red -> 120 km/h
  - Update how event details is shown
    - Previously, we had a navigation system
    - Now, we have exandable container
- DREF Import template
  - Fix issue related to richtext and excel
    - Filtered out empty text items
  - Fix issue with injecting client id
    - We were injecting clientId instead of client_id
    - We were not injecting clientId if keyFieldName was defined
  - Update descriptions on the dref import template
    - Add proposed guidance for the questions that cascade
    - Add text field for `Major coordination mechanism in place` 

## Changes

- Update labels for severity control
  - Green -> 60 km/h
  - Orange -> 90 km/h
  - Red -> 120 km/h
- Update how event details is shown
  - Previously, we had a navigation system
  - Now, we have exandable container
- Fix issue related to richtext and excel
  - Filtered out empty text items
- Fix issue with injecting client id
  - We were injecting clientId instead of client_id
  - We were not injecting clientId if keyFieldName was defined
- Update descriptions on the dref import template

## This PR doesn't introduce:
- [x] typos
- [x] conflict markers
- [x] unwanted comments
- [x] temporary files, auto-generated files or secret keys
- [x] `console.log` meant for debugging
- [x] codegen errors
