### PR TITLE
Type column to AppealDocs table

### DIFF
--- a/.changeset/modern-rings-know.md
+++ b/.changeset/modern-rings-know.md
@@ -1,0 +1,5 @@
+---
+"go-web-app": patch
+---
+
+Due to go-web-app/issues/1640 the appealdoc type is needed in tables

--- a/app/src/views/EmergencyReportAndDocument/i18n.json
+++ b/app/src/views/EmergencyReportAndDocument/i18n.json
@@ -13,7 +13,7 @@
         "addAReportLink": "Add a Report",
         "appealDocuments": "Appeal Documents ({count})",
         "appealDocumentDate": "Date",
-        "appealDocumentLocation": "Location",
+        "appealDocumentType": "Type",
         "appealDocumentCode": "Code",
         "appealDocumentDescription": "Description",
         "appealDocumentLink": "Name",

--- a/app/src/views/EmergencyReportAndDocument/index.tsx
+++ b/app/src/views/EmergencyReportAndDocument/index.tsx
@@ -184,9 +184,9 @@ export function Component() {
                 },
             ),
             createStringColumn<AppealDocumentType, number>(
-                'iso',
-                strings.appealDocumentLocation,
-                (item) => item.iso,
+                'type',
+                strings.appealDocumentType,
+                (item) => item.type,
             ),
             createStringColumn<AppealDocumentType, number>(
                 'code',
@@ -211,7 +211,7 @@ export function Component() {
         ]),
         [
             strings.appealDocumentDate,
-            strings.appealDocumentLocation,
+            strings.appealDocumentType,
             strings.appealDocumentCode,
             strings.appealDocumentDescription,
             strings.appealDocumentLink,

--- a/translationMigrations/000010-1738067954473.json
+++ b/translationMigrations/000010-1738067954473.json
@@ -1,0 +1,16 @@
+{
+    "parent": "000009-1737021478924.json",
+    "actions": [
+        {
+            "action": "add",
+            "key": "appealDocumentType",
+            "namespace": "emergencyReportAndDocument",
+            "value": "Type"
+        },
+        {
+            "action": "remove",
+            "key": "appealDocumentLocation",
+            "namespace": "emergencyReportAndDocument"
+        }
+    ]
+}


### PR DESCRIPTION
Refers to https://github.com/IFRCGo/go-web-app/issues/1640
According to Daniel, we remove the irrelevant "Location" column from the AppealDocs table. (But we add the Type.)