### PR TITLE
Use `ignores` property instead of `eslintignore` file

### DIFF
--- a/app/.eslintignore
+++ b/app/.eslintignore
@@ -1,3 +1,0 @@
-node_modules/
-build/
-coverage/

--- a/app/eslint.config.js
+++ b/app/eslint.config.js
@@ -131,7 +131,12 @@ const appConfigs = compat.config({
 }).map((conf) => ({
     ...conf,
     files: ['src/**/*.tsx', 'src/**/*.jsx', 'src/**/*.ts', 'src/**/*.js'],
-    ignores: ['src/generated/types.ts'],
+    ignores: [
+        "node_modules/",
+        "build/",
+        "coverage/",
+        'src/generated/types.ts'
+    ],
 }));
 
 const otherConfig = {

--- a/packages/go-ui-storybook/eslint.config.js
+++ b/packages/go-ui-storybook/eslint.config.js
@@ -120,7 +120,10 @@ const appConfigs = compat.config({
 }).map((conf) => ({
     ...conf,
     files: ['src/**/*.tsx', 'src/**/*.jsx', 'src/**/*.ts', 'src/**/*.js'],
-    ignores: ['src/generated/types.ts'],
+    ignores: [
+        "node_modules/",
+        "storybook-static/"
+    ]
 }));
 
 const otherConfig = {

--- a/packages/ui/.eslintignore
+++ b/packages/ui/.eslintignore
@@ -1,2 +1,0 @@
-node_modules/
-dist/

--- a/packages/ui/eslint.config.js
+++ b/packages/ui/eslint.config.js
@@ -120,7 +120,10 @@ const appConfigs = compat.config({
 }).map((conf) => ({
     ...conf,
     files: ['src/**/*.tsx', 'src/**/*.jsx', 'src/**/*.ts', 'src/**/*.js'],
-    ignores: ['src/generated/types.ts'],
+    ignores: [
+        "node_modules/",
+        "dist/"
+    ]
 }));
 
 const otherConfig = {


### PR DESCRIPTION
- [x] No typos or grammatical errors
- [x] No conflict markers left in the code
- [x] No unwanted comments, temporary files, or auto-generated files
- [x] No inclusion of secret keys or sensitive data
- [x] No `console.log` statements meant for debugging
- [x] All CI checks have passed
