### PR TITLE
fix: use current language for field report title generation

### DIFF
--- a/.changeset/new-shrimps-help.md
+++ b/.changeset/new-shrimps-help.md
@@ -1,0 +1,5 @@
+---
+"go-web-app": patch
+---
+
+Use current language for field report title generation

--- a/app/src/views/FieldReportForm/ContextFields/TitlePreview/index.tsx
+++ b/app/src/views/FieldReportForm/ContextFields/TitlePreview/index.tsx
@@ -49,6 +49,7 @@ function TitlePreview(props: Props) {
     } = useRequest({
         url: '/api/v2/field-report/generate-title/',
         method: 'POST',
+        useCurrentLanguageForMutation: true,
         body: debouncedVariables,
         preserveResponse: true,
         onFailure: () => {


### PR DESCRIPTION
## This PR Ensures:
- [x] No typos or grammatical errors
- [x] No conflict markers left in the code
- [x] No unwanted comments, temporary files, or auto-generated files
- [x] No inclusion of secret keys or sensitive data
- [x] No `console.log` statements meant for debugging
- [x] All CI checks have passed
