### PR TITLE
Active Operations and Appeal Documents table ordering

### DIFF
--- a/.changeset/calm-eggs-hammer.md
+++ b/.changeset/calm-eggs-hammer.md
@@ -3,3 +3,4 @@
 ---
 
 Active Operations and Appeal Documents table ordering
+Recent Emergencies in Region - table ordering by Date

--- a/.changeset/calm-eggs-hammer.md
+++ b/.changeset/calm-eggs-hammer.md
@@ -2,5 +2,9 @@
 "go-web-app": patch
 ---
 
-Active Operations and Appeal Documents table ordering
-Recent Emergencies in Region - table ordering by Date
+- Appeal Documents table, emergencies/xyzw/reports page
+- Recent Emergencies in Regions
+- All Appeals table
+- Main page, Active Operations table - and the same AppealsTable is used in the next ones:
+- Active Operations in Regions
+- Previous Operations on Countries

--- a/.changeset/calm-eggs-hammer.md
+++ b/.changeset/calm-eggs-hammer.md
@@ -2,13 +2,14 @@
 "go-web-app": patch
 ---
 
-- Appeal Documents table, emergencies/xyzw/reports page
-- Recent Emergencies in Regions
-- All Appeals table
-- All Deployed Personnel default sorting (filters to be added)
-- Deployed ERUs, changed filter title
-- Key Documents tables in Countries
-- Response documents
-- Main page, Active Operations table - and the same AppealsTable is used in the next ones:
-- Active Operations in Regions
-- Previous Operations on Countries
+- Improve tables by adding default and second level ordering in following
+    - Appeal Documents table, emergencies/xyzw/reports page
+    - Recent Emergencies in Regions
+    - All Appeals table
+    - All Deployed Personnel default sorting (filters to be added)
+    - Deployed ERUs, changed filter title
+    - Key Documents tables in Countries
+    - Response documents
+    - Main page, Active Operations table - and the same AppealsTable is used in the next ones:
+    - Active Operations in Regions
+    - Previous Operations on Countries

--- a/.changeset/calm-eggs-hammer.md
+++ b/.changeset/calm-eggs-hammer.md
@@ -5,8 +5,10 @@
 - Appeal Documents table, emergencies/xyzw/reports page
 - Recent Emergencies in Regions
 - All Appeals table
+- All Deployed Personnel default sorting (filters to be added)
 - Deployed ERUs, changed filter title
 - Key Documents tables in Countries
+- Response documents
 - Main page, Active Operations table - and the same AppealsTable is used in the next ones:
 - Active Operations in Regions
 - Previous Operations on Countries

--- a/.changeset/calm-eggs-hammer.md
+++ b/.changeset/calm-eggs-hammer.md
@@ -1,0 +1,5 @@
+---
+"go-web-app": patch
+---
+
+Active Operations and Appeal Documents table ordering

--- a/.changeset/calm-eggs-hammer.md
+++ b/.changeset/calm-eggs-hammer.md
@@ -6,6 +6,7 @@
 - Recent Emergencies in Regions
 - All Appeals table
 - Deployed ERUs, changed filter title
+- Key Documents tables in Countries
 - Main page, Active Operations table - and the same AppealsTable is used in the next ones:
 - Active Operations in Regions
 - Previous Operations on Countries

--- a/.changeset/calm-eggs-hammer.md
+++ b/.changeset/calm-eggs-hammer.md
@@ -5,6 +5,7 @@
 - Appeal Documents table, emergencies/xyzw/reports page
 - Recent Emergencies in Regions
 - All Appeals table
+- Deployed ERUs, changed filter title
 - Main page, Active Operations table - and the same AppealsTable is used in the next ones:
 - Active Operations in Regions
 - Previous Operations on Countries

--- a/app/src/components/domain/AppealsTable/index.tsx
+++ b/app/src/components/domain/AppealsTable/index.tsx
@@ -24,6 +24,7 @@ import {
 import {
     _cs,
     isDefined,
+    isNotDefined,
 } from '@togglecorp/fujs';
 
 import DisasterTypeSelectInput from '#components/domain/DisasterTypeSelectInput';
@@ -205,19 +206,30 @@ function AppealsTable(props: Props) {
         ],
     );
 
