### PR TITLE
[Hotfix 4]: Replace the from-communication-copied text of CoS Health header

### DIFF
--- a/.changeset/ninety-walls-film.md
+++ b/.changeset/ninety-walls-film.md
@@ -1,0 +1,5 @@
+---
+"go-web-app": patch
+---
+
+Replace the from-communication-copied text of CoS Health header

--- a/app/src/views/SurgeCatalogueHealth/i18n.json
+++ b/app/src/views/SurgeCatalogueHealth/i18n.json
@@ -2,7 +2,7 @@
     "namespace": "surgeCatalogueHealth",
     "strings": {
         "catalogueHealthTitle": "Health",
-        "healthDetails": "Together with its member National Societies, the IFRC has developed a network of skilled communications professionals to provide management, strategic and technical support and advice to emergency operations, from rapid onset disasters to protracted crises in various contexts. Through our global coordination system, our communications specialists are able to reach millions of people and diverse audiences globally using a wide-range of communication channels.",
+        "healthDetails": "The IFRC and its member National Societies have a network of personnel, equipment and approaches to prevent, detect and respond to health needs in emergencies, including both clinical and public health Emergency Response Units. These health response tools prevent and treat illness and improve health and dignity for communities affected by slow- and sudden-onset disasters or outbreaks. Deployable health capacities can support inter-agency health coordination, overall strategic direction for health, implementation of community- and clinic-based health interventions, and provide critical lifesaving services to communities, in support of government health systems and services.",
         "healthServicesTitle": "Services",
         "healthServicesEruClinicTitle": "Clinical - Emergency Response Unit",
         "healthClinical": "Clinical",


### PR DESCRIPTION
Refers to a correspondence with Surge team, where it was flagged that the Communications and Health has the same intro text.