### PR TITLE
project: Move field report title generation logic to server

### DIFF
--- a/.changeset/itchy-dryers-turn.md
+++ b/.changeset/itchy-dryers-turn.md
@@ -1,0 +1,5 @@
+---
+"go-web-app": patch
+---
+
+Move field report / emergency title generation logic from client to server

--- a/app/env.ts
+++ b/app/env.ts
@@ -16,7 +16,7 @@ export default defineConfig({
         return value as ('production' | 'staging' | 'testing' | `alpha-${number}` | 'development' | 'APP_ENVIRONMENT_PLACEHOLDER');
     },
     APP_API_ENDPOINT: Schema.string({ format: 'url', protocol: true, tld: false }),
-    APP_ADMIN_URL: Schema.string.optional({ format: 'url', protocol: true }),
+    APP_ADMIN_URL: Schema.string.optional({ format: 'url', protocol: true, tld: false }),
     APP_MAPBOX_ACCESS_TOKEN: Schema.string(),
     APP_TINY_API_KEY: Schema.string(),
     APP_RISK_API_ENDPOINT: Schema.string({ format: 'url', protocol: true }),

--- a/app/src/views/FieldReportForm/ContextFields/TitlePreview/i18n.json
+++ b/app/src/views/FieldReportForm/ContextFields/TitlePreview/i18n.json
@@ -1,0 +1,8 @@
+{
+    "namespace": "fieldReportForm",
+    "strings": {
+        "titlePreview": "Title Preview",
+        "failedToGenerateTitle": "Failed To Generate the Field Report Title"
+    }
+}
+

--- a/app/src/views/FieldReportForm/ContextFields/TitlePreview/index.tsx
+++ b/app/src/views/FieldReportForm/ContextFields/TitlePreview/index.tsx
@@ -1,0 +1,67 @@
+import { useMemo } from 'react';
+import { TextOutput } from '@ifrc-go/ui';
+import { useTranslation } from '@ifrc-go/ui/hooks';
+
+import useAlert from '#hooks/useAlert';
+import { useRequest } from '#utils/restRequest';
+
+import i18n from './i18n.json';
+
+interface Props {
+    country: number;
+    disasterType: number;
+    event?: number;
+    isCovidReport?: boolean;
+    startDate?: string;
+    title: string;
+}
+
+function TitlePreview(props: Props) {
+    const {
+        country,
+        disasterType,
+        event,
+        isCovidReport,
+        startDate,
+        title,
+    } = props;
+
+    const strings = useTranslation(i18n);
+    const alert = useAlert();
+
+    const variables = useMemo(() => ({
+        countries: [country],
+        is_covid_report: isCovidReport,
+        start_date: startDate,
+        dtype: disasterType,
+        event,
+        title,
+    }), [country, isCovidReport, startDate, disasterType, event, title]);
+
+    const {
+        response: genereateTitleResponse,
+    } = useRequest({
+        url: '/api/v2/field-report/generate-title/',
+        method: 'POST',
+        body: variables,
+        preserveResponse: true,
+        onFailure: () => {
+            alert.show(
+                strings.failedToGenerateTitle,
+                {
+                    variant: 'danger',
+                },
+            );
+        },
+    });
+
+    return (
+        <TextOutput
+            value={genereateTitleResponse?.title}
+            label={strings.titlePreview}
+            strongLabel
+        />
+    );
+}
+
+export default TitlePreview;

--- a/app/src/views/FieldReportForm/ContextFields/TitlePreview/index.tsx
+++ b/app/src/views/FieldReportForm/ContextFields/TitlePreview/index.tsx
@@ -3,6 +3,7 @@ import { TextOutput } from '@ifrc-go/ui';
 import { useTranslation } from '@ifrc-go/ui/hooks';
 
 import useAlert from '#hooks/useAlert';
+import useDebouncedValue from '#hooks/useDebouncedValue';
 import { useRequest } from '#utils/restRequest';
 
 import i18n from './i18n.json';
@@ -38,12 +39,14 @@ function TitlePreview(props: Props) {
         title,
     }), [country, isCovidReport, startDate, disasterType, event, title]);
 
