### PR TITLE
fix: Empty message in changes modal in local unit

### DIFF
--- a/app/src/views/CountryNsOverviewContextAndStructure/NationalSocietyLocalUnits/LocalUnitsFormModal/LocalUnitsForm/i18n.json
+++ b/app/src/views/CountryNsOverviewContextAndStructure/NationalSocietyLocalUnits/LocalUnitsFormModal/LocalUnitsForm/i18n.json
@@ -86,6 +86,7 @@
         "confirmChangesContentQuestion": "Are you sure you want to have these changes in this local unit?",
         "newLocalUnitDescription": "New local unit",
         "latitude": "Latitude",
-        "longitude": "Longitude"
+        "longitude": "Longitude",
+        "noChangesMessage": "You have made no changes to this local unit."
     }
 }

--- a/app/src/views/CountryNsOverviewContextAndStructure/NationalSocietyLocalUnits/LocalUnitsFormModal/LocalUnitsForm/index.tsx
+++ b/app/src/views/CountryNsOverviewContextAndStructure/NationalSocietyLocalUnits/LocalUnitsFormModal/LocalUnitsForm/index.tsx
@@ -490,6 +490,9 @@ function LocalUnitsForm(props: Props) {
     const readOnly = readOnlyFromProps
         || localUnitDetailsResponse?.is_locked;
 
+    const emptyLocalUnitChangesFormFields = localUnitChangedFormFields
+        && localUnitChangedFormFields.length <= 0;
+
     const {
         response: localUnitsOptions,
         pending: localUnitsOptionsPending,
@@ -696,8 +699,11 @@ function LocalUnitsForm(props: Props) {
         <Button
             name={undefined}
             onClick={handleFormSubmit}
-            disabled={addLocalUnitsPending
-                || updateLocalUnitsPending}
+            disabled={
+                addLocalUnitsPending
+                || updateLocalUnitsPending
+                || emptyLocalUnitChangesFormFields
+            }
         >
             {strings.submitButtonLabel}
         </Button>
@@ -1807,6 +1813,8 @@ function LocalUnitsForm(props: Props) {
                     onClose={setShowChangesModalFalse}
                     footerActions={submitButton}
                     headerDescription={strings.confirmChangesContentQuestion}
+                    empty={emptyLocalUnitChangesFormFields}
+                    emptyMessage={strings.noChangesMessage}
                 >
                     <RawList
                         data={localUnitChangedFormFields}


### PR DESCRIPTION
## Summary
Add Empty message and in localunit changes modal and disable the submit button.

## Addresses
- Issue(s): No issue created

## Changes
- Add empty message in modal container
- Add check for the localunitChangesFormField is empty

## This PR Ensures:
- [x] No typos or grammatical errors
- [x] No conflict markers left in the code
- [x] No unwanted comments, temporary files, or auto-generated files
- [x] No inclusion of secret keys or sensitive data
- [x] No `console.log` statements meant for debugging
- [x] All CI checks have passed
