### PR TITLE
Redirect `/about` to `/resources` 

### DIFF
--- a/app/src/App/routes/index.tsx
+++ b/app/src/App/routes/index.tsx
@@ -741,6 +741,7 @@ const resources = customWrapRoute({
         visibility: 'anything',
     },
 });
+
 const operationalLearning = customWrapRoute({
     parent: rootLayout,
     path: 'operational-learning',
@@ -1174,6 +1175,20 @@ const perWorkPlanForm = customWrapRoute({
     },
 });
 
+const aboutRedirect = customWrapRoute({
+    parent: rootLayout,
+    path: '/about',
+    component: {
+        render: () => import('#views/Resources'),
+        props: {},
+    },
+    wrapperComponent: Auth,
+    context: {
+        title: 'Resources',
+        visibility: 'anything',
+    },
+});
+
 // Redirect Routes
 const preparednessOperationalLearning = customWrapRoute({
     parent: preparednessLayout,
@@ -1306,6 +1321,7 @@ const wrappedRoutes = {
     threeWProjectDetail,
     termsAndConditions,
     operationalLearning,
+    aboutRedirect,
     ...regionRoutes,
     ...countryRoutes,
     ...surgeRoutes,


### PR DESCRIPTION
## Addresses
- https://github.com/IFRCGo/go-web-app/issues/1687

## Changes
* Redirect `/about` to `/resources`

## This PR Ensures:
* \[x] No typos or grammatical errors
* \[x] No conflict markers left in the code
* \[x] No unwanted comments, temporary files, or auto-generated files
* \[x] No inclusion of secret keys or sensitive data
* \[x] No `console.log` statements meant for debugging
* \[x] All CI checks have passed

