### PR TITLE
Fix label type for chip component

### DIFF
--- a/.changeset/cold-dingos-cross.md
+++ b/.changeset/cold-dingos-cross.md
@@ -1,0 +1,5 @@
+---
+"@ifrc-go/ui": patch
+---
+
+Fix label type for chip component

--- a/packages/ui/src/components/Chip/index.tsx
+++ b/packages/ui/src/components/Chip/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import React, { useCallback } from 'react';
 import { CloseFillIcon } from '@ifrc-go/icons';
 import {
     _cs,
@@ -22,7 +22,7 @@ const chipVariantToClassNameMap: Record<ChipVariant, string> = {
 export interface Props<N> {
     className?: string;
     name: N;
-    label: string;
+    label: React.ReactNode;
     variant?: ChipVariant;
     onDelete?: (name: N, e: React.MouseEvent<HTMLButtonElement>) => void;
 }


### PR DESCRIPTION


## Changes
- Chip label type change

## This PR doesn't introduce:
- [x] typos
- [x] conflict markers
- [x] unwanted comments
- [x] temporary files, auto-generated files or secret keys
- [x] `console.log` meant for debugging
- [x] codegen errors