-    let betterOrdering = ordering;
-    if (ordering === '-id') {
-        betterOrdering = '-start_date';
-    } else if (ordering.replace('-', '') !== 'start_date') {
-        betterOrdering = `${ordering},-start_date`;
-    }
+    const defaultOrdering = '-start_date';
+    const orderingWithFallback = useMemo(() => {
+        if (isNotDefined(ordering)) {
+            return defaultOrdering;
+        }
+
+        if (ordering === '-id') {
+            return '-start_date';
+        }
+
+        if (ordering === 'start_date' || ordering === '-start_date') {
+            return ordering;
+        }
+
+        // Add default ordering as second ordering
+        return [ordering, defaultOrdering].join(',');
+    }, [ordering]);
 
     const query = useMemo<AppealQueryParams>(
         () => {
             const baseQuery: AppealQueryParams = {
                 limit,
                 offset,
-                ordering: betterOrdering,
+                ordering: orderingWithFallback,
                 atype: filter.appeal,
                 dtype: filter.displacement,
                 district: hasSomeDefinedValue(filter.district) ? filter.district : undefined,
@@ -241,7 +253,7 @@ function AppealsTable(props: Props) {
             variant,
             countryId,
             regionId,
-            betterOrdering,
+            orderingWithFallback,
             filter,
             limit,
             offset,

--- a/app/src/components/domain/AppealsTable/index.tsx
+++ b/app/src/components/domain/AppealsTable/index.tsx
@@ -209,8 +209,7 @@ function AppealsTable(props: Props) {
     if (ordering === '-id') {
         betterOrdering = '-start_date';
     } else if (ordering.replace('-', '') !== 'start_date') {
-        // eslint-disable-next-line
-        betterOrdering = ordering + ',-start_date';
+        betterOrdering = `${ordering},-start_date`;
     }
 
     const query = useMemo<AppealQueryParams>(

--- a/app/src/components/domain/AppealsTable/index.tsx
+++ b/app/src/components/domain/AppealsTable/index.tsx
@@ -205,12 +205,20 @@ function AppealsTable(props: Props) {
         ],
     );
 
+    let betterOrdering = ordering;
+    if (ordering === '-id') {
+        betterOrdering = '-start_date';
+    } else if (ordering.replace('-', '') !== 'start_date') {
+        // eslint-disable-next-line
+        betterOrdering = ordering + ',-start_date';
+    }
+
     const query = useMemo<AppealQueryParams>(
         () => {
             const baseQuery: AppealQueryParams = {
                 limit,
                 offset,
-                ordering,
+                ordering: betterOrdering,
                 atype: filter.appeal,
                 dtype: filter.displacement,
                 district: hasSomeDefinedValue(filter.district) ? filter.district : undefined,
@@ -234,7 +242,7 @@ function AppealsTable(props: Props) {
             variant,
             countryId,
             regionId,
-            ordering,
+            betterOrdering,
             filter,
             limit,
             offset,

--- a/app/src/views/AllAppeals/index.tsx
+++ b/app/src/views/AllAppeals/index.tsx
@@ -137,11 +137,19 @@ export function Component() {
         (country) => country,
     );
 
+    let betterOrdering = ordering;
+    if (ordering === '-id') {
+        betterOrdering = '-start_date';
+    } else if (ordering.replace('-', '') !== 'start_date') {
+        // eslint-disable-next-line
+        betterOrdering = ordering + ',-start_date';
+    }
+
     const query = useMemo<AppealQueryParams>(
         () => ({
             limit,
             offset,
-            ordering,
+            ordering: betterOrdering,
             atype: filterAppealType,
             dtype: filterDisasterType,
             country: isDefined(filterCountry) ? [filterCountry] : undefined,
@@ -152,7 +160,7 @@ export function Component() {
         [
             limit,
             offset,
-            ordering,
+            betterOrdering,
             filterAppealType,
             filterDisasterType,
             filterCountry,
@@ -211,6 +219,7 @@ export function Component() {
                 'dtype',
                 strings.allAppealsDisasterType,
                 (item) => item.dtype?.name,
+                { sortable: true },
             ),
             createNumberColumn<AppealListItem, string>(
                 'amount_requested',

--- a/app/src/views/AllAppeals/index.tsx
+++ b/app/src/views/AllAppeals/index.tsx
@@ -20,7 +20,10 @@ import {
     getPercentage,
     resolveToComponent,
 } from '@ifrc-go/ui/utils';
-import { isDefined } from '@togglecorp/fujs';
+import {
+    isDefined,
+    isNotDefined,
+} from '@togglecorp/fujs';
 import { saveAs } from 'file-saver';
 import Papa from 'papaparse';
 
@@ -137,18 +140,29 @@ export function Component() {
         (country) => country,
     );
 
-    let betterOrdering = ordering;
-    if (ordering === '-id') {
-        betterOrdering = '-start_date';
-    } else if (ordering.replace('-', '') !== 'start_date') {
-        betterOrdering = `${ordering},-start_date`;
-    }
+    const defaultOrdering = '-start_date';
+    const orderingWithFallback = useMemo(() => {
+        if (isNotDefined(ordering)) {
+            return defaultOrdering;
+        }
+
+        if (ordering === '-id') {
+            return '-start_date';
+        }
+
+        if (ordering === 'start_date' || ordering === '-start_date') {
+            return ordering;
+        }
+
+        // Add default ordering as second ordering
+        return [ordering, defaultOrdering].join(',');
+    }, [ordering]);
 
     const query = useMemo<AppealQueryParams>(
         () => ({
             limit,
             offset,
-            ordering: betterOrdering,
+            ordering: orderingWithFallback,
             atype: filterAppealType,
             dtype: filterDisasterType,
             country: isDefined(filterCountry) ? [filterCountry] : undefined,
@@ -159,7 +173,7 @@ export function Component() {
         [
             limit,
             offset,
-            betterOrdering,
+            orderingWithFallback,
             filterAppealType,
             filterDisasterType,
             filterCountry,

--- a/app/src/views/AllAppeals/index.tsx
+++ b/app/src/views/AllAppeals/index.tsx
@@ -141,8 +141,7 @@ export function Component() {
     if (ordering === '-id') {
         betterOrdering = '-start_date';
     } else if (ordering.replace('-', '') !== 'start_date') {
-        // eslint-disable-next-line
-        betterOrdering = ordering + ',-start_date';
+        betterOrdering = `${ordering},-start_date`;
     }
 
     const query = useMemo<AppealQueryParams>(

--- a/app/src/views/AllDeployedPersonnel/index.tsx
+++ b/app/src/views/AllDeployedPersonnel/index.tsx
@@ -74,17 +74,25 @@ export function Component() {
         return type.toUpperCase();
     }, [strings.rapidResponse]);
 
+    let betterOrdering = ordering;
+    if (ordering === '-id') {
+        betterOrdering = '-start_date';
+    } else if (ordering.replace('-', '') !== 'start_date') {
+        // eslint-disable-next-line
+        betterOrdering = ordering + ',-start_date';
+    }
+
     const query = useMemo(() => ({
         limit,
         offset,
-        ordering,
+        ordering: betterOrdering,
         // FIXME: The server does not support date string
         start_date__gte: toDateTimeString(filter.startDateAfter),
         start_date__lte: toDateTimeString(filter.startDateBefore),
     }), [
         limit,
         offset,
-        ordering,
+        betterOrdering,
         filter,
     ]);
 

--- a/app/src/views/AllDeployedPersonnel/index.tsx
+++ b/app/src/views/AllDeployedPersonnel/index.tsx
@@ -78,8 +78,7 @@ export function Component() {
     if (ordering === '-id') {
         betterOrdering = '-start_date';
     } else if (ordering.replace('-', '') !== 'start_date') {
-        // eslint-disable-next-line
-        betterOrdering = ordering + ',-start_date';
+        betterOrdering = `${ordering},-start_date`;
     }
 
     const query = useMemo(() => ({

--- a/app/src/views/AllDeployedPersonnel/index.tsx
+++ b/app/src/views/AllDeployedPersonnel/index.tsx
@@ -74,24 +74,35 @@ export function Component() {
         return type.toUpperCase();
     }, [strings.rapidResponse]);
 
-    let betterOrdering = ordering;
-    if (ordering === '-id') {
-        betterOrdering = '-start_date';
-    } else if (ordering.replace('-', '') !== 'start_date') {
-        betterOrdering = `${ordering},-start_date`;
-    }
+    const defaultOrdering = '-start_date';
+    const orderingWithFallback = useMemo(() => {
+        if (isNotDefined(ordering)) {
+            return defaultOrdering;
+        }
+
+        if (ordering === '-id') {
+            return '-start_date';
+        }
+
+        if (ordering === 'start_date' || ordering === '-start_date') {
+            return ordering;
+        }
+
+        // Add default ordering as second ordering
+        return [ordering, defaultOrdering].join(',');
+    }, [ordering]);
 
     const query = useMemo(() => ({
         limit,
         offset,
-        ordering: betterOrdering,
+        ordering: orderingWithFallback,
         // FIXME: The server does not support date string
         start_date__gte: toDateTimeString(filter.startDateAfter),
         start_date__lte: toDateTimeString(filter.startDateBefore),
     }), [
         limit,
         offset,
-        betterOrdering,
+        orderingWithFallback,
         filter,
     ]);
 

--- a/app/src/views/CountryNsOverviewContextAndStructure/NationalSocietyKeyDocuments/index.tsx
+++ b/app/src/views/CountryNsOverviewContextAndStructure/NationalSocietyKeyDocuments/index.tsx
@@ -69,6 +69,7 @@ function NationalSocietyKeyDocuments() {
             search: filter.searchText,
             year__gte: filter.startDateAfter,
             year__lte: filter.startDateBefore,
+            ordering: '-year',
         },
         preserveResponse: true,
     });

--- a/app/src/views/EmergencyReportAndDocument/index.tsx
+++ b/app/src/views/EmergencyReportAndDocument/index.tsx
@@ -88,12 +88,23 @@ export function Component() {
         } : undefined, // TODO: we need to add search filter in server
     });
 
-    let betterOrdering = orderingAppealDocuments;
-    if (orderingAppealDocuments === '-id') {
-        betterOrdering = '-created_at';
-    } else if (orderingAppealDocuments.replace('-', '') !== 'created_at') {
-        betterOrdering = `${orderingAppealDocuments},-created_at`;
-    }
+    const defaultOrdering = '-created_at';
+    const orderingWithFallback = useMemo(() => {
+        if (isNotDefined(orderingAppealDocuments)) {
+            return defaultOrdering;
+        }
+
+        if (orderingAppealDocuments === '-id') {
+            return '-created_at';
+        }
+
+        if (orderingAppealDocuments === 'created_at' || orderingAppealDocuments === '-created_at') {
+            return orderingAppealDocuments;
+        }
+
+        // Add default ordering as second ordering
+        return [orderingAppealDocuments, defaultOrdering].join(',');
+    }, [orderingAppealDocuments]);
 
     const {
         pending: appealDocumentsPending,
@@ -111,7 +122,7 @@ export function Component() {
             appeal: emergencyResponse.appeals.map((appeal) => appeal.id).filter(isDefined),
             limit: appealDocumentsLimit,
             offset: appealDocumentsOffset,
-            ordering: betterOrdering,
+            ordering: orderingWithFallback,
         } : undefined,
     });
 

--- a/app/src/views/EmergencyReportAndDocument/index.tsx
+++ b/app/src/views/EmergencyReportAndDocument/index.tsx
@@ -92,8 +92,7 @@ export function Component() {
     if (orderingAppealDocuments === '-id') {
         betterOrdering = '-created_at';
     } else if (orderingAppealDocuments.replace('-', '') !== 'created_at') {
-        // eslint-disable-next-line
-        betterOrdering = orderingAppealDocuments + ',-created_at';
+        betterOrdering = `${orderingAppealDocuments},-created_at`;
     }
 
     const {

--- a/app/src/views/EmergencyReportAndDocument/index.tsx
+++ b/app/src/views/EmergencyReportAndDocument/index.tsx
@@ -11,6 +11,7 @@ import {
     RawList,
     Table,
 } from '@ifrc-go/ui';
+import { SortContext } from '@ifrc-go/ui/contexts';
 import { useTranslation } from '@ifrc-go/ui/hooks';
 import {
     createDateColumn,
@@ -59,9 +60,11 @@ export function Component() {
         offset: appealDocumentsOffset,
         setPage: setAppealDocumentsPage,
         limit: appealDocumentsLimit,
+        ordering: orderingAppealDocuments,
+        sortState: sortStateAppealDocuments,
     } = useFilterState<object>({
         filter: {},
-        pageSize: 10,
+        pageSize: PAGE_SIZE,
     });
 
     const {
@@ -84,6 +87,14 @@ export function Component() {
         } : undefined, // TODO: we need to add search filter in server
     });
 
+    let betterOrdering = orderingAppealDocuments;
+    if (orderingAppealDocuments === '-id') {
+        betterOrdering = '-created_at';
+    } else if (orderingAppealDocuments.replace('-', '') !== 'created_at') {
+        // eslint-disable-next-line
+        betterOrdering = orderingAppealDocuments + ',-created_at';
+    }
+
     const {
         pending: appealDocumentsPending,
         response: appealDocumentsResponse,
@@ -100,6 +111,7 @@ export function Component() {
             appeal: emergencyResponse.appeals.map((appeal) => appeal.id).filter(isDefined),
             limit: appealDocumentsLimit,
             offset: appealDocumentsOffset,
+            ordering: betterOrdering,
         } : undefined,
     });
 
@@ -181,6 +193,7 @@ export function Component() {
                 (item) => item.created_at,
                 {
                     columnClassName: styles.date,
+                    sortable: true,
                 },
             ),
             createStringColumn<AppealDocumentType, number>(
@@ -207,6 +220,9 @@ export function Component() {
                     withLinkIcon: true,
                     href: item.document ?? item.document_url ?? undefined,
                 }),
+                {
+                    sortable: true,
+                },
             ),
         ]),
         [
@@ -363,14 +379,16 @@ export function Component() {
                         />
                     )}
                 >
-                    <Table
-                        pending={appealDocumentsPending}
-                        filtered={false}
-                        className={styles.table}
-                        columns={appealColumns}
-                        keySelector={numericIdSelector}
-                        data={appealDocumentsResponse?.results}
-                    />
+                    <SortContext.Provider value={sortStateAppealDocuments}>
+                        <Table
+                            pending={appealDocumentsPending}
+                            filtered={false}
+                            className={styles.table}
+                            columns={appealColumns}
+                            keySelector={numericIdSelector}
+                            data={appealDocumentsResponse?.results}
+                        />
+                    </SortContext.Provider>
                 </Container>
             )}
         </div>

--- a/app/src/views/EmergencyReportAndDocument/index.tsx
+++ b/app/src/views/EmergencyReportAndDocument/index.tsx
@@ -84,6 +84,7 @@ export function Component() {
         query: isDefined(emergencyResponse) ? {
             event: emergencyResponse.id,
             limit: 9999,
+            ordering: '-is_pinned,-created_at',
         } : undefined, // TODO: we need to add search filter in server
     });
 

--- a/app/src/views/EmergencyReportAndDocument/index.tsx
+++ b/app/src/views/EmergencyReportAndDocument/index.tsx
@@ -201,6 +201,7 @@ export function Component() {
                 'type',
                 strings.appealDocumentType,
                 (item) => item.type,
+                { sortable: true },
             ),
             createStringColumn<AppealDocumentType, number>(
                 'code',

--- a/app/src/views/RegionOperations/RecentEmergenciesTable/index.tsx
+++ b/app/src/views/RegionOperations/RecentEmergenciesTable/index.tsx
@@ -14,7 +14,10 @@ import {
     resolveToComponent,
     sumSafe,
 } from '@ifrc-go/ui/utils';
-import { max } from '@togglecorp/fujs';
+import {
+    isNotDefined,
+    max,
+} from '@togglecorp/fujs';
 
 import Link from '#components/Link';
 import useFilterState from '#hooks/useFilterState';
@@ -129,12 +132,23 @@ function EventItemsTable(props: Props) {
         ],
     );
 
-    let betterOrdering = ordering;
-    if (ordering === '-id') {
-        betterOrdering = '-created_at';
-    } else if (ordering.replace('-', '') !== 'created_at') {
-        betterOrdering = `${ordering},-created_at`;
-    }
+    const defaultOrdering = '-created_at';
+    const orderingWithFallback = useMemo(() => {
+        if (isNotDefined(ordering)) {
+            return defaultOrdering;
+        }
+
+        if (ordering === '-id') {
+            return '-created_at';
+        }
+
+        if (ordering === 'created_at' || ordering === '-created_at') {
+            return ordering;
+        }
+
+        // Add default ordering as second ordering
+        return [ordering, defaultOrdering].join(',');
+    }, [ordering]);
 
     const {
         pending: eventPending,
@@ -145,7 +159,7 @@ function EventItemsTable(props: Props) {
         query: {
             limit,
             offset,
-            ordering: betterOrdering,
+            ordering: orderingWithFallback,
             disaster_start_date__gt: thirtyDaysAgo.toISOString(),
             regions__in: regionId,
         },

--- a/app/src/views/RegionOperations/RecentEmergenciesTable/index.tsx
+++ b/app/src/views/RegionOperations/RecentEmergenciesTable/index.tsx
@@ -133,8 +133,7 @@ function EventItemsTable(props: Props) {
     if (ordering === '-id') {
         betterOrdering = '-created_at';
     } else if (ordering.replace('-', '') !== 'created_at') {
-        // eslint-disable-next-line
-        betterOrdering = ordering + ',-created_at';
+        betterOrdering = `${ordering},-created_at`;
     }
 
     const {

--- a/app/src/views/RegionOperations/RecentEmergenciesTable/index.tsx
+++ b/app/src/views/RegionOperations/RecentEmergenciesTable/index.tsx
@@ -129,6 +129,14 @@ function EventItemsTable(props: Props) {
         ],
     );
 
+    let betterOrdering = ordering;
+    if (ordering === '-id') {
+        betterOrdering = '-created_at';
+    } else if (ordering.replace('-', '') !== 'created_at') {
+        // eslint-disable-next-line
+        betterOrdering = ordering + ',-created_at';
+    }
+
     const {
         pending: eventPending,
         response: eventResponse,
@@ -138,7 +146,7 @@ function EventItemsTable(props: Props) {
         query: {
             limit,
             offset,
-            ordering,
+            ordering: betterOrdering,
             disaster_start_date__gt: thirtyDaysAgo.toISOString(),
             regions__in: regionId,
         },

--- a/app/src/views/SurgeOverview/EmergencyResponseUnitsTable/i18n.json
+++ b/app/src/views/SurgeOverview/EmergencyResponseUnitsTable/i18n.json
@@ -10,6 +10,6 @@
         "emergencyResponseUnitsTableHeading": "Deployed ERUs ({count})",
         "emergencyResponseUnitsViewAll": "View All Deployed ERUs",
         "emergencyResponseUnitTypeFilterLabel": "Emergency Response Unit Type",
-        "emergencyResponseUnitTypeFilterPlaceholder": "All Emergency Response Unit Types"
+        "emergencyResponseUnitTypeFilterPlaceholder": "All ERU Types"
     }
 }

--- a/translationMigrations/000013-1738259366084.json
+++ b/translationMigrations/000013-1738259366084.json
@@ -1,0 +1,11 @@
+{
+    "parent": "000012-1738141854510.json",
+    "actions": [
+        {
+            "action": "update",
+            "key": "emergencyResponseUnitTypeFilterPlaceholder",
+            "namespace": "surgeOverview",
+            "newValue": "All ERU Types"
+        }
+    ]
+}

--- a/translationMigrations/000018-1739359398709.json
+++ b/translationMigrations/000018-1739359398709.json
@@ -1,5 +1,5 @@
 {
-    "parent": "000012-1738141854510.json",
+    "parent": "000017-1739357606028.json",
     "actions": [
         {
             "action": "update",


### PR DESCRIPTION
Refers to https://github.com/IFRCGo/go-web-app/issues/1633
These rows are solved:
- Appeal Documents table, emergencies/xyzw/reports page (12)
- Recent Emergencies in Regions (9)
- All Appeals table (2)
- All Deployed Personnel default sorting (filters to be added) (4a)
- Deployed ERUs, changed filter title (5)
- Key Documents tables in Countries (6)
- Response documents (10, still needs go-api change)
- Main page, Active Operations table (1) – and the same AppealsTable is used in the next ones:
- Active Operations in Regions (8)
- Previous Operations on Countries (7)