+    const debouncedVariables = useDebouncedValue(variables);
+
     const {
-        response: genereateTitleResponse,
+        response: generateTitleResponse,
     } = useRequest({
         url: '/api/v2/field-report/generate-title/',
         method: 'POST',
-        body: variables,
+        body: debouncedVariables,
         preserveResponse: true,
         onFailure: () => {
             alert.show(
@@ -57,7 +60,7 @@ function TitlePreview(props: Props) {
 
     return (
         <TextOutput
-            value={genereateTitleResponse?.title}
+            value={generateTitleResponse?.title}
             label={strings.titlePreview}
             strongLabel
         />

--- a/app/src/views/FieldReportForm/ContextFields/i18n.json
+++ b/app/src/views/FieldReportForm/ContextFields/i18n.json
@@ -33,8 +33,7 @@
         "fieldReportFormContextTitle": "Context",
         "fieldReportFormSearchTitle": "Search for existing emergency",
         "fieldReportFormSearchDescription": "Type the name of the country you want to report on in the box above to begin the search.",
-        "fieldPrefix": "Prefix",
-        "fieldReportFormSuffix": "Suffix"
+        "originalTitleSecondaryLabel": "Original Title"
     }
 }
 

--- a/app/src/views/FieldReportForm/ContextFields/i18n.json
+++ b/app/src/views/FieldReportForm/ContextFields/i18n.json
@@ -33,7 +33,8 @@
         "fieldReportFormContextTitle": "Context",
         "fieldReportFormSearchTitle": "Search for existing emergency",
         "fieldReportFormSearchDescription": "Type the name of the country you want to report on in the box above to begin the search.",
-        "originalTitleSecondaryLabel": "Original Title"
+        "originalTitle": "Original Title",
+        "generatedTitlePreview": "Title Preview"
     }
 }
 

--- a/app/src/views/FieldReportForm/ContextFields/index.tsx
+++ b/app/src/views/FieldReportForm/ContextFields/index.tsx
@@ -2,6 +2,7 @@ import {
     useCallback,
     useMemo,
 } from 'react';
+import { useParams } from 'react-router-dom';
 import {
     BooleanInput,
     Container,
@@ -9,9 +10,11 @@ import {
     InputSection,
     RadioInput,
     TextInput,
+    TextOutput,
 } from '@ifrc-go/ui';
 import { useTranslation } from '@ifrc-go/ui/hooks';
 import {
+    isDefined,
     isNotDefined,
     isTruthyString,
 } from '@togglecorp/fujs';
@@ -36,6 +39,7 @@ import {
 } from '#utils/constants';
 
 import { type PartialFormValue } from '../common';
+import TitlePreview from './TitlePreview';
 
 import i18n from './i18n.json';
 import styles from './styles.module.css';
@@ -70,6 +74,7 @@ function ContextFields(props: Props) {
     } = props;
 
     const strings = useTranslation(i18n);
+    const { fieldReportId } = useParams<{ fieldReportId: string }>();
 
     const {
         api_field_report_status,
@@ -298,16 +303,27 @@ function ContextFields(props: Props) {
                             disabled={disabled}
                             withAsterisk
                         />
-                        {isTruthyString(value.summary) && (
-                            <TextInput
-                                label={strings.originalTitleSecondaryLabel}
-                                name="summary"
-                                value={value.summary}
-                                onChange={onValueChange}
-                                error={error?.summary}
-                                disabled
-                            />
-                        )}
+                        {isDefined(value.country)
+                            && isDefined(value.dtype)
+                            && isDefined(value.title)
+                            && isTruthyString(value.title.trim())
+                            ? (
+                                <TitlePreview
+                                    country={value.country}
+                                    disasterType={value.dtype}
+                                    event={value.event}
+                                    isCovidReport={value.is_covid_report}
+                                    startDate={value.start_date}
+                                    title={value.title}
+                                />
+                            ) : (
+                                <TextOutput
+                                    value={value.summary}
+                                    label={isDefined(fieldReportId)
+                                        ? strings.originalTitle : strings.generatedTitlePreview}
+                                    strongLabel
+                                />
+                            )}
                     </>
                 )}
             </InputSection>

--- a/app/src/views/FieldReportForm/ContextFields/index.tsx
+++ b/app/src/views/FieldReportForm/ContextFields/index.tsx
@@ -11,10 +11,7 @@ import {
     TextInput,
 } from '@ifrc-go/ui';
 import { useTranslation } from '@ifrc-go/ui/hooks';
-import {
-    isNotDefined,
-    isTruthyString,
-} from '@togglecorp/fujs';
+import { isNotDefined } from '@togglecorp/fujs';
 import {
     type EntriesAsList,
     type Error,
@@ -54,10 +51,6 @@ interface Props {
     setDistrictOptions: React.Dispatch<React.SetStateAction<DistrictItem[] | null | undefined>>;
     setEventOptions: React.Dispatch<React.SetStateAction<EventItem[] | null | undefined>>;
     disabled?: boolean;
-
-    fieldReportId: string | undefined;
-    titlePrefix: string | undefined;
-    titleSuffix: string | undefined;
 }
 
 function ContextFields(props: Props) {
@@ -71,9 +64,6 @@ function ContextFields(props: Props) {
         setDistrictOptions,
         setEventOptions,
         disabled,
-        titlePrefix,
-        titleSuffix,
-        fieldReportId,
     } = props;
 
     const strings = useTranslation(i18n);
@@ -171,14 +161,10 @@ function ContextFields(props: Props) {
         [onValueChange, value.dtype],
     );
 
-    const prefixVisible = !fieldReportId && isTruthyString(titlePrefix);
     const summaryVisible = !value.is_covid_report;
-    const suffixVisible = !fieldReportId && isTruthyString(titleSuffix);
 
     const preferredColumnNoForSummary = Math.max(
-        (prefixVisible ? 1 : 0)
-        + (summaryVisible ? 1 : 0)
-        + (suffixVisible ? 1 : 0),
+        summaryVisible ? 1 : 0,
         1,
     ) as 1 | 2 | 3;
 
@@ -301,34 +287,17 @@ function ContextFields(props: Props) {
                 withAsteriskOnTitle
                 numPreferredColumns={preferredColumnNoForSummary}
             >
-                {prefixVisible && (
-                    <TextInput
-                        label={summaryVisible ? strings.fieldPrefix : strings.titleSecondaryLabel}
-                        name={undefined}
-                        value={titlePrefix}
-                        onChange={() => { }}
-                    />
-                )}
                 {summaryVisible && (
                     <TextInput
                         label={strings.titleSecondaryLabel}
                         placeholder={strings.titleInputPlaceholder}
-                        name="summary"
-                        value={value.summary}
+                        name="title"
+                        value={value.title}
                         maxLength={256}
                         onChange={onValueChange}
-                        error={error?.summary}
+                        error={error?.title}
                         disabled={disabled}
                         withAsterisk
-                    />
-                )}
-                {suffixVisible && (
-                    <TextInput
-                        label={strings.fieldReportFormSuffix}
-                        name={undefined}
-                        value={titleSuffix}
-                        onChange={() => { }}
-                    // readOnly
                     />
                 )}
             </InputSection>

--- a/app/src/views/FieldReportForm/ContextFields/index.tsx
+++ b/app/src/views/FieldReportForm/ContextFields/index.tsx
@@ -11,7 +11,10 @@ import {
     TextInput,
 } from '@ifrc-go/ui';
 import { useTranslation } from '@ifrc-go/ui/hooks';
-import { isNotDefined } from '@togglecorp/fujs';
+import {
+    isNotDefined,
+    isTruthyString,
+} from '@togglecorp/fujs';
 import {
     type EntriesAsList,
     type Error,
@@ -163,11 +166,6 @@ function ContextFields(props: Props) {
 
     const summaryVisible = !value.is_covid_report;
 
-    const preferredColumnNoForSummary = Math.max(
-        summaryVisible ? 1 : 0,
-        1,
-    ) as 1 | 2 | 3;
-
     return (
         <Container
             heading={strings.fieldReportFormContextTitle}
@@ -285,20 +283,32 @@ function ContextFields(props: Props) {
                 title={strings.summaryLabel}
                 description={strings.summaryDescription}
                 withAsteriskOnTitle
-                numPreferredColumns={preferredColumnNoForSummary}
+                numPreferredColumns={1}
             >
                 {summaryVisible && (
-                    <TextInput
-                        label={strings.titleSecondaryLabel}
-                        placeholder={strings.titleInputPlaceholder}
-                        name="title"
-                        value={value.title}
-                        maxLength={256}
-                        onChange={onValueChange}
-                        error={error?.title}
-                        disabled={disabled}
-                        withAsterisk
-                    />
+                    <>
+                        <TextInput
+                            label={strings.titleSecondaryLabel}
+                            placeholder={strings.titleInputPlaceholder}
+                            name="title"
+                            value={value.title}
+                            maxLength={256}
+                            onChange={onValueChange}
+                            error={error?.title}
+                            disabled={disabled}
+                            withAsterisk
+                        />
+                        {isTruthyString(value.summary) && (
+                            <TextInput
+                                label={strings.originalTitleSecondaryLabel}
+                                name="summary"
+                                value={value.summary}
+                                onChange={onValueChange}
+                                error={error?.summary}
+                                disabled
+                            />
+                        )}
+                    </>
                 )}
             </InputSection>
             <InputSection

--- a/app/src/views/FieldReportForm/common.ts
+++ b/app/src/views/FieldReportForm/common.ts
@@ -311,23 +311,23 @@ export const reportSchema: FormSchema = {
         });
 
         // CONTEXT
-        // baseSchema = addCondition(
-        //     baseSchema,
-        //     value,
-        //     ['status', 'is_covid_report', 'dtype'],
-        //     ['summary'],
-        //     (val): Pick<FormSchemaFields, 'summary'> => {
-        //         const reportType = getReportType(val?.status, val?.is_covid_report, val?.dtype);
-        //         if (reportType === 'COVID') {
-        //             return {
-        //                 summary: { forceValue: nullValue },
-        //             };
-        //         }
-        //         return {
-        //             summary: { required: true, requiredValidation: requiredStringCondition },
-        //         };
-        //     },
-        // );
+        baseSchema = addCondition(
+            baseSchema,
+            value,
+            ['status', 'is_covid_report', 'dtype'],
+            ['summary'],
+            (val): Pick<FormSchemaFields, 'summary'> => {
+                const reportType = getReportType(val?.status, val?.is_covid_report, val?.dtype);
+                if (reportType === 'COVID') {
+                    return {
+                        summary: { forceValue: nullValue },
+                    };
+                }
+                return {
+                    summary: { required: true, requiredValidation: requiredStringCondition },
+                };
+            },
+        );
 
         // SITUATION / RISK ANALYSIS
 

--- a/app/src/views/FieldReportForm/common.ts
+++ b/app/src/views/FieldReportForm/common.ts
@@ -275,7 +275,7 @@ export const reportSchema: FormSchema = {
             country: { required: true },
             districts: { defaultValue: [] },
             dtype: { required: true },
-            title: { required: true },
+            title: { required: true, requiredValidation: requiredStringCondition },
             start_date: { required: true },
             request_assistance: {},
             ns_request_assistance: {},

--- a/app/src/views/FieldReportForm/common.ts
+++ b/app/src/views/FieldReportForm/common.ts
@@ -152,6 +152,7 @@ const fieldsInContext = [
     'summary',
     'request_assistance',
     'ns_request_assistance',
+    'title',
 ] satisfies (keyof PartialFormValue)[];
 const fieldsInSituation = [
     'affected_pop_centres',
@@ -274,6 +275,7 @@ export const reportSchema: FormSchema = {
             country: { required: true },
             districts: { defaultValue: [] },
             dtype: { required: true },
+            title: { required: true },
             start_date: { required: true },
             request_assistance: {},
             ns_request_assistance: {},
@@ -309,23 +311,23 @@ export const reportSchema: FormSchema = {
         });
 
         // CONTEXT
-        baseSchema = addCondition(
-            baseSchema,
-            value,
-            ['status', 'is_covid_report', 'dtype'],
-            ['summary'],
-            (val): Pick<FormSchemaFields, 'summary'> => {
-                const reportType = getReportType(val?.status, val?.is_covid_report, val?.dtype);
-                if (reportType === 'COVID') {
-                    return {
-                        summary: { forceValue: nullValue },
-                    };
-                }
-                return {
-                    summary: { required: true, requiredValidation: requiredStringCondition },
-                };
-            },
-        );
+        // baseSchema = addCondition(
+        //     baseSchema,
+        //     value,
+        //     ['status', 'is_covid_report', 'dtype'],
+        //     ['summary'],
+        //     (val): Pick<FormSchemaFields, 'summary'> => {
+        //         const reportType = getReportType(val?.status, val?.is_covid_report, val?.dtype);
+        //         if (reportType === 'COVID') {
+        //             return {
+        //                 summary: { forceValue: nullValue },
+        //             };
+        //         }
+        //         return {
+        //             summary: { required: true, requiredValidation: requiredStringCondition },
+        //         };
+        //     },
+        // );
 
         // SITUATION / RISK ANALYSIS
 

--- a/app/src/views/FieldReportForm/index.tsx
+++ b/app/src/views/FieldReportForm/index.tsx
@@ -18,12 +18,9 @@ import {
     Tabs,
 } from '@ifrc-go/ui';
 import { useTranslation } from '@ifrc-go/ui/hooks';
-import { formatDate } from '@ifrc-go/ui/utils';
 import {
     isDefined,
-    isFalsyString,
     isNotDefined,
-    isTruthyString,
     listToGroupList,
 } from '@togglecorp/fujs';
 import {
@@ -38,9 +35,7 @@ import FormFailedToLoadMessage from '#components/domain/FormFailedToLoadMessage'
 import LanguageMismatchMessage from '#components/domain/LanguageMismatchMessage';
 import NonFieldError from '#components/NonFieldError';
 import Page from '#components/Page';
-import useCountryRaw from '#hooks/domain/useCountryRaw';
 import useCurrentLanguage from '#hooks/domain/useCurrentLanguage';
-import useDisasterType from '#hooks/domain/useDisasterType';
 import useAlert from '#hooks/useAlert';
 import useRouting from '#hooks/useRouting';
 import {
@@ -83,31 +78,6 @@ import SituationFields from './SituationFields';
 
 import i18n from './i18n.json';
 import styles from './styles.module.css';
-
-interface Part {
-    value: string | null | undefined;
-    compose?: string;
-}
-function concat(parts: Part[]) {
-    const validParts = parts
-        .map((part) => {
-            if (isFalsyString(part.value)) {
-                return undefined;
-            }
-            return {
-                value: part.value,
-                compose: part.compose ?? ' ',
-            };
-        })
-        .filter(isDefined)
-        .flatMap((validPart, index) => {
-            if (index === 0) {
-                return [validPart.value];
-            }
-            return [validPart.compose, validPart.value];
-        });
-    return validParts.join('');
-}
 
 function getNextStep(
     current: TabKeys,
@@ -157,8 +127,6 @@ export function Component() {
     const alert = useAlert();
     const strings = useTranslation(i18n);
     const formContentRef = useRef<ElementRef<'div'>>(null);
-    const countries = useCountryRaw();
-    const disasterTypeOptions = useDisasterType();
     const currentLanguage = useCurrentLanguage();
     const { state } = useLocation();
 
@@ -215,34 +183,6 @@ export function Component() {
     } = useRequest({
         url: '/api/v2/review-country/',
     });
-
-    const {
-        response: eventResponse,
-    } = useRequest({
-        url: '/api/v2/event/{id}/',
-        skip: isNotDefined(value.event),
-        pathVariables: isDefined(value.event) ? {
-            id: value.event,
-        } : undefined,
-    });
-
-    const fieldReportNumber = useMemo(
-        () => {
-            if (isNotDefined(value.country)) {
-                return 1;
-            }
-            const reports = eventResponse?.field_reports?.filter(
-                (fieldReport) => (
-                    isDefined(fieldReport.countries.find((country) => country.id === value.country))
-                ),
-            );
-            if (isNotDefined(reports)) {
-                return 1;
-            }
-            return reports.length + 1;
-        },
-        [eventResponse, value.country],
-    );
 
     const {
         pending: fieldReportPending,
@@ -382,118 +322,6 @@ export function Component() {
         },
     });
 
-    const countryIsoOptions = useMemo(
-        () => (
-            countries?.map((country) => {
-                // FIXME: why are we using this filter for independent and record_type
-                if (
-                    !country.independent
-                    // FIXME: Use named constant
-                    || country.record_type !== 1
-                    || isFalsyString(country.iso3)
-                ) {
-                    return undefined;
-                }
-                return {
-                    ...country,
-                    iso3: country.iso3,
-                    independent: country.independent,
-                    record_type: country.record_type,
-                };
-            }).filter(isDefined)
-        ),
-        [countries],
-    );
-
-    const getTitle = useCallback(
-        (
-            event: number | null | undefined,
-            country: number | null | undefined,
-            is_covid_report: boolean | undefined,
-            start_date: string | null | undefined,
-            dtype: number | null | undefined,
-            // summary: string | null | undefined,
-        ) => {
-            const dateLabel = formatDate(new Date(), 'yyyy-MM-dd');
-            const iso3Label = isDefined(country)
-                ? countryIsoOptions?.find(({ id }) => id === country)?.iso3
-                : undefined;
-
-            // COVID-19
-            if (is_covid_report && isDefined(event)) {
-                // eslint-disable-next-line max-len
-                return isTruthyString(iso3Label) && isDefined(fieldReportNumber) && isTruthyString(dateLabel)
-                    ? {
-                        titlePrefix: `${iso3Label}: COVID-19`,
-                        titleSuffix: `#${fieldReportNumber} (${dateLabel})`,
-                    }
-                    : undefined;
-            }
-            if (is_covid_report && isNotDefined(event)) {
-                return isTruthyString(iso3Label)
-                    ? {
-                        titlePrefix: `${iso3Label}: COVID-19`,
-                        titleSuffix: undefined,
-                    }
-                    : undefined;
-            }
-
-            // NON-COVID-19
-            const disasterLabel = isDefined(dtype)
-                ? disasterTypeOptions?.find(({ id }) => id === dtype)?.name
-                : undefined;
-
-            const shortDate = formatDate(start_date, 'MM-yyyy');
-
-            if (isDefined(event)) {
-                // eslint-disable-next-line max-len
-                return isTruthyString(iso3Label) && isTruthyString(disasterLabel) && isTruthyString(shortDate) && isDefined(fieldReportNumber) && isTruthyString(dateLabel)
-                    ? {
-                        titlePrefix: `${iso3Label}: ${disasterLabel} - ${shortDate}`,
-                        titleSuffix: `#${fieldReportNumber} (${dateLabel})`,
-                    }
-                    : undefined;
-            }
-            // eslint-disable-next-line max-len
-            return isTruthyString(iso3Label) && isTruthyString(disasterLabel) && isTruthyString(shortDate)
-                ? {
-                    titlePrefix: `${iso3Label}: ${disasterLabel} - ${shortDate}`,
-                    titleSuffix: undefined,
-                }
-                : undefined;
-        },
-        [countryIsoOptions, disasterTypeOptions, fieldReportNumber],
-    );
-
-    const generatedTitle = useMemo(
-        () => {
-            if (isNotDefined(fieldReportId)) {
-                return getTitle(
-                    value.event,
-                    value.country,
-                    value.is_covid_report,
-                    value.start_date,
-                    value.dtype,
-                    // value.summary ?? '',
-                );
-            }
-            return undefined;
-        },
-        [
-            getTitle,
-            fieldReportId,
-            value.event,
-            value.country,
-            value.is_covid_report,
-            value.start_date,
-            value.dtype,
-            // value.summary,
-        ],
-    );
-
-    const titlePrefix = generatedTitle?.titlePrefix;
-    const titleSuffix = generatedTitle?.titleSuffix;
-
     const isReviewCountry = useMemo(() => {
         if (isNotDefined(value.country)) {
             return false;
@@ -578,37 +406,12 @@ export function Component() {
                     ...sanitizedValues,
                 } as FieldReportBody);
             } else {
-                const title = getTitle(
-                    formValues.event,
-                    formValues.country,
-                    sanitizedValues.is_covid_report,
-                    sanitizedValues.start_date,
-                    sanitizedValues.dtype,
-                );
-
-                const generatedTitlePrefix = title?.titlePrefix;
-                const generatedTitleSuffix = title?.titleSuffix;
-
-                const summary = concat([
-                    { value: generatedTitlePrefix },
-                    {
-                        // NOTE: We do not use summary field on covid report
-                        value: sanitizedValues.is_covid_report
-                            ? undefined
-                            : sanitizedValues.summary,
-                        compose: ' - ',
-                    },
-                    { value: generatedTitleSuffix },
-                ]);
-
                 createSubmitRequest({
                     ...sanitizedValues,
-                    summary,
                 } as FieldReportPostBody);
             }
         },
         [
-            getTitle,
             fieldReportId,
             editSubmitRequest,
             createSubmitRequest,
@@ -757,9 +560,6 @@ export function Component() {
                                 setEventOptions={setEventOptions}
                                 eventOptions={eventOptions}
                                 disabled={pending}
-                                titlePrefix={titlePrefix}
-                                titleSuffix={titleSuffix}
-                                fieldReportId={fieldReportId}
                             />
                         </TabPanel>
                         <TabPanel name="risk-analysis">

--- a/package.json
+++ b/package.json
@@ -23,13 +23,13 @@
     },
     "engines": {
         "node": "20",
-        "pnpm": "8.6.0"
+        "pnpm": "8.15.9"
     },
     "devDependencies": {
         "@changesets/cli": "^2.27.10",
         "knip": "^5.36.3"
     },
-    "packageManager": "pnpm@8.6.0+sha1.71f9126a20cd3d00fa47c188f956918858180e54",
+    "packageManager": "pnpm@8.15.9",
     "pnpm": {
         "patchedDependencies": {
             "openapi-typescript@6.5.5": "patches/openapi-typescript@6.5.5.patch",

--- a/translationMigrations/000007-1735886091614.json
+++ b/translationMigrations/000007-1735886091614.json
@@ -1,0 +1,39 @@
+{
+    "parent": "000006-1735037040790.json",
+    "actions": [
+        {
+            "action": "add",
+            "key": "failedToGenerateTitle",
+            "namespace": "fieldReportForm",
+            "value": "Failed To Generate the Field Report Title"
+        },
+        {
+            "action": "add",
+            "key": "generatedTitlePreview",
+            "namespace": "fieldReportForm",
+            "value": "Title Preview"
+        },
+        {
+            "action": "add",
+            "key": "originalTitle",
+            "namespace": "fieldReportForm",
+            "value": "Original Title"
+        },
+        {
+            "action": "add",
+            "key": "titlePreview",
+            "namespace": "fieldReportForm",
+            "value": "Title Preview"
+        },
+        {
+            "action": "remove",
+            "key": "fieldPrefix",
+            "namespace": "fieldReportForm"
+        },
+        {
+            "action": "remove",
+            "key": "fieldReportFormSuffix",
+            "namespace": "fieldReportForm"
+        }
+    ]
+}

--- a/translationMigrations/000012-1738141854510.json
+++ b/translationMigrations/000012-1738141854510.json
@@ -1,5 +1,5 @@
 {
-    "parent": "000006-1735037040790.json",
+    "parent": "000011-1738138922126.json",
     "actions": [
         {
             "action": "add",


### PR DESCRIPTION
## Addresses:
- https://github.com/IFRCGo/go-web-app/issues/1382
- https://github.com/IFRCGo/go-web-app/issues/1385

## Depends on:
- https://github.com/IFRCGo/go-api/pull/2388

## Changes
- Removed title generation logic from the client, including the handling of prefixes and suffixes.
- The `title` field will now store the user-provided title for the field report.
- The `summary` field will contain the automatically generated title from the server.

## This PR doesn't introduce:
- [x] typos
- [x] conflict markers
- [x] unwanted comments
- [x] temporary files, auto-generated files or secret keys
- [x] `console.log` meant for debugging
- [x] codegen errors
