### PR TITLE
Fix disputed boundary map styling

### DIFF
--- a/app/src/components/domain/ActiveOperationMap/index.tsx
+++ b/app/src/components/domain/ActiveOperationMap/index.tsx
@@ -32,9 +32,8 @@ import {
     MapLayer,
     MapSource,
 } from '@togglecorp/re-map';
-import type { LngLatBoundsLike } from 'mapbox-gl';
+import { type LngLatBoundsLike } from 'mapbox-gl';
 
-import BaseMap from '#components/domain/BaseMap';
 import DisasterTypeSelectInput from '#components/domain/DisasterTypeSelectInput';
 import DistrictSearchMultiSelectInput, { type DistrictItem } from '#components/domain/DistrictSearchMultiSelectInput';
 import Link from '#components/Link';
@@ -48,13 +47,13 @@ import {
     DEFAULT_MAP_PADDING,
     DURATION_MAP_ZOOM,
 } from '#utils/constants';
-import { adminFillLayerOptions } from '#utils/map';
 import type {
     GoApiResponse,
     GoApiUrlQuery,
 } from '#utils/restRequest';
 import { useRequest } from '#utils/restRequest';
 
+import GlobalMap, { AdminZeroFeatureProperties } from '../GlobalMap';
 import {
     APPEAL_TYPE_DREF,
     APPEAL_TYPE_EAP,
@@ -87,24 +86,8 @@ const sourceOptions: mapboxgl.GeoJSONSourceRaw = {
     type: 'geojson',
 };
 
-interface CountryProperties {
-    country_id: number;
-    disputed: boolean;
-    fdrs: string;
-    independent: boolean;
-    is_deprecated: boolean;
-    iso: string;
-    iso3: string;
-    name: string;
-    name_ar: string;
-    name_es: string;
-    name_fr: string;
-    record_type: number;
-    region_id: number;
-}
-
 interface ClickedPoint {
-    feature: GeoJSON.Feature<GeoJSON.Point, CountryProperties>;
+    featureProperties: AdminZeroFeatureProperties;
     lngLat: mapboxgl.LngLatLike;
 }
 
@@ -188,8 +171,8 @@ function ActiveOperationMap(props: Props) {
     );
 
     const [
-        clickedPointProperties,
-        setClickedPointProperties,
+        clickedPoint,
+        setClickedPoint,
     ] = useState<ClickedPoint| undefined>();
 
     const [scaleBy, setScaleBy] = useInputState<ScaleOption['value']>('peopleTargeted');
@@ -348,29 +331,30 @@ function ActiveOperationMap(props: Props) {
     );
 
     const handleCountryClick = useCallback((
-        feature: mapboxgl.MapboxGeoJSONFeature,
+        featureProperties: AdminZeroFeatureProperties,
         lngLat: mapboxgl.LngLatLike,
     ) => {
-        setClickedPointProperties({
-            feature: feature as unknown as ClickedPoint['feature'],
+        setClickedPoint({
+            featureProperties,
             lngLat,
         });
-        return false;
+
+        return true;
     }, []);
 
     const handlePointClose = useCallback(
         () => {
-            setClickedPointProperties(undefined);
+            setClickedPoint(undefined);
         },
-        [setClickedPointProperties],
+        [setClickedPoint],
     );
 
     const handleClearFiltersButtonclick = useCallback(() => {
         setFilter({});
     }, [setFilter]);
 
-    const popupDetails = clickedPointProperties
-        ? countryGroupedAppeal[clickedPointProperties.feature.properties.iso3]
+    const popupDetails = clickedPoint
+        ? countryGroupedAppeal[clickedPoint.featureProperties.iso3]
         : undefined;
 
     const [districtOptions, setDistrictOptions] = useState<DistrictItem[] | null | undefined>();
@@ -447,15 +431,8 @@ function ActiveOperationMap(props: Props) {
                 </Link>
             )}
         >
-            <BaseMap
-                baseLayers={(
-                    <MapLayer
-                        layerKey="admin-0"
-                        hoverable
-                        layerOptions={adminFillLayerOptions}
-                        onClick={handleCountryClick}
-                    />
-                )}
+            <GlobalMap
+                onClick={handleCountryClick}
             >
                 <MapContainerWithDisclaimer
                     className={styles.mapContainer}
@@ -503,18 +480,18 @@ function ActiveOperationMap(props: Props) {
                         }
                     />
                 </MapSource>
-                {clickedPointProperties?.lngLat && (
+                {clickedPoint?.lngLat && (
                     <MapPopup
                         onCloseButtonClick={handlePointClose}
-                        coordinates={clickedPointProperties.lngLat}
+                        coordinates={clickedPoint.lngLat}
                         heading={(
                             <Link
                                 to="countriesLayout"
                                 urlParams={{
-                                    countryId: clickedPointProperties.feature.properties.country_id,
+                                    countryId: clickedPoint.featureProperties.country_id,
                                 }}
                             >
-                                {clickedPointProperties.feature.properties.name}
+                                {clickedPoint.featureProperties.name}
                             </Link>
                         )}
                         childrenContainerClassName={styles.popupContent}
@@ -560,7 +537,7 @@ function ActiveOperationMap(props: Props) {
                         padding={DEFAULT_MAP_PADDING}
                     />
                 )}
-            </BaseMap>
+            </GlobalMap>
             {onPresentationModeButtonClick && !presentationMode && (
                 <Button
                     className={styles.presentationModeButton}

--- a/app/src/components/domain/ActiveOperationMap/index.tsx
+++ b/app/src/components/domain/ActiveOperationMap/index.tsx
@@ -53,7 +53,7 @@ import type {
 } from '#utils/restRequest';
 import { useRequest } from '#utils/restRequest';
 
-import GlobalMap, { AdminZeroFeatureProperties } from '../GlobalMap';
+import GlobalMap, { type AdminZeroFeatureProperties } from '../GlobalMap';
 import {
     APPEAL_TYPE_DREF,
     APPEAL_TYPE_EAP,

--- a/app/src/components/domain/ActiveOperationMap/styles.module.css
+++ b/app/src/components/domain/ActiveOperationMap/styles.module.css
@@ -10,7 +10,8 @@
     }
 
     .map-container {
-        height: 40rem;
+        height: min(50rem, 70vh);
+        min-height: 20rem;
     }
 
     .footer {

--- a/app/src/components/domain/BaseMap/index.tsx
+++ b/app/src/components/domain/BaseMap/index.tsx
@@ -1,8 +1,5 @@
-import {
-    useContext,
-    useMemo,
-} from 'react';
-import { LanguageContext } from '@ifrc-go/ui/contexts';
+import { useMemo } from 'react';
+// import { LanguageContext } from '@ifrc-go/ui/contexts';
 import { ErrorBoundary } from '@sentry/react';
 import {
     isDefined,
@@ -104,10 +101,9 @@ function BaseMap(props: Props) {
         [countries],
     );
 
-    const {
-        currentLanguage,
-    } = useContext(LanguageContext);
+    // const { currentLanguage } = useContext(LanguageContext);
 
+    /*
     const adminLabelLayerOptions : Omit<SymbolLayer, 'id'> = useMemo(
         () => {
             // ar, es, fr
@@ -131,6 +127,7 @@ function BaseMap(props: Props) {
         },
         [currentLanguage],
     );
+    */
 
     return (
         <Map
@@ -147,18 +144,6 @@ function BaseMap(props: Props) {
                 sourceKey="composite"
                 managed={false}
             >
-                <MapLayer
-                    layerKey="admin-0-label"
-                    layerOptions={adminLabelLayerOptions}
-                />
-                <MapLayer
-                    layerKey="admin-0-label-non-independent"
-                    layerOptions={adminLabelLayerOptions}
-                />
-                <MapLayer
-                    layerKey="admin-0-label-priority"
-                    layerOptions={adminLabelLayerOptions}
-                />
                 {baseLayers}
             </MapSource>
             {!withoutLabel && (

--- a/app/src/components/domain/BaseMap/index.tsx
+++ b/app/src/components/domain/BaseMap/index.tsx
@@ -1,5 +1,4 @@
 import { useMemo } from 'react';
-// import { LanguageContext } from '@ifrc-go/ui/contexts';
 import { ErrorBoundary } from '@sentry/react';
 import {
     isDefined,
@@ -29,6 +28,8 @@ type overrides = 'mapStyle' | 'mapOptions' | 'navControlShown' | 'navControlPosi
 export type Props = Omit<MapProps, overrides> & {
     baseLayers?: React.ReactNode;
     withDisclaimer?: boolean;
+    // NOTE: Labels with be added from the country information instead of the
+    // mapbox layers
     withoutLabel?: boolean;
 } & Partial<Pick<MapProps, overrides>>;
 
@@ -76,6 +77,7 @@ function BaseMap(props: Props) {
 
     const countries = useCountry();
 
+    // FIXME: We should check for special cases like ICRC, IFRC, etc.
     const countryCentroidGeoJson = useMemo(
         (): GeoJSON.FeatureCollection<GeoJSON.Geometry> => ({
             type: 'FeatureCollection' as const,
@@ -101,34 +103,6 @@ function BaseMap(props: Props) {
         [countries],
     );
 
-    // const { currentLanguage } = useContext(LanguageContext);
-
-    /*
-    const adminLabelLayerOptions : Omit<SymbolLayer, 'id'> = useMemo(
-        () => {
-            // ar, es, fr
-            let label: string;
-            if (currentLanguage === 'es') {
-                label = 'name_es';
-            } else if (currentLanguage === 'ar') {
-                label = 'name_ar';
-            } else if (currentLanguage === 'fr') {
-                label = 'name_fr';
-            } else {
-                label = 'name';
-            }
-
-            return {
-                type: 'symbol',
-                layout: {
-                    'text-field': ['get', label],
-                },
-            };
-        },
-        [currentLanguage],
-    );
-    */
-
     return (
         <Map
             mapStyle={mapStyle ?? defaultMapStyle}
@@ -153,7 +127,7 @@ function BaseMap(props: Props) {
                     geoJson={countryCentroidGeoJson}
                 >
                     <MapLayer
-                        layerKey="point-circle"
+                        layerKey="symbol-label"
                         layerOptions={adminLabelOverrideOptions}
                     />
                 </MapSource>

--- a/app/src/components/domain/GlobalMap/index.tsx
+++ b/app/src/components/domain/GlobalMap/index.tsx
@@ -1,0 +1,238 @@
+import {
+    useContext,
+    useMemo,
+    useState,
+} from 'react';
+import { LanguageContext } from '@ifrc-go/ui/contexts';
+import { MapLayer } from '@togglecorp/re-map';
+import {
+    Expression,
+    FillLayer,
+    FillPaint,
+    LineLayer,
+    LngLatLike,
+    MapboxGeoJSONFeature,
+    SymbolLayer,
+} from 'mapbox-gl';
+
+import BaseMap, { type Props as BaseMapProps } from '#components/domain/BaseMap';
+import {
+    COLOR_BLACK,
+    CountryRecordTypeEnum,
+} from '#utils/constants';
+
+export interface AdminZeroFeatureProperties {
+    country_id: number;
+    disputed: boolean;
+    independent: boolean;
+    is_deprecated: boolean;
+    name: string;
+    name_ar: string;
+    name_es: string;
+    name_fr: string;
+    record_type: CountryRecordTypeEnum;
+
+    // NOTE: we check for undefined iso3 before triggering
+    // onClick and onHover
+    iso3: string;
+
+    fdrs?: string;
+    iso?: string;
+    region_id?: number;
+}
+
+const KOSOVO_ISO3 = 'XKX';
+const WESTERN_SAHARA_ISO3 = 'ESH';
+
+const overlappedDisputedCountriesIso3 = [
+    KOSOVO_ISO3,
+    WESTERN_SAHARA_ISO3,
+];
+
+const adminZeroHighlightPaint: FillPaint = {
+    'fill-color': COLOR_BLACK,
+    'fill-opacity': [
+        'case',
+        ['all',
+            ['==', ['feature-state', 'hovered'], true],
+            ['!=', ['get', 'iso3'], null],
+        ],
+        0.2,
+        0,
+    ],
+};
+
+interface Props extends Omit<BaseMapProps, 'baseLayers'> {
+    onHover?: (hoveredFeatureProperties: AdminZeroFeatureProperties | undefined) => void;
+    onClick?: (
+        clickedFeatureProperties: AdminZeroFeatureProperties,
+        lngLat: LngLatLike,
+    ) => void;
+    activeCountryIso3?: string | undefined | null;
+}
+
+function GlobalMap(props: Props) {
+    const {
+        onHover,
+        onClick,
+        ...baseMapProps
+    } = props;
+
+    const [hoveredCountryIso3, setHoverdCountryIso3] = useState<string | undefined>();
+
+    const handleFeatureMouseEnter = (feature: MapboxGeoJSONFeature) => {
+        const hoveredFeatureProperties = feature.properties as (
+            AdminZeroFeatureProperties | undefined
+        );
+
+        setHoverdCountryIso3(hoveredFeatureProperties?.iso3);
+
+        if (onHover) {
+            onHover(hoveredFeatureProperties);
+        }
+    };
+
+    const handleFeatureMouseLeave = () => {
+        setHoverdCountryIso3(undefined);
+
+        if (onHover) {
+            onHover(undefined);
+        }
+    };
+
+    const handleClick = (feature: MapboxGeoJSONFeature, lngLat: LngLatLike) => {
+        if (onClick) {
+            onClick(
+                feature.properties as AdminZeroFeatureProperties,
+                lngLat,
+            );
+        }
+
+        return true;
+    };
+
+    const fillSortKey = useMemo<number | Expression>(() => [
+        'match',
+        ['get', 'iso3'],
+        hoveredCountryIso3 ?? '???',
+        2,
+        ...(overlappedDisputedCountriesIso3.filter(
+            (iso3) => !(iso3 === hoveredCountryIso3),
+        ).flatMap((iso3) => [iso3, 1])),
+        0,
+    ], [hoveredCountryIso3]);
+
+    const adminZeroHighlightLayerOptions = useMemo<Omit<FillLayer, 'id'>>(
+        () => ({
+            type: 'fill',
+            layout: {
+                visibility: 'visible',
+                'fill-sort-key': fillSortKey,
+            },
+            paint: adminZeroHighlightPaint,
+            filter: ['!=', ['get', 'iso3'], null],
+        }),
+        [fillSortKey],
+    );
+
+    const adminZeroBaseLayerOptions = useMemo<Omit<FillLayer, 'id'>>(
+        () => ({
+            type: 'fill',
+            layout: {
+                visibility: 'visible',
+                'fill-sort-key': fillSortKey,
+            },
+        }),
+        [fillSortKey],
+    );
+
+    const adminZeroLineLayerOptions = useMemo<Omit<LineLayer, 'id'>>(
+        () => ({
+            type: 'line',
+            layout: {
+                visibility: 'visible',
+            },
+        }),
+        [],
+    );
+
+    const { currentLanguage } = useContext(LanguageContext);
+
+    const adminLabelLayerOptions : Omit<SymbolLayer, 'id'> = useMemo(
+        () => {
+            // ar, es, fr
+            let label: string;
+            if (currentLanguage === 'es') {
+                label = 'name_es';
+            } else if (currentLanguage === 'ar') {
+                label = 'name_ar';
+            } else if (currentLanguage === 'fr') {
+                label = 'name_fr';
+            } else {
+                label = 'name';
+            }
+
+            return {
+                type: 'symbol',
+                layout: {
+                    'text-field': ['get', label],
+                    visibility: 'visible',
+                },
+            };
+        },
+        [currentLanguage],
+    );
+
+    return (
+        <BaseMap
+            // eslint-disable-next-line react/jsx-props-no-spreading
+            {...baseMapProps}
+            withoutLabel
+            baseLayers={(
+                <>
+                    <MapLayer
+                        layerKey="admin-0"
+                        layerOptions={adminZeroBaseLayerOptions}
+                        onMouseEnter={handleFeatureMouseEnter}
+                        onMouseLeave={handleFeatureMouseLeave}
+                    />
+                    <MapLayer
+                        layerKey="admin-0-label"
+                        layerOptions={adminLabelLayerOptions}
+                    />
+                    <MapLayer
+                        layerKey="admin-0-label-non-independent"
+                        layerOptions={adminLabelLayerOptions}
+                    />
+                    <MapLayer
+                        layerKey="admin-0-label-priority"
+                        layerOptions={adminLabelLayerOptions}
+                    />
+                    <MapLayer
+                        layerKey="admin-0-boundary-mask"
+                        layerOptions={adminZeroLineLayerOptions}
+                    />
+                    <MapLayer
+                        layerKey="admin-0-boundary-disputed"
+                        layerOptions={adminZeroLineLayerOptions}
+                    />
+                    {(onHover || onClick) && (
+                        <MapLayer
+                            layerKey="admin-0-highlight"
+                            layerOptions={adminZeroHighlightLayerOptions}
+                            onClick={onClick ? handleClick : undefined}
+                        />
+                    )}
+                    {/*
+                    <MapLayer
+                        layerKey="admin-0-boundary"
+                        layerOptions={adminZeroLineLayerOptions}
+                    />
+                    */}
+                </>
+            )}
+        />
+    );
+}
+
+export default GlobalMap;

--- a/app/src/components/domain/GlobalMap/index.tsx
+++ b/app/src/components/domain/GlobalMap/index.tsx
@@ -114,11 +114,15 @@ function GlobalMap(props: Props) {
     const fillSortKey = useMemo<number | Expression>(() => [
         'match',
         ['get', 'iso3'],
+        // NOTE: Hovered geoarea should be at the top
         hoveredCountryIso3 ?? '???',
         2,
+        // NOTE: After that, we should have geoarea that is 100%
+        // included in another geoarea
         ...(overlappedDisputedCountriesIso3.filter(
             (iso3) => !(iso3 === hoveredCountryIso3),
         ).flatMap((iso3) => [iso3, 1])),
+        // NOTE: Everything else should be after that
         0,
     ], [hoveredCountryIso3]);
 

--- a/app/src/components/domain/GlobalMap/index.tsx
+++ b/app/src/components/domain/GlobalMap/index.tsx
@@ -6,19 +6,19 @@ import {
 import { LanguageContext } from '@ifrc-go/ui/contexts';
 import { MapLayer } from '@togglecorp/re-map';
 import {
-    Expression,
-    FillLayer,
-    FillPaint,
-    LineLayer,
-    LngLatLike,
-    MapboxGeoJSONFeature,
-    SymbolLayer,
+    type Expression,
+    type FillLayer,
+    type FillPaint,
+    type LineLayer,
+    type LngLatLike,
+    type MapboxGeoJSONFeature,
+    type SymbolLayer,
 } from 'mapbox-gl';
 
 import BaseMap, { type Props as BaseMapProps } from '#components/domain/BaseMap';
 import {
     COLOR_BLACK,
-    CountryRecordTypeEnum,
+    type CountryRecordTypeEnum,
 } from '#utils/constants';
 
 export interface AdminZeroFeatureProperties {

--- a/app/src/components/domain/GlobalMap/index.tsx
+++ b/app/src/components/domain/GlobalMap/index.tsx
@@ -212,10 +212,12 @@ function GlobalMap(props: Props) {
                         layerKey="admin-0-label-priority"
                         layerOptions={adminLabelLayerOptions}
                     />
+                    {/*
                     <MapLayer
-                        layerKey="admin-0-boundary-mask"
+                        layerKey="admin-0-boundary"
                         layerOptions={adminZeroLineLayerOptions}
                     />
+                    */}
                     <MapLayer
                         layerKey="admin-0-boundary-disputed"
                         layerOptions={adminZeroLineLayerOptions}
@@ -227,12 +229,6 @@ function GlobalMap(props: Props) {
                             onClick={onClick ? handleClick : undefined}
                         />
                     )}
-                    {/*
-                    <MapLayer
-                        layerKey="admin-0-boundary"
-                        layerOptions={adminZeroLineLayerOptions}
-                    />
-                    */}
                 </>
             )}
         />

--- a/app/src/components/domain/RiskImminentEventMap/index.tsx
+++ b/app/src/components/domain/RiskImminentEventMap/index.tsx
@@ -29,6 +29,7 @@ import type {
     SymbolLayer,
 } from 'mapbox-gl';
 
+import BaseMap from '#components/domain/BaseMap';
 import MapContainerWithDisclaimer from '#components/MapContainerWithDisclaimer';
 import { type components } from '#generated/riskTypes';
 import useDebouncedValue from '#hooks/useDebouncedValue';
@@ -38,7 +39,6 @@ import {
     DURATION_MAP_ZOOM,
 } from '#utils/constants';
 
-import GlobalMap from '../GlobalMap';
 import LayerOptions, { type LayerOptionsValue } from './LayerOptions';
 import {
     activeHazardPointLayer,
@@ -347,7 +347,7 @@ function RiskImminentEventMap<
 
     return (
         <div className={styles.riskImminentEventMap}>
-            <GlobalMap
+            <BaseMap
                 mapOptions={{ bounds }}
             >
                 <MapContainerWithDisclaimer

--- a/app/src/components/domain/RiskImminentEventMap/index.tsx
+++ b/app/src/components/domain/RiskImminentEventMap/index.tsx
@@ -29,7 +29,6 @@ import type {
     SymbolLayer,
 } from 'mapbox-gl';
 
-import BaseMap from '#components/domain/BaseMap';
 import MapContainerWithDisclaimer from '#components/MapContainerWithDisclaimer';
 import { type components } from '#generated/riskTypes';
 import useDebouncedValue from '#hooks/useDebouncedValue';
@@ -39,6 +38,7 @@ import {
     DURATION_MAP_ZOOM,
 } from '#utils/constants';
 
+import GlobalMap from '../GlobalMap';
 import LayerOptions, { type LayerOptionsValue } from './LayerOptions';
 import {
     activeHazardPointLayer,
@@ -347,7 +347,7 @@ function RiskImminentEventMap<
 
     return (
         <div className={styles.riskImminentEventMap}>
-            <BaseMap
+            <GlobalMap
                 mapOptions={{ bounds }}
             >
                 <MapContainerWithDisclaimer
@@ -469,7 +469,7 @@ function RiskImminentEventMap<
                         padding={DEFAULT_MAP_PADDING}
                     />
                 )}
-            </BaseMap>
+            </GlobalMap>
             <Container
                 heading={sidePanelHeading}
                 className={styles.sidePanel}

--- a/app/src/components/domain/RiskImminentEventMap/index.tsx
+++ b/app/src/components/domain/RiskImminentEventMap/index.tsx
@@ -469,7 +469,7 @@ function RiskImminentEventMap<
                         padding={DEFAULT_MAP_PADDING}
                     />
                 )}
-            </GlobalMap>
+            </BaseMap>
             <Container
                 heading={sidePanelHeading}
                 className={styles.sidePanel}

--- a/app/src/utils/constants.ts
+++ b/app/src/utils/constants.ts
@@ -175,7 +175,7 @@ export const REGION_ASIA = 2 satisfies Region;
 export const REGION_EUROPE = 3 satisfies Region;
 export const REGION_MENA = 4 satisfies Region;
 
-type CountryRecordTypeEnum = components<'read'>['schemas']['ApiCountryTypeEnumKey'];
+export type CountryRecordTypeEnum = components<'read'>['schemas']['ApiCountryTypeEnumKey'];
 // const COUNTRY_RECORD_TYPE_COUNTRY = 1 satisfies CountryRecordTypeEnum;
 // const COUNTRY_RECORD_TYPE_CLUSTER = 2 satisfies CountryRecordTypeEnum;
 export const COUNTRY_RECORD_TYPE_REGION = 3 satisfies CountryRecordTypeEnum;


### PR DESCRIPTION
## Changes

This PR address the styling issues and inconsistent behavior of the overlapping boundaries. 

> The side-effect of this changes in BaseMap is that translation of labels has been removed from the admin layers.

At the moment, changes are only applied to the Active Operation Map visible in the home page.
- [x] src/components/domain/ActiveOperationMap
- [ ] src/components/domain/BaseMapPointInput
- [ ] src/components/domain/RiskImminentEventMap
- [ ] src/components/domain/RiskSeasonalMap
- [ ] src/views/CountryNsOverviewActivities/Map
- [ ] src/views/CountryNsOverviewContextAndStructure/NationalSocietyLocalUnits/LocalUnitsMap
- [ ] src/views/CountryOngoingActivitiesEmergencies
- [ ] src/views/CountryOngoingActivitiesThreeWActivities/ResponseActivitiesMap
- [ ] src/views/CountryOngoingActivitiesThreeWProjects/Map
- [ ] src/views/CountryProfileOverview/PopulationMap
- [ ] src/views/Emergencies/Map
- [ ] src/views/EmergencyActivities/ActivitesMap
- [ ] src/views/EmergencyDetails/EmergencyMap
- [ ] src/views/GlobalThreeW/Map
- [ ] src/views/RegionThreeW/MovementActivitiesMap
- [ ] src/views/SurgeOverview/SurgeMap
- [ ] src/views/ThreeWProjectForm/DistrictMap/DistrictMapModal


## Address

- https://github.com/IFRCGo/go-web-app/issues/1036
- https://github.com/IFRCGo/go-web-app/issues/1417

## Depends on

There are no dependencies on the backend or the mapbox styles.