### PR TITLE
Fix the normalization logic in seasonal risk

### DIFF
--- a/app/eslint.config.js
+++ b/app/eslint.config.js
@@ -59,6 +59,15 @@ const appConfigs = compat.config({
         'no-shadow': 0,
         '@typescript-eslint/no-shadow': ['error'],
 
+        '@typescript-eslint/consistent-type-imports': [
+            'warn',
+            {
+                disallowTypeAnnotations: false,
+                fixStyle: 'inline-type-imports',
+                prefer: 'type-imports',
+            },
+        ],
+
         'import/no-extraneous-dependencies': [
             'error',
             {

--- a/app/src/App/index.tsx
+++ b/app/src/App/index.tsx
@@ -31,8 +31,8 @@ import {
 } from '#config';
 import RouteContext from '#contexts/route';
 import UserContext, {
-    UserAuth,
-    UserContextProps,
+    type UserAuth,
+    type UserContextProps,
 } from '#contexts/user';
 import {
     KEY_LANGUAGE_STORAGE,

--- a/app/src/components/CatalogueInfoCard/index.tsx
+++ b/app/src/components/CatalogueInfoCard/index.tsx
@@ -5,7 +5,7 @@ import {
 } from '@ifrc-go/ui';
 import { _cs } from '@togglecorp/fujs';
 
-import Link, { Props as LinkProps } from '#components/Link';
+import Link, { type Props as LinkProps } from '#components/Link';
 
 import styles from './styles.module.css';
 

--- a/app/src/components/DropdownMenuItem/index.tsx
+++ b/app/src/components/DropdownMenuItem/index.tsx
@@ -4,14 +4,14 @@ import {
 } from 'react';
 import {
     Button,
-    ButtonProps,
+    type ButtonProps,
     ConfirmButton,
-    ConfirmButtonProps,
+    type ConfirmButtonProps,
 } from '@ifrc-go/ui';
 import { DropdownMenuContext } from '@ifrc-go/ui/contexts';
 import { isDefined } from '@togglecorp/fujs';
 
-import Link, { Props as LinkProps } from '#components/Link';
+import Link, { type Props as LinkProps } from '#components/Link';
 
 type CommonProp = {
     persist?: boolean;

--- a/app/src/components/Link/index.tsx
+++ b/app/src/components/Link/index.tsx
@@ -5,7 +5,7 @@ import {
 import {
     generatePath,
     Link as InternalLink,
-    LinkProps as RouterLinkProps,
+    type LinkProps as RouterLinkProps,
 } from 'react-router-dom';
 import {
     ChevronRightLineIcon,

--- a/app/src/components/MapPopup/index.tsx
+++ b/app/src/components/MapPopup/index.tsx
@@ -3,7 +3,7 @@ import { CloseLineIcon } from '@ifrc-go/icons';
 import {
     Button,
     Container,
-    ContainerProps,
+    type ContainerProps,
 } from '@ifrc-go/ui';
 import { useTranslation } from '@ifrc-go/ui/hooks';
 import { _cs } from '@togglecorp/fujs';

--- a/app/src/components/NonFieldError/index.tsx
+++ b/app/src/components/NonFieldError/index.tsx
@@ -8,7 +8,7 @@ import {
 } from '@togglecorp/fujs';
 import {
     analyzeErrors,
-    Error,
+    type Error,
     getErrorObject,
     nonFieldError,
 } from '@togglecorp/toggle-form';

--- a/app/src/components/Page/index.tsx
+++ b/app/src/components/Page/index.tsx
@@ -1,6 +1,6 @@
 import {
-    ElementRef,
-    RefObject,
+    type ElementRef,
+    type RefObject,
     useEffect,
 } from 'react';
 import {
@@ -19,7 +19,7 @@ import {
     isNotDefined,
 } from '@togglecorp/fujs';
 
-import { components } from '#generated/types';
+import { type components } from '#generated/types';
 import useCurrentLanguage from '#hooks/domain/useCurrentLanguage';
 
 import i18n from './i18n.json';

--- a/app/src/components/RichTextArea/index.tsx
+++ b/app/src/components/RichTextArea/index.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import {
     InputContainer,
-    InputContainerProps,
+    type InputContainerProps,
 } from '@ifrc-go/ui';
 import {
     Editor,
-    IAllProps,
+    type IAllProps,
 } from '@tinymce/tinymce-react';
 import { _cs } from '@togglecorp/fujs';
 

--- a/app/src/components/domain/ActiveCountryBaseMapLayer/index.tsx
+++ b/app/src/components/domain/ActiveCountryBaseMapLayer/index.tsx
@@ -1,9 +1,9 @@
 import { useMemo } from 'react';
 import { MapLayer } from '@togglecorp/re-map';
 import {
-    FillLayer,
-    LineLayer,
-    SymbolLayer,
+    type FillLayer,
+    type LineLayer,
+    type SymbolLayer,
 } from 'mapbox-gl';
 
 import {

--- a/app/src/components/domain/ActiveOperationMap/index.tsx
+++ b/app/src/components/domain/ActiveOperationMap/index.tsx
@@ -69,7 +69,7 @@ import {
     optionLabelSelector,
     outerCircleLayerOptionsForFinancialRequirements,
     outerCircleLayerOptionsForPeopleTargeted,
-    ScaleOption,
+    type ScaleOption,
 } from './utils';
 
 import i18n from './i18n.json';

--- a/app/src/components/domain/ActivityEventSearchSelectInput.tsx
+++ b/app/src/components/domain/ActivityEventSearchSelectInput.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import {
     SearchSelectInput,
-    SearchSelectInputProps,
+    type SearchSelectInputProps,
 } from '@ifrc-go/ui';
 
 import useDebouncedValue from '#hooks/useDebouncedValue';

--- a/app/src/components/domain/BaseMapPointInput/index.tsx
+++ b/app/src/components/domain/BaseMapPointInput/index.tsx
@@ -14,18 +14,18 @@ import {
     MapLayer,
     MapSource,
 } from '@togglecorp/re-map';
-import { ObjectError } from '@togglecorp/toggle-form';
+import { type ObjectError } from '@togglecorp/toggle-form';
 import getBbox from '@turf/bbox';
 import {
-    CircleLayer,
-    FillLayer,
-    LngLat,
-    Map,
-    MapboxGeoJSONFeature,
-    Point,
+    type CircleLayer,
+    type FillLayer,
+    type LngLat,
+    type Map,
+    type MapboxGeoJSONFeature,
+    type Point,
 } from 'mapbox-gl';
 
-import BaseMap, { Props as BaseMapProps } from '#components/domain/BaseMap';
+import BaseMap, { type Props as BaseMapProps } from '#components/domain/BaseMap';
 import useCountry from '#hooks/domain/useCountry';
 import {
     COLOR_LIGHT_GREY,

--- a/app/src/components/domain/CountryMultiSelectInput.tsx
+++ b/app/src/components/domain/CountryMultiSelectInput.tsx
@@ -1,13 +1,13 @@
 import {
     MultiSelectInput,
-    MultiSelectInputProps,
+    type MultiSelectInputProps,
 } from '@ifrc-go/ui';
 import {
     numericIdSelector,
     stringNameSelector,
 } from '@ifrc-go/ui/utils';
 
-import useCountry, { Country } from '#hooks/domain/useCountry';
+import useCountry, { type Country } from '#hooks/domain/useCountry';
 
 export type CountryOption = Country;
 

--- a/app/src/components/domain/CountrySelectInput.tsx
+++ b/app/src/components/domain/CountrySelectInput.tsx
@@ -1,13 +1,13 @@
 import {
     SelectInput,
-    SelectInputProps,
+    type SelectInputProps,
 } from '@ifrc-go/ui';
 import {
     numericIdSelector,
     stringNameSelector,
 } from '@ifrc-go/ui/utils';
 
-import useCountry, { Country } from '#hooks/domain/useCountry';
+import useCountry, { type Country } from '#hooks/domain/useCountry';
 
 type Props<NAME> = SelectInputProps<
     number,

--- a/app/src/components/domain/DisasterTypeSelectInput.tsx
+++ b/app/src/components/domain/DisasterTypeSelectInput.tsx
@@ -1,9 +1,9 @@
 import {
     SelectInput,
-    SelectInputProps,
+    type SelectInputProps,
 } from '@ifrc-go/ui';
 
-import { DisasterTypes } from '#contexts/domain';
+import { type DisasterTypes } from '#contexts/domain';
 import useDisasterType from '#hooks/domain/useDisasterType';
 
 export type DisasterTypeItem = NonNullable<DisasterTypes['results']>[number];

--- a/app/src/components/domain/DistrictMultiCountrySearchMultiSelectInput.tsx
+++ b/app/src/components/domain/DistrictMultiCountrySearchMultiSelectInput.tsx
@@ -1,11 +1,11 @@
 import { useState } from 'react';
 import {
     SearchMultiSelectInput,
-    SearchMultiSelectInputProps,
+    type SearchMultiSelectInputProps,
 } from '@ifrc-go/ui';
 import { isNotDefined } from '@togglecorp/fujs';
 
-import { paths } from '#generated/types';
+import { type paths } from '#generated/types';
 import useDebouncedValue from '#hooks/useDebouncedValue';
 import { useRequest } from '#utils/restRequest';
 

--- a/app/src/components/domain/DistrictSearchMultiSelectInput/index.tsx
+++ b/app/src/components/domain/DistrictSearchMultiSelectInput/index.tsx
@@ -6,7 +6,7 @@ import { CheckDoubleFillIcon } from '@ifrc-go/icons';
 import {
     Button,
     SearchMultiSelectInput,
-    SearchMultiSelectInputProps,
+    type SearchMultiSelectInputProps,
 } from '@ifrc-go/ui';
 import { useTranslation } from '@ifrc-go/ui/hooks';
 import {

--- a/app/src/components/domain/EventSearchSelectInput.tsx
+++ b/app/src/components/domain/EventSearchSelectInput.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import {
     SearchSelectInput,
-    SearchSelectInputProps,
+    type SearchSelectInputProps,
 } from '@ifrc-go/ui';
 
 import useDebouncedValue from '#hooks/useDebouncedValue';

--- a/app/src/components/domain/FieldReportSearchSelectInput.tsx
+++ b/app/src/components/domain/FieldReportSearchSelectInput.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import {
     SearchSelectInput,
-    SearchSelectInputProps,
+    type SearchSelectInputProps,
 } from '@ifrc-go/ui';
 
 import useDebouncedValue from '#hooks/useDebouncedValue';

--- a/app/src/components/domain/GoMultiFileInput/index.tsx
+++ b/app/src/components/domain/GoMultiFileInput/index.tsx
@@ -3,13 +3,13 @@ import React, {
     useRef,
 } from 'react';
 import { DeleteBinFillIcon } from '@ifrc-go/icons';
-import type { ButtonVariant } from '@ifrc-go/ui';
-import {
+import type {
     Button,
+    ButtonVariant,
     InputError,
-    NameType,
+    type NameType,
     RawFileInput,
-    RawFileInputProps,
+    type RawFileInputProps,
 } from '@ifrc-go/ui';
 import { useTranslation } from '@ifrc-go/ui/hooks';
 import {

--- a/app/src/components/domain/GoSingleFileInput/index.tsx
+++ b/app/src/components/domain/GoSingleFileInput/index.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from 'react';
 import { DeleteBinLineIcon } from '@ifrc-go/icons';
 import {
-    ButtonVariant,
+    type ButtonVariant,
     IconButton,
     InputError,
     type NameType,

--- a/app/src/components/domain/NationalSocietyMultiSelectInput.tsx
+++ b/app/src/components/domain/NationalSocietyMultiSelectInput.tsx
@@ -1,10 +1,10 @@
 import {
     MultiSelectInput,
-    MultiSelectInputProps,
+    type MultiSelectInputProps,
 } from '@ifrc-go/ui';
 import { numericIdSelector } from '@ifrc-go/ui/utils';
 
-import useNationalSociety, { NationalSociety } from '#hooks/domain/useNationalSociety';
+import useNationalSociety, { type NationalSociety } from '#hooks/domain/useNationalSociety';
 
 function countrySocietyNameSelector(country: NationalSociety) {
     return country.society_name;

--- a/app/src/components/domain/NationalSocietySelectInput.tsx
+++ b/app/src/components/domain/NationalSocietySelectInput.tsx
@@ -1,11 +1,11 @@
 import {
     SelectInput,
-    SelectInputProps,
+    type SelectInputProps,
 } from '@ifrc-go/ui';
 import { numericIdSelector } from '@ifrc-go/ui/utils';
 import { isDefined } from '@togglecorp/fujs';
 
-import useNationalSociety, { NationalSociety } from '#hooks/domain/useNationalSociety';
+import useNationalSociety, { type NationalSociety } from '#hooks/domain/useNationalSociety';
 
 function countrySocietyNameSelector(country: NationalSociety) {
     return country.society_name;

--- a/app/src/components/domain/PerAssessmentSummary/index.tsx
+++ b/app/src/components/domain/PerAssessmentSummary/index.tsx
@@ -20,7 +20,7 @@ import {
     listToMap,
     mapToList,
 } from '@togglecorp/fujs';
-import { PartialForm } from '@togglecorp/toggle-form';
+import { type PartialForm } from '@togglecorp/toggle-form';
 
 import {
     getPerAreaColor,

--- a/app/src/components/domain/RegionSelectInput.tsx
+++ b/app/src/components/domain/RegionSelectInput.tsx
@@ -1,6 +1,6 @@
 import {
     SelectInput,
-    SelectInputProps,
+    type SelectInputProps,
 } from '@ifrc-go/ui';
 import { stringValueSelector } from '@ifrc-go/ui/utils';
 

--- a/app/src/components/domain/RiskImminentEventMap/LayerOptions/index.tsx
+++ b/app/src/components/domain/RiskImminentEventMap/LayerOptions/index.tsx
@@ -13,7 +13,7 @@ import {
     COLOR_RED,
 } from '#utils/constants';
 
-import { RiskLayerSeverity } from '../utils';
+import { type RiskLayerSeverity } from '../utils';
 
 import styles from './styles.module.css';
 

--- a/app/src/components/domain/RiskImminentEventMap/index.tsx
+++ b/app/src/components/domain/RiskImminentEventMap/index.tsx
@@ -39,7 +39,7 @@ import {
     DURATION_MAP_ZOOM,
 } from '#utils/constants';
 
-import LayerOptions, { LayerOptionsValue } from './LayerOptions';
+import LayerOptions, { type LayerOptionsValue } from './LayerOptions';
 import {
     activeHazardPointLayer,
     exposureFillLayer,
@@ -57,7 +57,7 @@ import {
     trackPointOuterCircleLayer,
     uncertaintyConeLayer,
 } from './mapStyles';
-import { RiskLayerProperties } from './utils';
+import { type RiskLayerProperties } from './utils';
 
 import i18n from './i18n.json';
 import styles from './styles.module.css';

--- a/app/src/components/domain/RiskImminentEvents/Gdacs/EventListItem/index.tsx
+++ b/app/src/components/domain/RiskImminentEvents/Gdacs/EventListItem/index.tsx
@@ -14,7 +14,7 @@ import {
 import { useTranslation } from '@ifrc-go/ui/hooks';
 import { _cs } from '@togglecorp/fujs';
 
-import { RiskEventListItemProps } from '#components/domain/RiskImminentEventMap';
+import { type RiskEventListItemProps } from '#components/domain/RiskImminentEventMap';
 import { type RiskApiResponse } from '#utils/restRequest';
 
 import i18n from './i18n.json';

--- a/app/src/components/domain/RiskImminentEvents/Gdacs/index.tsx
+++ b/app/src/components/domain/RiskImminentEvents/Gdacs/index.tsx
@@ -8,12 +8,12 @@ import { type LngLatBoundsLike } from 'mapbox-gl';
 
 import RiskImminentEventMap, { type EventPointFeature } from '#components/domain/RiskImminentEventMap';
 import {
-    RiskLayerProperties,
-    RiskLayerSeverity,
+    type RiskLayerProperties,
+    type RiskLayerSeverity,
 } from '#components/domain/RiskImminentEventMap/utils';
 import { isValidFeatureCollection } from '#utils/domain/risk';
 import {
-    RiskApiResponse,
+    type RiskApiResponse,
     useRiskLazyRequest,
     useRiskRequest,
 } from '#utils/restRequest';

--- a/app/src/components/domain/RiskImminentEvents/MeteoSwiss/EventListItem/index.tsx
+++ b/app/src/components/domain/RiskImminentEvents/MeteoSwiss/EventListItem/index.tsx
@@ -14,7 +14,7 @@ import {
 import { useTranslation } from '@ifrc-go/ui/hooks';
 import { _cs } from '@togglecorp/fujs';
 
-import { RiskEventListItemProps } from '#components/domain/RiskImminentEventMap';
+import { type RiskEventListItemProps } from '#components/domain/RiskImminentEventMap';
 import { type RiskApiResponse } from '#utils/restRequest';
 
 import i18n from './i18n.json';

--- a/app/src/components/domain/RiskImminentEvents/MeteoSwiss/index.tsx
+++ b/app/src/components/domain/RiskImminentEvents/MeteoSwiss/index.tsx
@@ -8,7 +8,7 @@ import type { LngLatBoundsLike } from 'mapbox-gl';
 
 import type { EventPointFeature } from '#components/domain/RiskImminentEventMap';
 import RiskImminentEventMap from '#components/domain/RiskImminentEventMap';
-import { RiskLayerProperties } from '#components/domain/RiskImminentEventMap/utils';
+import { type RiskLayerProperties } from '#components/domain/RiskImminentEventMap/utils';
 import { isValidFeatureCollection } from '#utils/domain/risk';
 import {
     type RiskApiResponse,

--- a/app/src/components/domain/RiskImminentEvents/Pdc/EventListItem/index.tsx
+++ b/app/src/components/domain/RiskImminentEvents/Pdc/EventListItem/index.tsx
@@ -14,7 +14,7 @@ import {
 import { useTranslation } from '@ifrc-go/ui/hooks';
 import { _cs } from '@togglecorp/fujs';
 
-import { RiskEventListItemProps } from '#components/domain/RiskImminentEventMap';
+import { type RiskEventListItemProps } from '#components/domain/RiskImminentEventMap';
 import { type RiskApiResponse } from '#utils/restRequest';
 
 import i18n from './i18n.json';

--- a/app/src/components/domain/RiskImminentEvents/Pdc/index.tsx
+++ b/app/src/components/domain/RiskImminentEvents/Pdc/index.tsx
@@ -10,7 +10,7 @@ import {
 import { type LngLatBoundsLike } from 'mapbox-gl';
 
 import RiskImminentEventMap, { type EventPointFeature } from '#components/domain/RiskImminentEventMap';
-import { RiskLayerProperties } from '#components/domain/RiskImminentEventMap/utils';
+import { type RiskLayerProperties } from '#components/domain/RiskImminentEventMap/utils';
 import {
     isValidFeature,
     isValidPointFeature,

--- a/app/src/components/domain/RiskImminentEvents/WfpAdam/EventListItem/index.tsx
+++ b/app/src/components/domain/RiskImminentEvents/WfpAdam/EventListItem/index.tsx
@@ -14,7 +14,7 @@ import {
 import { useTranslation } from '@ifrc-go/ui/hooks';
 import { _cs } from '@togglecorp/fujs';
 
-import { RiskEventListItemProps } from '#components/domain/RiskImminentEventMap';
+import { type RiskEventListItemProps } from '#components/domain/RiskImminentEventMap';
 import { type RiskApiResponse } from '#utils/restRequest';
 
 import i18n from './i18n.json';

--- a/app/src/components/domain/RiskImminentEvents/WfpAdam/index.tsx
+++ b/app/src/components/domain/RiskImminentEvents/WfpAdam/index.tsx
@@ -8,8 +8,8 @@ import { type LngLatBoundsLike } from 'mapbox-gl';
 
 import RiskImminentEventMap, { type EventPointFeature } from '#components/domain/RiskImminentEventMap';
 import {
-    RiskLayerProperties,
-    RiskLayerSeverity,
+    type RiskLayerProperties,
+    type RiskLayerSeverity,
 } from '#components/domain/RiskImminentEventMap/utils';
 import { isValidFeatureCollection } from '#utils/domain/risk';
 import {

--- a/app/src/components/domain/RiskSeasonalMap/Filters/index.tsx
+++ b/app/src/components/domain/RiskSeasonalMap/Filters/index.tsx
@@ -122,7 +122,7 @@ function Filters(props: Props) {
                     value={value.normalizeByPopulation}
                     onChange={handleChange}
                 />
-                {value.riskMetric !== 'riskScore' && (
+                {value.riskMetric === 'riskScore' && (
                     <Checkbox
                         name="includeCopingCapacity"
                         label={strings.riskCopingCapacity}

--- a/app/src/components/domain/RiskSeasonalMap/Filters/index.tsx
+++ b/app/src/components/domain/RiskSeasonalMap/Filters/index.tsx
@@ -11,7 +11,7 @@ import {
     stringLabelSelector,
     stringNameSelector,
 } from '@ifrc-go/ui/utils';
-import { EntriesAsList } from '@togglecorp/toggle-form';
+import { type EntriesAsList } from '@togglecorp/toggle-form';
 
 import useCountry from '#hooks/domain/useCountry';
 import {

--- a/app/src/components/domain/RiskSeasonalMap/index.tsx
+++ b/app/src/components/domain/RiskSeasonalMap/index.tsx
@@ -528,7 +528,15 @@ function RiskSeasonalMap(props: Props) {
                 ),
             ).filter(isDefined);
 
+            /*
             const maxPopulation = maxSafe(
+                populationListSafe.map(
+                    (item) => item.population_in_thousands,
+                ),
+            ) ?? 1;
+            */
+
+            const totalPopulation = sumSafe(
                 populationListSafe.map(
                     (item) => item.population_in_thousands,
                 ),
@@ -537,7 +545,7 @@ function RiskSeasonalMap(props: Props) {
             const populationFactorMap = listToMap(
                 populationListSafe,
                 (result) => result.iso3,
-                (result) => result.population_in_thousands / maxPopulation,
+                (result) => 1 - (result.population_in_thousands / totalPopulation) ** (1 / 4),
             );
 
             const populationMap = listToMap(
@@ -692,7 +700,7 @@ function RiskSeasonalMap(props: Props) {
                                     }
                                 }
 
-                                if (filters.riskMetric !== 'riskScore' && filters.includeCopingCapacity) {
+                                if (filters.riskMetric === 'riskScore' && filters.includeCopingCapacity) {
                                     const lccFactor = mappings?.lccFactor[
                                         item.country_details.iso3
                                     ];

--- a/app/src/components/domain/RiskSeasonalMap/index.tsx
+++ b/app/src/components/domain/RiskSeasonalMap/index.tsx
@@ -70,7 +70,7 @@ import {
     type HazardTypeOption,
     hazardTypeToColorMap,
     type RiskDataItem,
-    RiskMetric,
+    type RiskMetric,
     type RiskMetricOption,
     riskScoreToCategory,
 } from '#utils/domain/risk';
@@ -536,15 +536,19 @@ function RiskSeasonalMap(props: Props) {
             ) ?? 1;
             */
 
-            const totalPopulation = sumSafe(
-                populationListSafe.map(
-                    (item) => item.population_in_thousands,
-                ),
-            ) ?? 1;
+            const totalPopulation = Math.max(
+                sumSafe(
+                    populationListSafe.map(
+                        (item) => item.population_in_thousands,
+                    ),
+                ) ?? 0,
+                1,
+            );
 
             const populationFactorMap = listToMap(
                 populationListSafe,
                 (result) => result.iso3,
+                // FIXME: Let's try to update this logic later
                 (result) => 1 - (result.population_in_thousands / totalPopulation) ** (1 / 4),
             );
 

--- a/app/src/components/domain/SurgeCatalogueContainer/index.tsx
+++ b/app/src/components/domain/SurgeCatalogueContainer/index.tsx
@@ -10,7 +10,7 @@ import { isDefined } from '@togglecorp/fujs';
 
 import useRouting from '#hooks/useRouting';
 
-import { WrappedRoutes } from '../../../App/routes';
+import { type WrappedRoutes } from '../../../App/routes';
 
 import i18n from './i18n.json';
 import styles from './styles.module.css';

--- a/app/src/components/domain/UserSearchMultiSelectInput.tsx
+++ b/app/src/components/domain/UserSearchMultiSelectInput.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import {
     SearchMultiSelectInput,
-    SearchMultiSelectInputProps,
+    type SearchMultiSelectInputProps,
 } from '@ifrc-go/ui';
 
 import useDebouncedValue from '#hooks/useDebouncedValue';

--- a/app/src/hooks/domain/useDisasterType.ts
+++ b/app/src/hooks/domain/useDisasterType.ts
@@ -5,7 +5,7 @@ import {
 } from 'react';
 import { isTruthyString } from '@togglecorp/fujs';
 
-import DomainContext, { DisasterTypes } from '#contexts/domain';
+import DomainContext, { type DisasterTypes } from '#contexts/domain';
 
 type PartialDisasterType = NonNullable<DisasterTypes['results']>[number];
 

--- a/app/src/hooks/domain/useGlobalEnums.ts
+++ b/app/src/hooks/domain/useGlobalEnums.ts
@@ -3,7 +3,7 @@ import {
     useEffect,
 } from 'react';
 
-import DomainContext, { GlobalEnums } from '#contexts/domain';
+import DomainContext, { type GlobalEnums } from '#contexts/domain';
 
 const defaultGlobalEnums: GlobalEnums = {};
 

--- a/app/src/hooks/domain/usePerComponent.ts
+++ b/app/src/hooks/domain/usePerComponent.ts
@@ -5,7 +5,7 @@ import {
 } from 'react';
 import { isDefined } from '@togglecorp/fujs';
 
-import DomainContext, { PerComponents } from '#contexts/domain';
+import DomainContext, { type PerComponents } from '#contexts/domain';
 
 export type PerComponent = NonNullable<PerComponents['results']>[number];
 

--- a/app/src/hooks/useFilterState.ts
+++ b/app/src/hooks/useFilterState.ts
@@ -6,7 +6,7 @@ import {
 } from 'react';
 import { hasSomeDefinedValue } from '@ifrc-go/ui/utils';
 import { isNotDefined } from '@togglecorp/fujs';
-import { EntriesAsList } from '@togglecorp/toggle-form';
+import { type EntriesAsList } from '@togglecorp/toggle-form';
 
 import useDebouncedValue from '#hooks/useDebouncedValue';
 

--- a/app/src/hooks/useSetFieldValue.ts
+++ b/app/src/hooks/useSetFieldValue.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 import {
-    EntriesAsList,
+    type EntriesAsList,
     isCallable,
 } from '@togglecorp/toggle-form';
 

--- a/app/src/hooks/useUrlSearchState.ts
+++ b/app/src/hooks/useUrlSearchState.ts
@@ -5,7 +5,7 @@ import {
     useRef,
 } from 'react';
 import {
-    NavigateOptions,
+    type NavigateOptions,
     useSearchParams,
 } from 'react-router-dom';
 import {

--- a/app/src/utils/constants.ts
+++ b/app/src/utils/constants.ts
@@ -1,3 +1,5 @@
+import { listToMap } from '@togglecorp/fujs';
+
 import { type components } from '#generated/types';
 
 export const defaultChartMargin = {
@@ -199,3 +201,10 @@ type SupportedByOrganizationType = components<'read'>['schemas']['PerSupportedBy
 export const NATIONAL_SOCIETY = 3 satisfies SupportedByOrganizationType;
 
 export const MAX_PAGE_LIMIT = 9999;
+
+export const monthKeyList = Array.from(Array(12).keys());
+export const multiMonthSelectDefaultValue = listToMap(
+    monthKeyList,
+    (key) => key,
+    () => false,
+);

--- a/app/src/utils/domain/dref.ts
+++ b/app/src/utils/domain/dref.ts
@@ -1,4 +1,4 @@
-import { components } from '#generated/types';
+import { type components } from '#generated/types';
 
 type PlannedIntervention = components<'read'>['schemas']['PlannedIntervention'];
 type PlannedInterventionTitle = NonNullable<PlannedIntervention['title']>;

--- a/app/src/utils/domain/tableHelpers.ts
+++ b/app/src/utils/domain/tableHelpers.ts
@@ -5,7 +5,7 @@ import {
     ReducedListDisplay,
     type ReducedListDisplayProps,
     type SortDirection,
-    TableActionsProps,
+    type TableActionsProps,
 } from '@ifrc-go/ui';
 import { numericIdSelector } from '@ifrc-go/ui/utils';
 

--- a/app/src/utils/form.ts
+++ b/app/src/utils/form.ts
@@ -7,7 +7,7 @@ import {
 } from '@togglecorp/fujs';
 import {
     isCallable,
-    SetValueArg,
+    type SetValueArg,
 } from '@togglecorp/toggle-form';
 
 function isNumber(value: unknown): value is number {

--- a/app/src/utils/restRequest/go.ts
+++ b/app/src/utils/restRequest/go.ts
@@ -4,7 +4,7 @@ import {
     isFalsyString,
     isNotDefined,
 } from '@togglecorp/fujs';
-import { ContextInterface } from '@togglecorp/toggle-request';
+import { type ContextInterface } from '@togglecorp/toggle-request';
 
 import {
     api,

--- a/app/src/utils/restRequest/overrideTypes.ts
+++ b/app/src/utils/restRequest/overrideTypes.ts
@@ -1,14 +1,14 @@
 import { type DeepNevaRemove } from '@ifrc-go/ui/utils';
 import {
-    LazyRequestOptions,
-    RequestOptions,
-    useLazyRequest,
-    useRequest,
+    type LazyRequestOptions,
+    type RequestOptions,
+    type useLazyRequest,
+    type useRequest,
 } from '@togglecorp/toggle-request';
 
 import {
-    AdditionalOptions,
-    TransformedError,
+    type AdditionalOptions,
+    type TransformedError,
 } from './go';
 
 export type VALID_METHOD = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';

--- a/app/src/utils/routes.tsx
+++ b/app/src/utils/routes.tsx
@@ -1,7 +1,7 @@
 import {
-    IndexRouteObject,
-    NonIndexRouteObject,
-    RouteObject,
+    type IndexRouteObject,
+    type NonIndexRouteObject,
+    type RouteObject,
 } from 'react-router-dom';
 import {
     isDefined,

--- a/app/src/views/AccountDetails/ChangePassword/index.tsx
+++ b/app/src/views/AccountDetails/ChangePassword/index.tsx
@@ -13,8 +13,8 @@ import {
     addCondition,
     createSubmitHandler,
     getErrorObject,
-    ObjectSchema,
-    PartialForm,
+    type ObjectSchema,
+    type PartialForm,
     requiredStringCondition,
     undefinedValue,
     useForm,
@@ -23,7 +23,7 @@ import {
 import NonFieldError from '#components/NonFieldError';
 import useAlert from '#hooks/useAlert';
 import {
-    GoApiBody,
+    type GoApiBody,
     useLazyRequest,
 } from '#utils/restRequest';
 import { transformObjectError } from '#utils/restRequest/error';

--- a/app/src/views/AccountDetails/TokenDetails/index.tsx
+++ b/app/src/views/AccountDetails/TokenDetails/index.tsx
@@ -12,7 +12,7 @@ import {
 } from '@togglecorp/fujs';
 
 import useAlert from '#hooks/useAlert';
-import { GoApiResponse } from '#utils/restRequest';
+import { type GoApiResponse } from '#utils/restRequest';
 
 import i18n from './i18n.json';
 import styles from './styles.module.css';

--- a/app/src/views/AccountMyFormsDref/DownloadImportTemplateButton/DownloadImportTemplateModal/index.tsx
+++ b/app/src/views/AccountMyFormsDref/DownloadImportTemplateButton/DownloadImportTemplateModal/index.tsx
@@ -18,7 +18,7 @@ import {
 import useGlobalEnums from '#hooks/domain/useGlobalEnums';
 import {
     DREF_TYPE_RESPONSE,
-    TypeOfDrefEnum,
+    type TypeOfDrefEnum,
 } from '#utils/constants';
 import { createImportTemplate } from '#utils/importTemplate';
 

--- a/app/src/views/AccountMyFormsDref/DownloadImportTemplateButton/DownloadImportTemplateModal/useImportTemplateSchema.ts
+++ b/app/src/views/AccountMyFormsDref/DownloadImportTemplateButton/DownloadImportTemplateModal/useImportTemplateSchema.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 
 import useCountry from '#hooks/domain/useCountry';
-import useDisasterTypes, { DisasterType } from '#hooks/domain/useDisasterType';
+import useDisasterTypes, { type DisasterType } from '#hooks/domain/useDisasterType';
 import useGlobalEnums from '#hooks/domain/useGlobalEnums';
 import useNationalSociety from '#hooks/domain/useNationalSociety';
 import { type TemplateSchema } from '#utils/importTemplate';

--- a/app/src/views/AccountMyFormsDref/DownloadImportTemplateButton/DownloadImportTemplateModal/utils.ts
+++ b/app/src/views/AccountMyFormsDref/DownloadImportTemplateButton/DownloadImportTemplateModal/utils.ts
@@ -22,10 +22,10 @@ import {
     COLOR_WHITE,
     DREF_TYPE_RESPONSE,
     FONT_FAMILY_HEADER,
-    TypeOfDrefEnum,
+    type TypeOfDrefEnum,
 } from '#utils/constants';
 import {
-    DrefSheetName,
+    type DrefSheetName,
     SHEET_ACTIONS_NEEDS,
     SHEET_EVENT_DETAIL,
     SHEET_OPERATION,
@@ -45,7 +45,7 @@ import {
     timeframeAndContactsTabFields,
 } from '#views/DrefApplicationForm/common';
 
-import { OptionsMapping } from './useImportTemplateSchema';
+import { type OptionsMapping } from './useImportTemplateSchema';
 
 // FIXME: move to utils
 function hexToArgb(hexStr: string, alphaStr = 'ff') {

--- a/app/src/views/AccountMyFormsDref/DrefTableActions/index.tsx
+++ b/app/src/views/AccountMyFormsDref/DrefTableActions/index.tsx
@@ -30,10 +30,10 @@ import {
     DREF_STATUS_IN_PROGRESS,
     DREF_TYPE_IMMINENT,
     DREF_TYPE_LOAN,
-    DrefStatus,
+    type DrefStatus,
 } from '#utils/constants';
 import {
-    GoApiBody,
+    type GoApiBody,
     useLazyRequest,
 } from '#utils/restRequest';
 

--- a/app/src/views/AccountMyFormsDref/Filters/index.tsx
+++ b/app/src/views/AccountMyFormsDref/Filters/index.tsx
@@ -4,7 +4,7 @@ import {
 } from '@ifrc-go/ui';
 import { useTranslation } from '@ifrc-go/ui/hooks';
 import { stringValueSelector } from '@ifrc-go/ui/utils';
-import { EntriesAsList } from '@togglecorp/toggle-form';
+import { type EntriesAsList } from '@togglecorp/toggle-form';
 
 import CountrySelectInput from '#components/domain/CountrySelectInput';
 import DisasterTypeSelectInput from '#components/domain/DisasterTypeSelectInput';

--- a/app/src/views/AccountMyFormsFieldReport/index.tsx
+++ b/app/src/views/AccountMyFormsFieldReport/index.tsx
@@ -23,7 +23,7 @@ import {
     createLinkColumn,
 } from '#utils/domain/tableHelpers';
 import {
-    GoApiResponse,
+    type GoApiResponse,
     useRequest,
 } from '#utils/restRequest';
 

--- a/app/src/views/AllFieldReports/index.tsx
+++ b/app/src/views/AllFieldReports/index.tsx
@@ -25,7 +25,7 @@ import DisasterTypeSelectInput from '#components/domain/DisasterTypeSelectInput'
 import ExportButton from '#components/domain/ExportButton';
 import RegionSelectInput from '#components/domain/RegionSelectInput';
 import Page from '#components/Page';
-import { components } from '#generated/types';
+import { type components } from '#generated/types';
 import useAlert from '#hooks/useAlert';
 import useFilterState from '#hooks/useFilterState';
 import useRecursiveCsvExport from '#hooks/useRecursiveCsvRequest';

--- a/app/src/views/AllFlashUpdates/index.tsx
+++ b/app/src/views/AllFlashUpdates/index.tsx
@@ -23,7 +23,7 @@ import {
 import type { GoApiResponse } from '#utils/restRequest';
 import { useRequest } from '#utils/restRequest';
 
-import FlashUpdatesTableAction, { Props as FlashUpdatesTableActions } from './FlashUpdatesTableActions';
+import FlashUpdatesTableAction, { type Props as FlashUpdatesTableActions } from './FlashUpdatesTableActions';
 
 import i18n from './i18n.json';
 import styles from './styles.module.css';

--- a/app/src/views/CountryAdditionalInfo/index.tsx
+++ b/app/src/views/CountryAdditionalInfo/index.tsx
@@ -9,7 +9,7 @@ import {
 import {
     Container,
     HtmlOutput,
-    HtmlOutputProps,
+    type HtmlOutputProps,
     List,
     Message,
     Table,

--- a/app/src/views/CountryNsOverview/index.tsx
+++ b/app/src/views/CountryNsOverview/index.tsx
@@ -6,7 +6,7 @@ import { NavigationTabList } from '@ifrc-go/ui';
 import { useTranslation } from '@ifrc-go/ui/hooks';
 
 import NavigationTab from '#components/NavigationTab';
-import { CountryOutletContext } from '#utils/outletContext';
+import { type CountryOutletContext } from '#utils/outletContext';
 
 import i18n from './i18n.json';
 import styles from './styles.module.css';

--- a/app/src/views/CountryNsOverviewActivities/Filters/index.tsx
+++ b/app/src/views/CountryNsOverviewActivities/Filters/index.tsx
@@ -6,9 +6,9 @@ import {
     stringLabelSelector,
     stringValueSelector,
 } from '@ifrc-go/ui/utils';
-import { EntriesAsList } from '@togglecorp/toggle-form';
+import { type EntriesAsList } from '@togglecorp/toggle-form';
 
-import useCountryRaw, { Country } from '#hooks/domain/useCountryRaw';
+import useCountryRaw, { type Country } from '#hooks/domain/useCountryRaw';
 import useGlobalEnums from '#hooks/domain/useGlobalEnums';
 import { useRequest } from '#utils/restRequest';
 

--- a/app/src/views/CountryNsOverviewActivities/Map/index.tsx
+++ b/app/src/views/CountryNsOverviewActivities/Map/index.tsx
@@ -29,10 +29,10 @@ import {
 } from '@togglecorp/re-map';
 import getBbox from '@turf/bbox';
 import {
-    LineLayout,
-    LinePaint,
-    SymbolLayout,
-    SymbolPaint,
+    type LineLayout,
+    type LinePaint,
+    type SymbolLayout,
+    type SymbolPaint,
 } from 'mapbox-gl';
 
 import BaseMap from '#components/domain/BaseMap';
@@ -40,7 +40,7 @@ import Link from '#components/Link';
 import MapContainerWithDisclaimer from '#components/MapContainerWithDisclaimer';
 import MapPopup from '#components/MapPopup';
 import useCountry from '#hooks/domain/useCountry';
-import useCountryRaw, { Country } from '#hooks/domain/useCountryRaw';
+import useCountryRaw, { type Country } from '#hooks/domain/useCountryRaw';
 import {
     COLOR_BLACK,
     COLOR_BLUE,
@@ -53,7 +53,7 @@ import {
     getPointCircleHaloPaint,
     getPointCirclePaint,
 } from '#utils/map';
-import { CountryOutletContext } from '#utils/outletContext';
+import { type CountryOutletContext } from '#utils/outletContext';
 import {
     type GoApiResponse,
     useRequest,

--- a/app/src/views/CountryNsOverviewActivities/NationalSocietyDevelopmentInitiatives/InitiativeCard/index.tsx
+++ b/app/src/views/CountryNsOverviewActivities/NationalSocietyDevelopmentInitiatives/InitiativeCard/index.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from '@ifrc-go/ui/hooks';
 import { resolveToString } from '@ifrc-go/ui/utils';
 import { _cs } from '@togglecorp/fujs';
 
-import { GoApiResponse } from '#utils/restRequest';
+import { type GoApiResponse } from '#utils/restRequest';
 
 import i18n from './i18n.json';
 import styles from './styles.module.css';

--- a/app/src/views/CountryNsOverviewActivities/index.tsx
+++ b/app/src/views/CountryNsOverviewActivities/index.tsx
@@ -35,7 +35,7 @@ import { saveAs } from 'file-saver';
 import { unparse } from 'papaparse';
 
 import ExportButton from '#components/domain/ExportButton';
-import ProjectActions, { Props as ProjectActionsProps } from '#components/domain/ProjectActions';
+import ProjectActions, { type Props as ProjectActionsProps } from '#components/domain/ProjectActions';
 import Link from '#components/Link';
 import WikiLink from '#components/WikiLink';
 import useAlert from '#hooks/useAlert';
@@ -46,7 +46,7 @@ import type { CountryOutletContext } from '#utils/outletContext';
 import { type GoApiResponse } from '#utils/restRequest';
 import { useRequest } from '#utils/restRequest';
 
-import Filter, { FilterValue } from './Filters';
+import Filter, { type FilterValue } from './Filters';
 import Map from './Map';
 import NationalSocietyDevelopmentInitiatives from './NationalSocietyDevelopmentInitiatives';
 

--- a/app/src/views/CountryNsOverviewCapacity/CountryNsCapacityStrengthening/OCACListItem/index.tsx
+++ b/app/src/views/CountryNsOverviewCapacity/CountryNsCapacityStrengthening/OCACListItem/index.tsx
@@ -4,7 +4,7 @@ import {
 } from '@ifrc-go/ui';
 import { useTranslation } from '@ifrc-go/ui/hooks';
 
-import { CountryOutletContext } from '#utils/outletContext';
+import { type CountryOutletContext } from '#utils/outletContext';
 
 import i18n from './i18n.json';
 import styles from './styles.module.css';

--- a/app/src/views/CountryNsOverviewCapacity/CountryNsCapacityStrengthening/index.tsx
+++ b/app/src/views/CountryNsOverviewCapacity/CountryNsCapacityStrengthening/index.tsx
@@ -13,8 +13,8 @@ import {
 } from '@togglecorp/fujs';
 
 import Link from '#components/Link';
-import { components } from '#generated/types';
-import { CountryOutletContext } from '#utils/outletContext';
+import { type components } from '#generated/types';
+import { type CountryOutletContext } from '#utils/outletContext';
 
 import OCACListItem from './OCACListItem';
 

--- a/app/src/views/CountryNsOverviewContextAndStructure/NationalSocietyDirectory/index.tsx
+++ b/app/src/views/CountryNsOverviewContextAndStructure/NationalSocietyDirectory/index.tsx
@@ -13,7 +13,7 @@ import {
 
 import Link from '#components/Link';
 import { type CountryOutletContext } from '#utils/outletContext';
-import { GoApiResponse } from '#utils/restRequest';
+import { type GoApiResponse } from '#utils/restRequest';
 
 import i18n from './i18n.json';
 import styles from './styles.module.css';

--- a/app/src/views/CountryNsOverviewContextAndStructure/NationalSocietyIncomeOverTime/index.tsx
+++ b/app/src/views/CountryNsOverviewContextAndStructure/NationalSocietyIncomeOverTime/index.tsx
@@ -24,7 +24,7 @@ import Link from '#components/Link';
 import useNumericChartData from '#hooks/useNumericChartData';
 import { DEFAULT_Y_AXIS_WIDTH_WITH_LABEL } from '#utils/constants';
 import { type CountryOutletContext } from '#utils/outletContext';
-import { GoApiResponse } from '#utils/restRequest';
+import { type GoApiResponse } from '#utils/restRequest';
 
 import i18n from './i18n.json';
 import styles from './styles.module.css';

--- a/app/src/views/CountryNsOverviewContextAndStructure/NationalSocietyIndicators/index.tsx
+++ b/app/src/views/CountryNsOverviewContextAndStructure/NationalSocietyIndicators/index.tsx
@@ -29,7 +29,7 @@ import {
 
 import Link from '#components/Link';
 import { type CountryOutletContext } from '#utils/outletContext';
-import { GoApiResponse } from '#utils/restRequest';
+import { type GoApiResponse } from '#utils/restRequest';
 
 import i18n from './i18n.json';
 import styles from './styles.module.css';

--- a/app/src/views/CountryNsOverviewContextAndStructure/NationalSocietyKeyDocuments/DocumentListCard/index.tsx
+++ b/app/src/views/CountryNsOverviewContextAndStructure/NationalSocietyKeyDocuments/DocumentListCard/index.tsx
@@ -10,7 +10,7 @@ import {
 } from '@ifrc-go/ui/utils';
 
 import { createLinkColumn } from '#utils/domain/tableHelpers';
-import { GoApiResponse } from '#utils/restRequest';
+import { type GoApiResponse } from '#utils/restRequest';
 
 import styles from './styles.module.css';
 

--- a/app/src/views/CountryNsOverviewContextAndStructure/NationalSocietyKeyDocuments/index.tsx
+++ b/app/src/views/CountryNsOverviewContextAndStructure/NationalSocietyKeyDocuments/index.tsx
@@ -19,9 +19,9 @@ import {
 
 import Link from '#components/Link';
 import useFilterState from '#hooks/useFilterState';
-import { CountryOutletContext } from '#utils/outletContext';
+import { type CountryOutletContext } from '#utils/outletContext';
 import {
-    GoApiResponse,
+    type GoApiResponse,
     useRequest,
 } from '#utils/restRequest';
 

--- a/app/src/views/CountryNsOverviewContextAndStructure/NationalSocietyLocalUnits/Filters/index.tsx
+++ b/app/src/views/CountryNsOverviewContextAndStructure/NationalSocietyLocalUnits/Filters/index.tsx
@@ -10,14 +10,14 @@ import {
     stringLabelSelector,
     stringNameSelector,
 } from '@ifrc-go/ui/utils';
-import { EntriesAsList } from '@togglecorp/toggle-form';
+import { type EntriesAsList } from '@togglecorp/toggle-form';
 
-import { GoApiResponse } from '#utils/restRequest';
+import { type GoApiResponse } from '#utils/restRequest';
 
 import {
     NOT_VALIDATED,
     VALIDATED,
-    Validation,
+    type Validation,
 } from '../common';
 
 import i18n from './i18n.json';

--- a/app/src/views/CountryNsOverviewContextAndStructure/NationalSocietyLocalUnits/LocalUnitDeleteButton/index.tsx
+++ b/app/src/views/CountryNsOverviewContextAndStructure/NationalSocietyLocalUnits/LocalUnitDeleteButton/index.tsx
@@ -1,5 +1,5 @@
 import {
-    ButtonVariant,
+    type ButtonVariant,
     ConfirmButton,
 } from '@ifrc-go/ui';
 import { useTranslation } from '@ifrc-go/ui/hooks';

--- a/app/src/views/CountryNsOverviewContextAndStructure/NationalSocietyLocalUnits/LocalUnitsFormModal/LocalUnitsForm/index.tsx
+++ b/app/src/views/CountryNsOverviewContextAndStructure/NationalSocietyLocalUnits/LocalUnitsFormModal/LocalUnitsForm/index.tsx
@@ -1,5 +1,5 @@
 import {
-    RefObject,
+    type RefObject,
     useCallback,
     useRef,
 } from 'react';
@@ -47,7 +47,7 @@ import useAlert from '#hooks/useAlert';
 import { getFirstTruthyString } from '#utils/common';
 import { VISIBILITY_PUBLIC } from '#utils/constants';
 import { getUserName } from '#utils/domain/user';
-import { CountryOutletContext } from '#utils/outletContext';
+import { type CountryOutletContext } from '#utils/outletContext';
 import {
     type GoApiResponse,
     useLazyRequest,

--- a/app/src/views/CountryNsOverviewContextAndStructure/NationalSocietyLocalUnits/LocalUnitsMap/index.tsx
+++ b/app/src/views/CountryNsOverviewContextAndStructure/NationalSocietyLocalUnits/LocalUnitsMap/index.tsx
@@ -57,8 +57,8 @@ import {
 import { localUnitMapStyle } from '#utils/map';
 import { type CountryOutletContext } from '#utils/outletContext';
 import {
-    GoApiResponse,
-    GoApiUrlQuery,
+    type GoApiResponse,
+    type GoApiUrlQuery,
     useRequest,
 } from '#utils/restRequest';
 

--- a/app/src/views/CountryNsOverviewContextAndStructure/NationalSocietyLocalUnits/index.tsx
+++ b/app/src/views/CountryNsOverviewContextAndStructure/NationalSocietyLocalUnits/index.tsx
@@ -29,10 +29,10 @@ import { environment } from '#config';
 import useAuth from '#hooks/domain/useAuth';
 import usePermissions from '#hooks/domain/usePermissions';
 import useFilterState from '#hooks/useFilterState';
-import { CountryOutletContext } from '#utils/outletContext';
+import { type CountryOutletContext } from '#utils/outletContext';
 import { useRequest } from '#utils/restRequest';
 
-import Filters, { FilterValue } from './Filters';
+import Filters, { type FilterValue } from './Filters';
 import LocalUnitsFormModal from './LocalUnitsFormModal';
 import LocalUnitsMap from './LocalUnitsMap';
 import LocalUnitsTable from './LocalUnitsTable';

--- a/app/src/views/CountryNsOverviewSupportingPartners/SupportingPartnersContacts/index.tsx
+++ b/app/src/views/CountryNsOverviewSupportingPartners/SupportingPartnersContacts/index.tsx
@@ -20,7 +20,7 @@ import {
 import { createLinkColumn } from '#utils/domain/tableHelpers';
 import { type CountryOutletContext } from '#utils/outletContext';
 import {
-    GoApiResponse,
+    type GoApiResponse,
     useRequest,
 } from '#utils/restRequest';
 

--- a/app/src/views/CountryOngoingActivities/index.tsx
+++ b/app/src/views/CountryOngoingActivities/index.tsx
@@ -6,7 +6,7 @@ import { NavigationTabList } from '@ifrc-go/ui';
 import { useTranslation } from '@ifrc-go/ui/hooks';
 
 import NavigationTab from '#components/NavigationTab';
-import { CountryOutletContext } from '#utils/outletContext';
+import { type CountryOutletContext } from '#utils/outletContext';
 
 import i18n from './i18n.json';
 import styles from './styles.module.css';

--- a/app/src/views/CountryOngoingActivitiesEmergencies/Filters/index.tsx
+++ b/app/src/views/CountryOngoingActivitiesEmergencies/Filters/index.tsx
@@ -5,7 +5,7 @@ import {
     SelectInput,
 } from '@ifrc-go/ui';
 import { useTranslation } from '@ifrc-go/ui/hooks';
-import { EntriesAsList } from '@togglecorp/toggle-form';
+import { type EntriesAsList } from '@togglecorp/toggle-form';
 
 import DisasterTypeSelectInput from '#components/domain/DisasterTypeSelectInput';
 import useGlobalEnums from '#hooks/domain/useGlobalEnums';

--- a/app/src/views/CountryOngoingActivitiesEmergencies/index.tsx
+++ b/app/src/views/CountryOngoingActivitiesEmergencies/index.tsx
@@ -58,7 +58,7 @@ import {
     optionLabelSelector,
     outerCircleLayerOptionsForFinancialRequirements,
     outerCircleLayerOptionsForPeopleTargeted,
-    ScaleOption,
+    type ScaleOption,
 } from '#components/domain/ActiveOperationMap/utils';
 import BaseMap from '#components/domain/BaseMap';
 import HighlightedOperations from '#components/domain/HighlightedOperations';

--- a/app/src/views/CountryOngoingActivitiesThreeWActivities/Filters/index.tsx
+++ b/app/src/views/CountryOngoingActivitiesThreeWActivities/Filters/index.tsx
@@ -11,7 +11,7 @@ import {
 } from '@ifrc-go/ui/utils';
 import { isNotDefined } from '@togglecorp/fujs';
 import {
-    EntriesAsList,
+    type EntriesAsList,
     type SetValueArg,
 } from '@togglecorp/toggle-form';
 

--- a/app/src/views/CountryOngoingActivitiesThreeWActivities/index.tsx
+++ b/app/src/views/CountryOngoingActivitiesThreeWActivities/index.tsx
@@ -40,7 +40,7 @@ import Link from '#components/Link';
 import useAlert from '#hooks/useAlert';
 import useFilterState from '#hooks/useFilterState';
 import useRecursiveCsvExport from '#hooks/useRecursiveCsvRequest';
-import { CountryOutletContext } from '#utils/outletContext';
+import { type CountryOutletContext } from '#utils/outletContext';
 import { useRequest } from '#utils/restRequest';
 import { type GoApiResponse } from '#utils/restRequest';
 import ActivityActions, { type Props as ActivityActionsProps } from '#views/EmergencyActivities/ActivityActions';

--- a/app/src/views/CountryOngoingActivitiesThreeWProjects/Filters/index.tsx
+++ b/app/src/views/CountryOngoingActivitiesThreeWProjects/Filters/index.tsx
@@ -9,10 +9,10 @@ import {
     stringValueSelector,
 } from '@ifrc-go/ui/utils';
 import { _cs } from '@togglecorp/fujs';
-import { EntriesAsList } from '@togglecorp/toggle-form';
+import { type EntriesAsList } from '@togglecorp/toggle-form';
 
 import useGlobalEnums from '#hooks/domain/useGlobalEnums';
-import useNationalSociety, { NationalSociety } from '#hooks/domain/useNationalSociety';
+import useNationalSociety, { type NationalSociety } from '#hooks/domain/useNationalSociety';
 import type { GoApiResponse } from '#utils/restRequest';
 import { useRequest } from '#utils/restRequest';
 

--- a/app/src/views/CountryOngoingActivitiesThreeWProjects/index.tsx
+++ b/app/src/views/CountryOngoingActivitiesThreeWProjects/index.tsx
@@ -38,7 +38,7 @@ import { saveAs } from 'file-saver';
 import { unparse } from 'papaparse';
 
 import ExportButton from '#components/domain/ExportButton';
-import ProjectActions, { Props as ProjectActionsProps } from '#components/domain/ProjectActions';
+import ProjectActions, { type Props as ProjectActionsProps } from '#components/domain/ProjectActions';
 import Link from '#components/Link';
 import WikiLink from '#components/WikiLink';
 import useUserMe from '#hooks/domain/useUserMe';
@@ -47,11 +47,11 @@ import useRecursiveCsvExport from '#hooks/useRecursiveCsvRequest';
 import { PROJECT_STATUS_ONGOING } from '#utils/constants';
 import type { CountryOutletContext } from '#utils/outletContext';
 import {
-    GoApiResponse,
+    type GoApiResponse,
     useRequest,
 } from '#utils/restRequest';
 
-import Filter, { FilterValue } from './Filters';
+import Filter, { type FilterValue } from './Filters';
 import Map from './Map';
 
 import i18n from './i18n.json';

--- a/app/src/views/CountryProfile/index.tsx
+++ b/app/src/views/CountryProfile/index.tsx
@@ -6,7 +6,7 @@ import { NavigationTabList } from '@ifrc-go/ui';
 import { useTranslation } from '@ifrc-go/ui/hooks';
 
 import NavigationTab from '#components/NavigationTab';
-import { CountryOutletContext } from '#utils/outletContext';
+import { type CountryOutletContext } from '#utils/outletContext';
 
 import i18n from './i18n.json';
 import styles from './styles.module.css';

--- a/app/src/views/CountryProfileOverview/ClimateChart/index.tsx
+++ b/app/src/views/CountryProfileOverview/ClimateChart/index.tsx
@@ -22,7 +22,7 @@ import {
 
 import Link from '#components/Link';
 import useTemporalChartData from '#hooks/useTemporalChartData';
-import { GoApiResponse } from '#utils/restRequest';
+import { type GoApiResponse } from '#utils/restRequest';
 
 import i18n from './i18n.json';
 import styles from './styles.module.css';

--- a/app/src/views/CountryProfileOverview/PopulationMap/index.tsx
+++ b/app/src/views/CountryProfileOverview/PopulationMap/index.tsx
@@ -40,7 +40,7 @@ import {
     DEFAULT_MAP_PADDING,
     DURATION_MAP_ZOOM,
 } from '#utils/constants';
-import { GoApiResponse } from '#utils/restRequest';
+import { type GoApiResponse } from '#utils/restRequest';
 
 import i18n from './i18n.json';
 import styles from './styles.module.css';

--- a/app/src/views/CountryProfileOverview/index.tsx
+++ b/app/src/views/CountryProfileOverview/index.tsx
@@ -26,7 +26,7 @@ import Link from '#components/Link';
 import WikiLink from '#components/WikiLink';
 import { type CountryOutletContext } from '#utils/outletContext';
 import {
-    GoApiResponse,
+    type GoApiResponse,
     useRequest,
 } from '#utils/restRequest';
 

--- a/app/src/views/CountryProfilePreviousEvents/CountryHistoricalKeyFigures/index.tsx
+++ b/app/src/views/CountryProfilePreviousEvents/CountryHistoricalKeyFigures/index.tsx
@@ -13,7 +13,7 @@ import { useTranslation } from '@ifrc-go/ui/hooks';
 import { getPercentage } from '@ifrc-go/ui/utils';
 import { _cs } from '@togglecorp/fujs';
 
-import { GoApiResponse } from '#utils/restRequest';
+import { type GoApiResponse } from '#utils/restRequest';
 
 import i18n from './i18n.json';
 import styles from './styles.module.css';

--- a/app/src/views/CountryProfilePreviousEvents/index.tsx
+++ b/app/src/views/CountryProfilePreviousEvents/index.tsx
@@ -21,7 +21,7 @@ import AppealsTable from '#components/domain/AppealsTable';
 import WikiLink from '#components/WikiLink';
 import { type CountryOutletContext } from '#utils/outletContext';
 import {
-    GoApiResponse,
+    type GoApiResponse,
     useRequest,
 } from '#utils/restRequest';
 

--- a/app/src/views/CountryProfileRiskWatch/CountryRiskSourcesOutput/index.tsx
+++ b/app/src/views/CountryProfileRiskWatch/CountryRiskSourcesOutput/index.tsx
@@ -1,4 +1,7 @@
-import { useMemo } from 'react';
+import {
+    Fragment,
+    useMemo,
+} from 'react';
 import { TextOutput } from '@ifrc-go/ui';
 import { useTranslation } from '@ifrc-go/ui/hooks';
 import { resolveToComponent } from '@ifrc-go/ui/utils';
@@ -13,21 +16,25 @@ function CountryRiskSourcesOutput() {
     const riskByMonthSources = useMemo(
         () => [
             {
+                key: 'inform',
                 link: 'https://drmkc.jrc.ec.europa.eu/inform-index/INFORM-Risk',
                 label: strings.inform,
                 description: strings.sourceINFORM,
             },
             {
+                key: 'undrr',
                 link: 'https://www.undrr.org/',
                 label: strings.undrr,
                 description: strings.sourceUNDRR,
             },
             {
+                key: 'idmc',
                 link: 'https://www.internal-displacement.org/',
                 label: strings.idmc,
                 description: strings.sourceIDMC,
             },
             {
+                key: 'ipc',
                 link: 'https://www.ipcinfo.org/',
                 label: strings.ipc,
                 description: strings.sourceIPC,
@@ -40,8 +47,8 @@ function CountryRiskSourcesOutput() {
         <TextOutput
             label={strings.source}
             value={
-                riskByMonthSources.map((source) => (
-                    <>
+                riskByMonthSources.map((source, i) => (
+                    <Fragment key={source.key}>
                         {resolveToComponent(
                             source.description,
                             {
@@ -57,8 +64,8 @@ function CountryRiskSourcesOutput() {
                                 ),
                             },
                         )}
-                        <br />
-                    </>
+                        {i < (riskByMonthSources.length - 1) && <br />}
+                    </Fragment>
                 ))
             }
         />

--- a/app/src/views/CountryProfileRiskWatch/MultiMonthSelectInput/index.tsx
+++ b/app/src/views/CountryProfileRiskWatch/MultiMonthSelectInput/index.tsx
@@ -12,15 +12,13 @@ import {
 } from '@togglecorp/fujs';
 import type { SetValueArg } from '@togglecorp/toggle-form';
 
+import {
+    monthKeyList,
+    multiMonthSelectDefaultValue,
+} from '#utils/constants';
+
 import i18n from './i18n.json';
 import styles from './styles.module.css';
-
-const keyList = Array.from(Array(12).keys());
-const defaultValue = listToMap(
-    keyList,
-    (key) => key,
-    () => false,
-);
 
 interface Props<NAME> {
     className?: string;
@@ -87,7 +85,7 @@ function MultiMonthSelectInput<NAME>(props: Props<NAME>) {
                     ) {
                         // Selecting only single value
                         return {
-                            ...defaultValue,
+                            ...multiMonthSelectDefaultValue,
                             [month]: true,
                         };
                     }
@@ -127,7 +125,7 @@ function MultiMonthSelectInput<NAME>(props: Props<NAME>) {
     return (
         <div className={_cs(styles.multiMonthSelectInput, className)}>
             <div className={styles.monthList}>
-                {keyList.map(
+                {monthKeyList.map(
                     (key) => {
                         const date = new Date();
                         date.setDate(1);

--- a/app/src/views/CountryProfileRiskWatch/RiskBarChart/CombinedChart/index.tsx
+++ b/app/src/views/CountryProfileRiskWatch/RiskBarChart/CombinedChart/index.tsx
@@ -34,7 +34,7 @@ import {
     getWfRiskDataItem,
     hazardTypeToColorMap,
     monthNumberToNameMap,
-    RiskMetricOption,
+    type RiskMetricOption,
     riskScoreToCategory,
 } from '#utils/domain/risk';
 import { type RiskApiResponse } from '#utils/restRequest';

--- a/app/src/views/CountryProfileRiskWatch/RiskBarChart/WildfireChart/index.tsx
+++ b/app/src/views/CountryProfileRiskWatch/RiskBarChart/WildfireChart/index.tsx
@@ -25,7 +25,7 @@ import {
     mapToList,
 } from '@togglecorp/fujs';
 
-import { paths } from '#generated/riskTypes';
+import { type paths } from '#generated/riskTypes';
 import useTemporalChartData from '#hooks/useTemporalChartData';
 import {
     COLOR_PRIMARY_BLUE,

--- a/app/src/views/CountryProfileRiskWatch/index.tsx
+++ b/app/src/views/CountryProfileRiskWatch/index.tsx
@@ -16,6 +16,7 @@ import RiskImminentEvents, { type ImminentEventSource } from '#components/domain
 import Link from '#components/Link';
 import WikiLink from '#components/WikiLink';
 import useInputState from '#hooks/useInputState';
+import { multiMonthSelectDefaultValue } from '#utils/constants';
 import type { CountryOutletContext } from '#utils/outletContext';
 import { useRiskRequest } from '#utils/restRequest';
 
@@ -29,6 +30,10 @@ import RiskTable from './RiskTable';
 import i18n from './i18n.json';
 import styles from './styles.module.css';
 
+function getCurrentMonth() {
+    return new Date().getMonth();
+}
+
 /** @knipignore */
 // eslint-disable-next-line import/prefer-default-export
 export function Component() {
@@ -38,7 +43,10 @@ export function Component() {
     const [
         selectedMonths,
         setSelectedMonths,
-    ] = useInputState<Record<number, boolean> | undefined>({ 0: true });
+    ] = useInputState<(typeof multiMonthSelectDefaultValue) | undefined>({
+        ...multiMonthSelectDefaultValue,
+        [getCurrentMonth()]: true,
+    });
 
     const {
         pending: pendingCountryRiskResponse,

--- a/app/src/views/DrefApplicationExport/index.tsx
+++ b/app/src/views/DrefApplicationExport/index.tsx
@@ -29,7 +29,7 @@ import {
     DISASTER_CATEGORY_ORANGE,
     DISASTER_CATEGORY_RED,
     DISASTER_CATEGORY_YELLOW,
-    DisasterCategory,
+    type DisasterCategory,
     DREF_TYPE_ASSESSMENT,
     DREF_TYPE_IMMINENT,
     ONSET_SLOW,

--- a/app/src/views/DrefApplicationForm/DrefImportButton/DrefImportModal/index.tsx
+++ b/app/src/views/DrefApplicationForm/DrefImportButton/DrefImportModal/index.tsx
@@ -15,8 +15,8 @@ import {
     isObject,
 } from '@togglecorp/fujs';
 import xlsx, {
-    CellValue,
-    Row,
+    type CellValue,
+    type Row,
 } from 'exceljs';
 
 import useAlert from '#hooks/useAlert';
@@ -30,7 +30,7 @@ import {
 } from '#utils/domain/dref';
 import { getValueFromImportTemplate } from '#utils/importTemplate';
 import useImportTemplateSchema from '#views/AccountMyFormsDref/DownloadImportTemplateButton/DownloadImportTemplateModal/useImportTemplateSchema';
-import { PartialDref } from '#views/DrefApplicationForm/schema';
+import { type PartialDref } from '#views/DrefApplicationForm/schema';
 
 import i18n from './i18n.json';
 import styles from './styles.module.css';

--- a/app/src/views/DrefApplicationForm/DrefImportButton/index.tsx
+++ b/app/src/views/DrefApplicationForm/DrefImportButton/index.tsx
@@ -4,7 +4,7 @@ import {
     useTranslation,
 } from '@ifrc-go/ui/hooks';
 
-import { PartialDref } from '../schema';
+import { type PartialDref } from '../schema';
 import DrefImportModal from './DrefImportModal';
 
 import i18n from './i18n.json';

--- a/app/src/views/DrefApplicationForm/Operation/InterventionInput/IndicatorInput/index.tsx
+++ b/app/src/views/DrefApplicationForm/Operation/InterventionInput/IndicatorInput/index.tsx
@@ -14,7 +14,7 @@ import {
 
 import NonFieldError from '#components/NonFieldError';
 
-import { PartialDref } from '../../../schema';
+import { type PartialDref } from '../../../schema';
 
 import i18n from './i18n.json';
 import styles from './styles.module.css';

--- a/app/src/views/DrefFinalReportExport/index.tsx
+++ b/app/src/views/DrefFinalReportExport/index.tsx
@@ -32,7 +32,7 @@ import {
     DISASTER_CATEGORY_ORANGE,
     DISASTER_CATEGORY_RED,
     DISASTER_CATEGORY_YELLOW,
-    DisasterCategory,
+    type DisasterCategory,
     DREF_TYPE_ASSESSMENT,
     DREF_TYPE_IMMINENT,
     ONSET_SLOW,

--- a/app/src/views/DrefFinalReportForm/Operation/InterventionInput/IndicatorInput/index.tsx
+++ b/app/src/views/DrefFinalReportForm/Operation/InterventionInput/IndicatorInput/index.tsx
@@ -14,7 +14,7 @@ import {
 
 import NonFieldError from '#components/NonFieldError';
 
-import { PartialFinalReport } from '../../../schema';
+import { type PartialFinalReport } from '../../../schema';
 
 import i18n from './i18n.json';
 import styles from './styles.module.css';

--- a/app/src/views/DrefOperationalUpdateExport/index.tsx
+++ b/app/src/views/DrefOperationalUpdateExport/index.tsx
@@ -35,7 +35,7 @@ import {
     DISASTER_CATEGORY_ORANGE,
     DISASTER_CATEGORY_RED,
     DISASTER_CATEGORY_YELLOW,
-    DisasterCategory,
+    type DisasterCategory,
     DREF_TYPE_ASSESSMENT,
     DREF_TYPE_IMMINENT,
     ONSET_SLOW,

--- a/app/src/views/DrefOperationalUpdateForm/Operation/InterventionInput/IndicatorInput/index.tsx
+++ b/app/src/views/DrefOperationalUpdateForm/Operation/InterventionInput/IndicatorInput/index.tsx
@@ -14,7 +14,7 @@ import {
 
 import NonFieldError from '#components/NonFieldError';
 
-import { PartialOpsUpdate } from '../../../schema';
+import { type PartialOpsUpdate } from '../../../schema';
 
 import i18n from './i18n.json';
 import styles from './styles.module.css';

--- a/app/src/views/Emergencies/FlashUpdatesTable/index.tsx
+++ b/app/src/views/Emergencies/FlashUpdatesTable/index.tsx
@@ -23,7 +23,7 @@ import {
 import type { GoApiResponse } from '#utils/restRequest';
 import { useRequest } from '#utils/restRequest';
 
-import FlashUpdatesTableAction, { Props as FlashUpdatesTableActions } from './FlashUpdatesTableActions';
+import FlashUpdatesTableAction, { type Props as FlashUpdatesTableActions } from './FlashUpdatesTableActions';
 
 import i18n from './i18n.json';
 import styles from './styles.module.css';

--- a/app/src/views/Emergencies/Map/index.tsx
+++ b/app/src/views/Emergencies/Map/index.tsx
@@ -50,7 +50,7 @@ import {
     RESPONSE_LEVEL_MIXED_RESPONSE,
     RESPONSE_LEVEL_WITH_IFRC_RESPONSE,
     RESPONSE_LEVEL_WITHOUT_IFRC_RESPONSE,
-    ScaleOption,
+    type ScaleOption,
 } from './utils';
 
 import i18n from './i18n.json';

--- a/app/src/views/EmergencyActivities/Filters/index.tsx
+++ b/app/src/views/EmergencyActivities/Filters/index.tsx
@@ -14,7 +14,7 @@ import {
     isNotDefined,
 } from '@togglecorp/fujs';
 import {
-    EntriesAsList,
+    type EntriesAsList,
     type SetValueArg,
 } from '@togglecorp/toggle-form';
 

--- a/app/src/views/EmergencyDetails/FieldReportStats/index.tsx
+++ b/app/src/views/EmergencyDetails/FieldReportStats/index.tsx
@@ -10,7 +10,7 @@ import Link from '#components/Link';
 import {
     DISASTER_TYPE_EPIDEMIC,
     FIELD_REPORT_STATUS_EARLY_WARNING,
-    ReportType,
+    type ReportType,
 } from '#utils/constants';
 import { type GoApiResponse } from '#utils/restRequest';
 

--- a/app/src/views/EmergencyReportAndDocument/index.tsx
+++ b/app/src/views/EmergencyReportAndDocument/index.tsx
@@ -26,7 +26,7 @@ import {
     unique,
 } from '@togglecorp/fujs';
 
-import Link, { Props as LinkProps } from '#components/Link';
+import Link, { type Props as LinkProps } from '#components/Link';
 import { adminUrl } from '#config';
 import useRegion, { type Region } from '#hooks/domain/useRegion';
 import useFilterState from '#hooks/useFilterState';

--- a/app/src/views/FlashUpdateDetails/FlashUpdateShareModal/index.tsx
+++ b/app/src/views/FlashUpdateDetails/FlashUpdateShareModal/index.tsx
@@ -15,7 +15,7 @@ import { isDefined } from '@togglecorp/fujs';
 import useAlert from '#hooks/useAlert';
 import useInputState from '#hooks/useInputState';
 import {
-    GoApiBody,
+    type GoApiBody,
     useLazyRequest,
     useRequest,
 } from '#utils/restRequest';

--- a/app/src/views/FlashUpdateForm/ActionsTab/ActionInput/index.tsx
+++ b/app/src/views/FlashUpdateForm/ActionsTab/ActionInput/index.tsx
@@ -4,10 +4,10 @@ import {
 } from '@ifrc-go/ui';
 import { randomString } from '@togglecorp/fujs';
 import {
-    ArrayError,
+    type ArrayError,
     getErrorObject,
     getErrorString,
-    SetValueArg,
+    type SetValueArg,
     useFormObject,
 } from '@togglecorp/toggle-form';
 

--- a/app/src/views/FlashUpdateForm/ContextTab/CountryProvinceInput/index.tsx
+++ b/app/src/views/FlashUpdateForm/ContextTab/CountryProvinceInput/index.tsx
@@ -17,7 +17,7 @@ import CountrySelectInput from '#components/domain/CountrySelectInput';
 import DistrictSearchMultiSelectInput, { type DistrictItem } from '#components/domain/DistrictSearchMultiSelectInput';
 import NonFieldError from '#components/NonFieldError';
 
-import { PartialCountryDistrict } from '../../schema';
+import { type PartialCountryDistrict } from '../../schema';
 
 import i18n from './i18n.json';
 import styles from './styles.module.css';

--- a/app/src/views/FlashUpdateForm/ContextTab/ReferenceInput/index.tsx
+++ b/app/src/views/FlashUpdateForm/ContextTab/ReferenceInput/index.tsx
@@ -17,7 +17,7 @@ import {
 import GoSingleFileInput from '#components/domain/GoSingleFileInput';
 import NonFieldError from '#components/NonFieldError';
 
-import { PartialReferenceType } from '../../schema';
+import { type PartialReferenceType } from '../../schema';
 
 import i18n from './i18n.json';
 import styles from './styles.module.css';

--- a/app/src/views/FlashUpdateForm/FocalPointsTab/index.tsx
+++ b/app/src/views/FlashUpdateForm/FocalPointsTab/index.tsx
@@ -5,12 +5,12 @@ import {
 } from '@ifrc-go/ui';
 import { useTranslation } from '@ifrc-go/ui/hooks';
 import {
-    EntriesAsList,
-    Error,
+    type EntriesAsList,
+    type Error,
     getErrorObject,
 } from '@togglecorp/toggle-form';
 
-import { FormType } from '../schema';
+import { type FormType } from '../schema';
 
 import i18n from './i18n.json';
 

--- a/app/src/views/FlashUpdateForm/schema.ts
+++ b/app/src/views/FlashUpdateForm/schema.ts
@@ -4,7 +4,7 @@ import { isDefined } from '@togglecorp/fujs';
 import {
     type ArraySchema,
     emailCondition,
-    ObjectSchema,
+    type ObjectSchema,
     type PartialForm,
     type PurgeNull,
     requiredStringCondition,

--- a/app/src/views/OperationalLearning/Filters/index.tsx
+++ b/app/src/views/OperationalLearning/Filters/index.tsx
@@ -13,12 +13,12 @@ import {
     stringTitleSelector,
     stringValueSelector,
 } from '@ifrc-go/ui/utils';
-import { EntriesAsList } from '@togglecorp/toggle-form';
+import { type EntriesAsList } from '@togglecorp/toggle-form';
 
 import CountryMultiSelectInput, { type CountryOption } from '#components/domain/CountryMultiSelectInput';
 import RegionSelectInput, { type RegionOption } from '#components/domain/RegionSelectInput';
 import { type components } from '#generated/types';
-import { DisasterType } from '#hooks/domain/useDisasterType';
+import { type DisasterType } from '#hooks/domain/useDisasterType';
 import { type PerComponent } from '#hooks/domain/usePerComponent';
 import { type SecondarySector } from '#hooks/domain/useSecondarySector';
 import { getFormattedComponentName } from '#utils/domain/per';

--- a/app/src/views/OperationalLearning/index.tsx
+++ b/app/src/views/OperationalLearning/index.tsx
@@ -35,7 +35,7 @@ import {
     isTruthyString,
     sum,
 } from '@togglecorp/fujs';
-import { EntriesAsList } from '@togglecorp/toggle-form';
+import { type EntriesAsList } from '@togglecorp/toggle-form';
 import { saveAs } from 'file-saver';
 import Papa from 'papaparse';
 
@@ -45,7 +45,7 @@ import Link from '#components/Link';
 import Page from '#components/Page';
 import { type components } from '#generated/types';
 import useCountry from '#hooks/domain/useCountry';
-import useDisasterTypes, { DisasterType } from '#hooks/domain/useDisasterType';
+import useDisasterTypes, { type DisasterType } from '#hooks/domain/useDisasterType';
 import useGlobalEnums from '#hooks/domain/useGlobalEnums';
 import usePerComponent from '#hooks/domain/usePerComponent';
 import useSecondarySector from '#hooks/domain/useSecondarySector';
@@ -55,7 +55,7 @@ import useRecursiveCsvExport from '#hooks/useRecursiveCsvRequest';
 import { getFormattedComponentName } from '#utils/domain/per';
 import {
     type GoApiResponse,
-    GoApiUrlQuery,
+    type GoApiUrlQuery,
     useRequest,
 } from '#utils/restRequest';
 

--- a/app/src/views/PerAssessmentForm/AreaInput/ComponentInput/QuestionInput/index.tsx
+++ b/app/src/views/PerAssessmentForm/AreaInput/ComponentInput/QuestionInput/index.tsx
@@ -7,9 +7,9 @@ import {
 import { useTranslation } from '@ifrc-go/ui/hooks';
 import { isDefined } from '@togglecorp/fujs';
 import {
-    Error,
+    type Error,
     getErrorObject,
-    SetValueArg,
+    type SetValueArg,
     useFormObject,
 } from '@togglecorp/toggle-form';
 

--- a/app/src/views/PerAssessmentForm/AreaInput/ComponentInput/index.tsx
+++ b/app/src/views/PerAssessmentForm/AreaInput/ComponentInput/index.tsx
@@ -22,9 +22,9 @@ import {
     mapToList,
 } from '@togglecorp/fujs';
 import {
-    Error,
+    type Error,
     getErrorObject,
-    SetValueArg,
+    type SetValueArg,
     useFormArray,
     useFormObject,
 } from '@togglecorp/toggle-form';
@@ -32,7 +32,7 @@ import {
 import NonFieldError from '#components/NonFieldError';
 import {
     type GoApiResponse,
-    ListResponseItem,
+    type ListResponseItem,
 } from '#utils/restRequest';
 
 import { type PartialAssessment } from '../../schema';

--- a/app/src/views/PerAssessmentForm/AreaInput/index.tsx
+++ b/app/src/views/PerAssessmentForm/AreaInput/index.tsx
@@ -5,7 +5,7 @@ import {
     listToMap,
 } from '@togglecorp/fujs';
 import {
-    Error,
+    type Error,
     getErrorObject,
     type SetValueArg,
     useFormArray,
@@ -15,7 +15,7 @@ import {
 import NonFieldError from '#components/NonFieldError';
 import {
     type GoApiResponse,
-    ListResponseItem,
+    type ListResponseItem,
 } from '#utils/restRequest';
 
 import { type PartialAssessment } from '../schema';

--- a/app/src/views/PerAssessmentForm/index.tsx
+++ b/app/src/views/PerAssessmentForm/index.tsx
@@ -59,7 +59,7 @@ import {
 import AreaInput from './AreaInput';
 import {
     assessmentSchema,
-    PartialAssessment,
+    type PartialAssessment,
 } from './schema';
 
 import i18n from './i18n.json';

--- a/app/src/views/PerAssessmentForm/schema.ts
+++ b/app/src/views/PerAssessmentForm/schema.ts
@@ -1,8 +1,8 @@
 import { type DeepReplace } from '@ifrc-go/ui/utils';
 import {
-    ObjectSchema,
-    PartialForm,
-    PurgeNull,
+    type ObjectSchema,
+    type PartialForm,
+    type PurgeNull,
 } from '@togglecorp/toggle-form';
 
 import { type GoApiResponse } from '#utils/restRequest';

--- a/app/src/views/PerOverviewForm/index.tsx
+++ b/app/src/views/PerOverviewForm/index.tsx
@@ -61,8 +61,8 @@ import { transformObjectError } from '#utils/restRequest/error';
 
 import {
     overviewSchema,
-    PartialOverviewFormFields,
-    PerOverviewRequestBody,
+    type PartialOverviewFormFields,
+    type PerOverviewRequestBody,
 } from './schema';
 
 import i18n from './i18n.json';

--- a/app/src/views/PerOverviewForm/schema.ts
+++ b/app/src/views/PerOverviewForm/schema.ts
@@ -6,8 +6,8 @@ import {
 import {
     addCondition,
     emailCondition,
-    ObjectSchema,
-    PartialForm,
+    type ObjectSchema,
+    type PartialForm,
     undefinedValue,
 } from '@togglecorp/toggle-form';
 

--- a/app/src/views/PerPrioritizationForm/ComponentInput/index.tsx
+++ b/app/src/views/PerPrioritizationForm/ComponentInput/index.tsx
@@ -20,9 +20,9 @@ import {
     mapToList,
 } from '@togglecorp/fujs';
 import {
-    Error,
+    type Error,
     getErrorObject,
-    SetValueArg,
+    type SetValueArg,
     useFormObject,
 } from '@togglecorp/toggle-form';
 

--- a/app/src/views/PerPrioritizationForm/schema.ts
+++ b/app/src/views/PerPrioritizationForm/schema.ts
@@ -1,6 +1,6 @@
 import {
-    ObjectSchema,
-    PartialForm,
+    type ObjectSchema,
+    type PartialForm,
 } from '@togglecorp/toggle-form';
 
 import { type GoApiBody } from '#utils/restRequest';

--- a/app/src/views/PerWorkPlanForm/AdditionalActionInput/index.tsx
+++ b/app/src/views/PerWorkPlanForm/AdditionalActionInput/index.tsx
@@ -17,9 +17,9 @@ import {
 } from '@ifrc-go/ui/utils';
 import { randomString } from '@togglecorp/fujs';
 import {
-    Error,
+    type Error,
     getErrorObject,
-    SetValueArg,
+    type SetValueArg,
     useFormObject,
 } from '@togglecorp/toggle-form';
 
@@ -29,7 +29,7 @@ import useGlobalEnums from '#hooks/domain/useGlobalEnums';
 import { NATIONAL_SOCIETY } from '#utils/constants';
 import { type GoApiResponse } from '#utils/restRequest';
 
-import { PartialWorkPlan } from '../schema';
+import { type PartialWorkPlan } from '../schema';
 
 import i18n from './i18n.json';
 import styles from './styles.module.css';

--- a/app/src/views/PerWorkPlanForm/index.tsx
+++ b/app/src/views/PerWorkPlanForm/index.tsx
@@ -48,8 +48,8 @@ import {
 import AdditionalActionInput from './AdditionalActionInput';
 import PrioritizedActionInput from './PrioritizedActionInput';
 import {
-    PartialWorkPlan,
-    WorkPlanBody,
+    type PartialWorkPlan,
+    type WorkPlanBody,
     workplanSchema,
 } from './schema';
 

--- a/app/src/views/PerWorkPlanForm/schema.ts
+++ b/app/src/views/PerWorkPlanForm/schema.ts
@@ -1,8 +1,8 @@
 import {
     addCondition,
     nullValue,
-    ObjectSchema,
-    PartialForm,
+    type ObjectSchema,
+    type PartialForm,
     requiredStringCondition,
 } from '@togglecorp/toggle-form';
 

--- a/app/src/views/RecoverAccountConfirm/index.tsx
+++ b/app/src/views/RecoverAccountConfirm/index.tsx
@@ -21,7 +21,7 @@ import Page from '#components/Page';
 import useAlert from '#hooks/useAlert';
 import useRouting from '#hooks/useRouting';
 import {
-    GoApiBody,
+    type GoApiBody,
     useLazyRequest,
 } from '#utils/restRequest';
 import { transformObjectError } from '#utils/restRequest/error';

--- a/app/src/views/RegionAdditionalInfo/index.tsx
+++ b/app/src/views/RegionAdditionalInfo/index.tsx
@@ -3,7 +3,7 @@ import { useOutletContext } from 'react-router-dom';
 import {
     Container,
     HtmlOutput,
-    HtmlOutputProps,
+    type HtmlOutputProps,
     KeyFigure,
     List,
     Message,

--- a/app/src/views/RegionRiskWatch/index.tsx
+++ b/app/src/views/RegionRiskWatch/index.tsx
@@ -9,7 +9,7 @@ import { isFalsyString } from '@togglecorp/fujs';
 
 import NavigationTab from '#components/NavigationTab';
 import WikiLink from '#components/WikiLink';
-import { RegionOutletContext } from '#utils/outletContext';
+import { type RegionOutletContext } from '#utils/outletContext';
 
 import i18n from './i18n.json';
 import styles from './styles.module.css';

--- a/app/src/views/RegionRiskWatchImminent/index.tsx
+++ b/app/src/views/RegionRiskWatchImminent/index.tsx
@@ -3,7 +3,7 @@ import { useOutletContext } from 'react-router-dom';
 import getBbox from '@turf/bbox';
 
 import RiskImminentEvents from '#components/domain/RiskImminentEvents';
-import { RegionOutletContext } from '#utils/outletContext';
+import { type RegionOutletContext } from '#utils/outletContext';
 
 import styles from './styles.module.css';
 

--- a/app/src/views/RegionThreeW/Filters/index.tsx
+++ b/app/src/views/RegionThreeW/Filters/index.tsx
@@ -5,7 +5,7 @@ import {
     stringLabelSelector,
     stringValueSelector,
 } from '@ifrc-go/ui/utils';
-import { EntriesAsList } from '@togglecorp/toggle-form';
+import { type EntriesAsList } from '@togglecorp/toggle-form';
 
 import useGlobalEnums from '#hooks/domain/useGlobalEnums';
 import {

--- a/app/src/views/RegionThreeW/MovementActivitiesMap/index.tsx
+++ b/app/src/views/RegionThreeW/MovementActivitiesMap/index.tsx
@@ -7,7 +7,7 @@ import { useOutletContext } from 'react-router-dom';
 import {
     RawList,
     TextOutput,
-    TextOutputProps,
+    type TextOutputProps,
 } from '@ifrc-go/ui';
 import { useTranslation } from '@ifrc-go/ui/hooks';
 import { numericIdSelector } from '@ifrc-go/ui/utils';
@@ -27,7 +27,7 @@ import BaseMap from '#components/domain/BaseMap';
 import Link from '#components/Link';
 import MapContainerWithDisclaimer from '#components/MapContainerWithDisclaimer';
 import MapPopup from '#components/MapPopup';
-import useCountryRaw, { Country } from '#hooks/domain/useCountryRaw';
+import useCountryRaw, { type Country } from '#hooks/domain/useCountryRaw';
 import {
     COLOR_RED,
     DEFAULT_MAP_PADDING,

--- a/app/src/views/RegionThreeW/index.tsx
+++ b/app/src/views/RegionThreeW/index.tsx
@@ -7,7 +7,7 @@ import {
     BlockLoading,
     Container,
     ExpandableContainer,
-    ExpandableContainerProps,
+    type ExpandableContainerProps,
     KeyFigure,
     List,
     PieChart,

--- a/app/src/views/Register/index.tsx
+++ b/app/src/views/Register/index.tsx
@@ -33,7 +33,7 @@ import NonFieldError from '#components/NonFieldError';
 import Page from '#components/Page';
 import WikiLink from '#components/WikiLink';
 import useGlobalEnums from '#hooks/domain/useGlobalEnums';
-import useNationalSociety, { NationalSociety } from '#hooks/domain/useNationalSociety';
+import useNationalSociety, { type NationalSociety } from '#hooks/domain/useNationalSociety';
 import useAlert from '#hooks/useAlert';
 import useRouting from '#hooks/useRouting';
 import {

--- a/app/src/views/SurgeCatalogueBasecamp/index.tsx
+++ b/app/src/views/SurgeCatalogueBasecamp/index.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from '@ifrc-go/ui/hooks';
 
-import CatalogueInfoCard, { LinkData } from '#components/CatalogueInfoCard';
+import CatalogueInfoCard, { type LinkData } from '#components/CatalogueInfoCard';
 import SurgeCardContainer from '#components/domain/SurgeCardContainer';
 import SurgeCatalogueContainer from '#components/domain/SurgeCatalogueContainer';
 

--- a/app/src/views/SurgeCatalogueCash/index.tsx
+++ b/app/src/views/SurgeCatalogueCash/index.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from '@ifrc-go/ui/hooks';
 
-import CatalogueInfoCard, { LinkData } from '#components/CatalogueInfoCard';
+import CatalogueInfoCard, { type LinkData } from '#components/CatalogueInfoCard';
 import SurgeCardContainer from '#components/domain/SurgeCardContainer';
 import SurgeCatalogueContainer from '#components/domain/SurgeCatalogueContainer';
 

--- a/app/src/views/SurgeCatalogueCommunication/index.tsx
+++ b/app/src/views/SurgeCatalogueCommunication/index.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from '@ifrc-go/ui/hooks';
 
-import CatalogueInfoCard, { LinkData } from '#components/CatalogueInfoCard';
+import CatalogueInfoCard, { type LinkData } from '#components/CatalogueInfoCard';
 import SurgeCardContainer from '#components/domain/SurgeCardContainer';
 import SurgeCatalogueContainer from '#components/domain/SurgeCatalogueContainer';
 

--- a/app/src/views/SurgeCatalogueCommunityEngagement/index.tsx
+++ b/app/src/views/SurgeCatalogueCommunityEngagement/index.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from '@ifrc-go/ui/hooks';
 
-import CatalogueInfoCard, { LinkData } from '#components/CatalogueInfoCard';
+import CatalogueInfoCard, { type LinkData } from '#components/CatalogueInfoCard';
 import SurgeCardContainer from '#components/domain/SurgeCardContainer';
 import SurgeCatalogueContainer from '#components/domain/SurgeCatalogueContainer';
 

--- a/app/src/views/SurgeCatalogueEmergencyNeedsAssessment/index.tsx
+++ b/app/src/views/SurgeCatalogueEmergencyNeedsAssessment/index.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { useTranslation } from '@ifrc-go/ui/hooks';
 
-import CatalogueInfoCard, { LinkData } from '#components/CatalogueInfoCard';
+import CatalogueInfoCard, { type LinkData } from '#components/CatalogueInfoCard';
 import SurgeCardContainer from '#components/domain/SurgeCardContainer';
 import SurgeCatalogueContainer from '#components/domain/SurgeCatalogueContainer';
 

--- a/app/src/views/SurgeCatalogueHealth/index.tsx
+++ b/app/src/views/SurgeCatalogueHealth/index.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from '@ifrc-go/ui/hooks';
 
-import CatalogueInfoCard, { LinkData } from '#components/CatalogueInfoCard';
+import CatalogueInfoCard, { type LinkData } from '#components/CatalogueInfoCard';
 import SurgeCardContainer from '#components/domain/SurgeCardContainer';
 import SurgeCatalogueContainer from '#components/domain/SurgeCatalogueContainer';
 

--- a/app/src/views/SurgeCatalogueInformationManagement/index.tsx
+++ b/app/src/views/SurgeCatalogueInformationManagement/index.tsx
@@ -2,7 +2,7 @@ import { Image } from '@ifrc-go/ui';
 import { useTranslation } from '@ifrc-go/ui/hooks';
 
 import pyramidImage from '#assets/images/surge-im-pyramid.png';
-import CatalogueInfoCard, { LinkData } from '#components/CatalogueInfoCard';
+import CatalogueInfoCard, { type LinkData } from '#components/CatalogueInfoCard';
 import SurgeCardContainer from '#components/domain/SurgeCardContainer';
 import SurgeCatalogueContainer from '#components/domain/SurgeCatalogueContainer';
 

--- a/app/src/views/SurgeCatalogueInformationTechnology/index.tsx
+++ b/app/src/views/SurgeCatalogueInformationTechnology/index.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from '@ifrc-go/ui/hooks';
 
-import CatalogueInfoCard, { LinkData } from '#components/CatalogueInfoCard';
+import CatalogueInfoCard, { type LinkData } from '#components/CatalogueInfoCard';
 import SurgeCardContainer from '#components/domain/SurgeCardContainer';
 import SurgeCatalogueContainer from '#components/domain/SurgeCatalogueContainer';
 

--- a/app/src/views/SurgeCatalogueLivelihood/index.tsx
+++ b/app/src/views/SurgeCatalogueLivelihood/index.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from '@ifrc-go/ui/hooks';
 
-import CatalogueInfoCard, { LinkData } from '#components/CatalogueInfoCard';
+import CatalogueInfoCard, { type LinkData } from '#components/CatalogueInfoCard';
 import SurgeCardContainer from '#components/domain/SurgeCardContainer';
 import SurgeCatalogueContainer from '#components/domain/SurgeCatalogueContainer';
 

--- a/app/src/views/SurgeCatalogueLogistics/index.tsx
+++ b/app/src/views/SurgeCatalogueLogistics/index.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { useTranslation } from '@ifrc-go/ui/hooks';
 
-import CatalogueInfoCard, { LinkData } from '#components/CatalogueInfoCard';
+import CatalogueInfoCard, { type LinkData } from '#components/CatalogueInfoCard';
 import SurgeCardContainer from '#components/domain/SurgeCardContainer';
 import SurgeCatalogueContainer from '#components/domain/SurgeCatalogueContainer';
 

--- a/app/src/views/SurgeCatalogueOperationsManagement/index.tsx
+++ b/app/src/views/SurgeCatalogueOperationsManagement/index.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from '@ifrc-go/ui/hooks';
 
-import CatalogueInfoCard, { LinkData } from '#components/CatalogueInfoCard';
+import CatalogueInfoCard, { type LinkData } from '#components/CatalogueInfoCard';
 import SurgeCardContainer from '#components/domain/SurgeCardContainer';
 import SurgeCatalogueContainer from '#components/domain/SurgeCatalogueContainer';
 

--- a/app/src/views/SurgeCatalogueOtherStrategicPartnershipsResourceMobilisation/index.tsx
+++ b/app/src/views/SurgeCatalogueOtherStrategicPartnershipsResourceMobilisation/index.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from '@ifrc-go/ui/hooks';
 
-import CatalogueInfoCard, { LinkData } from '#components/CatalogueInfoCard';
+import CatalogueInfoCard, { type LinkData } from '#components/CatalogueInfoCard';
 import SurgeCardContainer from '#components/domain/SurgeCardContainer';
 import SurgeCatalogueContainer from '#components/domain/SurgeCatalogueContainer';
 import SurgeContentContainer from '#components/domain/SurgeContentContainer';

--- a/app/src/views/SurgeCataloguePgi/index.tsx
+++ b/app/src/views/SurgeCataloguePgi/index.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from '@ifrc-go/ui/hooks';
 
-import CatalogueInfoCard, { LinkData } from '#components/CatalogueInfoCard';
+import CatalogueInfoCard, { type LinkData } from '#components/CatalogueInfoCard';
 import SurgeCardContainer from '#components/domain/SurgeCardContainer';
 import SurgeCatalogueContainer from '#components/domain/SurgeCatalogueContainer';
 

--- a/app/src/views/SurgeCatalogueShelter/index.tsx
+++ b/app/src/views/SurgeCatalogueShelter/index.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from '@ifrc-go/ui/hooks';
 
-import CatalogueInfoCard, { LinkData } from '#components/CatalogueInfoCard';
+import CatalogueInfoCard, { type LinkData } from '#components/CatalogueInfoCard';
 import SurgeCardContainer from '#components/domain/SurgeCardContainer';
 import SurgeCatalogueContainer from '#components/domain/SurgeCatalogueContainer';
 

--- a/app/src/views/SurgeCatalogueWash/index.tsx
+++ b/app/src/views/SurgeCatalogueWash/index.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from '@ifrc-go/ui/hooks';
 
-import CatalogueInfoCard, { LinkData } from '#components/CatalogueInfoCard';
+import CatalogueInfoCard, { type LinkData } from '#components/CatalogueInfoCard';
 import SurgeCardContainer from '#components/domain/SurgeCardContainer';
 import SurgeCatalogueContainer from '#components/domain/SurgeCatalogueContainer';
 

--- a/app/src/views/SurgeOperationalToolbox/index.tsx
+++ b/app/src/views/SurgeOperationalToolbox/index.tsx
@@ -1,4 +1,4 @@
-import { MouseEventHandler } from 'react';
+import { type MouseEventHandler } from 'react';
 import {
     Container,
     ExpandableContainer,

--- a/app/src/views/SurgeOverview/SurgeMap/index.tsx
+++ b/app/src/views/SurgeOverview/SurgeMap/index.tsx
@@ -40,7 +40,7 @@ import {
     optionLabelSelector,
     outerCircleLayerOptionsForEru,
     outerCircleLayerOptionsForPersonnel,
-    ScaleOption,
+    type ScaleOption,
 } from './utils';
 
 import i18n from './i18n.json';

--- a/app/src/views/ThreeWProjectForm/schema.ts
+++ b/app/src/views/ThreeWProjectForm/schema.ts
@@ -1,11 +1,11 @@
 import { type DeepReplace } from '@ifrc-go/ui/utils';
 import {
     addCondition,
-    ArraySchema,
+    type ArraySchema,
     emailCondition,
     nullValue,
-    ObjectSchema,
-    PartialForm,
+    type ObjectSchema,
+    type PartialForm,
     requiredStringCondition,
     undefinedValue,
 } from '@togglecorp/toggle-form';


### PR DESCRIPTION
- Add option to include Lack of Coping capacity for Risk score
- Remove option to include Lack of Coping capacity for People exposed and People at Risk of Displacement
- Use current month as default value in country seasonal risk month selector

## Addresses:

- https://github.com/IFRCGo/go-web-app/issues/1545
- https://github.com/IFRCGo/go-web-app/issues/1230 (partially)