### PR TITLE
Add Montandon landing page

### DIFF
--- a/.changeset/silver-cups-cut.md
+++ b/.changeset/silver-cups-cut.md
@@ -1,0 +1,8 @@
+---
+"go-web-app": minor
+---
+
+Add Montandon landing page
+
+- Add a basic landing page for Montandon with links and information
+- Add link to Montandon landing page to Learn > Resources menu

--- a/app/src/App/routes/index.tsx
+++ b/app/src/App/routes/index.tsx
@@ -1226,6 +1226,20 @@ const obsoleteFieldReportDetails = customWrapRoute({
     },
 });
 
+const montandonLandingPage = customWrapRoute({
+    parent: rootLayout,
+    path: 'montandon-landing',
+    component: {
+        render: () => import('#views/MontandonLandingPage'),
+        props: {},
+    },
+    wrapperComponent: Auth,
+    context: {
+        title: 'Montandon',
+        visibility: 'anything',
+    },
+});
+
 const wrappedRoutes = {
     fourHundredFour,
     rootLayout,
@@ -1306,6 +1320,7 @@ const wrappedRoutes = {
     threeWProjectDetail,
     termsAndConditions,
     operationalLearning,
+    montandonLandingPage,
     ...regionRoutes,
     ...countryRoutes,
     ...surgeRoutes,

--- a/app/src/components/Navbar/i18n.json
+++ b/app/src/components/Navbar/i18n.json
@@ -30,6 +30,8 @@
         "userMenuPERDescription":"The PER Approach is a continuous and flexible process that enables National Societies to assess, measure and analyse the strengths and gaps of its preparedness and response mechanism.",
         "userMenuGlobalSummary":"Global Summary",
         "userMenuGlobalPerformance":"Global Performance",
+        "userMenuMontandonItem":"Montandon - the Global Crisis Data Bank",
+        "userMenuMontandonItemDescription":"Montandon - the world's largest disaster database, containing data on hazards, impacts, and what actions were taken to address them.",
         "userMenuCatalogueResources":"Catalogue of Resources",
         "userMenuStartPER":"Start PER Process",
         "userMenuGlobal3WProjectDescription":"The Programmatic Partnership is an innovative and ambitious three-year partnership between the IFRC, many of our member National Societies, and the European Union.",

--- a/app/src/components/Navbar/index.tsx
+++ b/app/src/components/Navbar/index.tsx
@@ -500,6 +500,19 @@ function Navbar(props: Props) {
                                 <div className={styles.menuItemWithDescription}>
                                     <DropdownMenuItem
                                         type="link"
+                                        to="montandonLandingPage"
+                                        variant="tertiary"
+                                        state={{ earlyWarning: true }}
+                                    >
+                                        {strings.userMenuMontandonItem}
+                                    </DropdownMenuItem>
+                                    <div className={styles.description}>
+                                        {strings.userMenuMontandonItemDescription}
+                                    </div>
+                                </div>
+                                <div className={styles.menuItemWithDescription}>
+                                    <DropdownMenuItem
+                                        type="link"
                                         to="surgeCatalogueLayout"
                                         variant="tertiary"
                                         state={{ earlyWarning: true }}
@@ -507,7 +520,7 @@ function Navbar(props: Props) {
                                         {strings.userMenuCatalogueSurgeServicesItem}
                                     </DropdownMenuItem>
                                     <div className={styles.description}>
-                                        {strings.userMenuCatalogueSurgeServicesItem}
+                                        {strings.userMenuCatalogueSurgeServicesItemDescription}
                                     </div>
                                 </div>
                                 <div className={styles.menuItemWithDescription}>

--- a/app/src/views/MontandonLandingPage/i18n.json
+++ b/app/src/views/MontandonLandingPage/i18n.json
@@ -1,0 +1,42 @@
+{
+    "namespace": "montandonLandingPage",
+    "strings": {
+        "montandonPageTitle": "Montandon - The Global Crisis Data Bank",
+        "montandonHeading": "Montandon - The Global Crisis Data Bank",
+        "montandonHeadingDescription": "Montandon is the world’s largest disaster database—a global public good with applications far beyond IFRC. Montandon integrates three key types of data: 1) forecasted and recorded natural hazards; 2) impact data on these hazards; and 3) operational response data (where available). Montandon contains more than millions of records about hazards and their impacts for hundreds of thousands of events.",
+
+        "sourceButtonTitle": "Source",
+        "sourcePopupTitle": "Source Data",
+        "stacIdLabel": "ID",
+        "stacIdValue": "stac-fastapi",
+        "stacVersionLabel": "STAC Version",
+        "stacVersionValue": "1.0.0",
+        "validLabel": "Valid",
+        "validValue": "Yes",
+        "stacLocationText": "The STAC metadata file is located at",
+        "montandonEoapi": "Montandon EoAPI",
+
+        "sharePopupTitle": "Share",
+        "emailLabel": "Email",
+        "shareUrlLabel": "Share the URL of this page:",
+
+        "videoTitle": "IFRC GO Platform: Mapping global crises' historical data with Montandon",
+
+        "resources": "Resources",
+        "visitGithub": "GitHub",
+        "goWiki": "GO Wiki",
+        "apiDescription": "OpenAPI service description",
+        "apiDocumentation": "OpenAPI service documentation",
+
+        "blogPosts": "Blog Posts",
+        "leveragingDataBlogPostTitle": "Leveraging data to learn from past disasters",
+        "scaledUpSystemsBlogPostTitle": "Scaled-up ambitions require scaled-up systems",
+
+        "contact": "Contact",
+        "contactName": "Justin Ginetti",
+        "contactInfo": "Senior Officer, Information Management and Risk Analysis, IFRC",
+
+        "accessAPILabel": "Access API",
+        "exploreRadiantEarthLabel": "Explore Radiant Earth API"
+    }
+}

--- a/app/src/views/MontandonLandingPage/index.tsx
+++ b/app/src/views/MontandonLandingPage/index.tsx
@@ -1,0 +1,254 @@
+import {
+    DrefTwoIcon,
+    MailIcon,
+    ShareLineIcon,
+} from '@ifrc-go/icons';
+import {
+    Container,
+    DropdownMenu,
+    TextInput,
+    TextOutput,
+} from '@ifrc-go/ui';
+import { useTranslation } from '@ifrc-go/ui/hooks';
+
+import Link from '#components/Link';
+import Page from '#components/Page';
+
+import i18n from './i18n.json';
+import styles from './styles.module.css';
+
+// TODO: Does this need translation?
+const emailSubject = encodeURIComponent('Explore Montandon Data');
+const linkToMontandon = 'https://radiantearth.github.io/stac-browser/#/external/montandon-eoapi-stage.ifrc.org/stac/';
+const emailBody = encodeURIComponent(`Sharing with you a link to Montandon API: ${linkToMontandon}`);
+const mailtoLink = `mailto:?subject=${emailSubject}&body=${emailBody}`;
+
+const noOp = () => {};
+
+/** @knipignore */
+// eslint-disable-next-line import/prefer-default-export
+export function Component() {
+    const strings = useTranslation(i18n);
+
+    return (
+        <Page
+            className={styles.montandonLandingPage}
+            title={strings.montandonPageTitle}
+            heading={strings.montandonHeading}
+            description={strings.montandonHeadingDescription}
+            mainSectionClassName={styles.content}
+            actions={(
+                <>
+                    <DropdownMenu
+                        label={strings.sourcePopupTitle}
+                        icons={<DrefTwoIcon className={styles.icon} />}
+                        preferredPopupWidth={30}
+                        withoutDropdownIcon
+                        persistent
+                    >
+                        <Container
+                            heading={strings.sourcePopupTitle}
+                            withHeaderBorder
+                            withInternalPadding
+                            contentViewType="vertical"
+                        >
+                            <div className={styles.stacDescription}>
+                                <TextOutput
+                                    strongLabel
+                                    label={strings.stacIdLabel}
+                                    value={strings.stacIdValue}
+                                />
+                                <TextOutput
+                                    strongLabel
+                                    label={strings.stacVersionLabel}
+                                    value={strings.stacVersionValue}
+                                />
+                                <TextOutput
+                                    strongLabel
+                                    label={strings.validLabel}
+                                    value={strings.validValue}
+                                />
+                                <div className={styles.separator} />
+                                {strings.stacLocationText}
+                                <TextInput
+                                    name="link"
+                                    value="https://montandon-eoapi-stage.ifrc.org/stac/"
+                                    onChange={noOp}
+                                    readOnly
+                                />
+                            </div>
+                        </Container>
+                    </DropdownMenu>
+                    <DropdownMenu
+                        icons={<ShareLineIcon className={styles.icon} />}
+                        label={strings.sharePopupTitle}
+                        withoutDropdownIcon
+                        preferredPopupWidth={30}
+                        persistent
+                    >
+                        <Container
+                            heading={strings.sharePopupTitle}
+                            withHeaderBorder
+                            withInternalPadding
+                            withFooterBorder
+                            contentViewType="vertical"
+                            footerContent={(
+                                <Link
+                                    href={mailtoLink}
+                                    icons={<MailIcon className={styles.icon} />}
+                                    variant="secondary"
+                                    external
+                                >
+                                    {strings.emailLabel}
+                                </Link>
+                            )}
+                        >
+                            {strings.shareUrlLabel}
+                            <Link
+                                href="https://radiantearth.github.io/stac-browser/#/external/montandon-eoapi-stage.ifrc.org/stac/"
+                                variant="tertiary"
+                                external
+                            >
+                                https://radiantearth.github.io/stac-browser/#/external/montandon-eoapi-stage.ifrc.org/stac/
+                            </Link>
+                        </Container>
+                    </DropdownMenu>
+                </>
+            )}
+            infoContainerClassName={styles.iframeEmbed}
+            info={(
+                <iframe
+                    className={styles.iframe}
+                    src="https://www.youtube.com/embed/BEWxqYfrQek"
+                    title={strings.videoTitle}
+                    allow=""
+                    allowFullScreen
+                />
+            )}
+        >
+            <Container
+                className={styles.resources}
+                contentViewType="grid"
+                numPreferredGridContentColumns={3}
+                spacing="comfortable"
+            >
+                <Container
+                    className={styles.guideCard}
+                    heading={strings.resources}
+                    contentViewType="vertical"
+                    withHeaderBorder
+                    withInternalPadding
+                >
+                    <Link
+                        href="https://github.com/IFRCGo/monty-stac-extension/blob/main/README.md"
+                        external
+                        withLinkIcon
+                    >
+                        {strings.visitGithub}
+                    </Link>
+                    <Link
+                        href="https://go-wiki.ifrc.org/en/home"
+                        external
+                        withLinkIcon
+                    >
+                        {strings.goWiki}
+                    </Link>
+                    <Link
+                        href="https://montandon-eoapi-stage.ifrc.org/stac/api"
+                        external
+                        withLinkIcon
+                    >
+                        {strings.apiDescription}
+                    </Link>
+                    <Link
+                        href="https://montandon-eoapi-stage.ifrc.org/stac/api.html"
+                        external
+                        withLinkIcon
+                    >
+                        {strings.apiDocumentation}
+                    </Link>
+                </Container>
+
+                <Container
+                    className={styles.guideCard}
+                    heading={strings.blogPosts}
+                    contentViewType="vertical"
+                    withHeaderBorder
+                    withInternalPadding
+                >
+                    <Link
+                        href="https://ifrcgoproject.medium.com/toward-a-more-comprehensive-understanding-of-disasters-fc422d65377"
+                        external
+                        withLinkIcon
+                    >
+                        {strings.leveragingDataBlogPostTitle}
+                    </Link>
+
+                    <Link
+                        href="https://ifrcgoproject.medium.com/scaled-up-ambitions-require-scaled-up-systems-4a92456fab59"
+                        external
+                        withLinkIcon
+                    >
+                        {strings.scaledUpSystemsBlogPostTitle}
+                    </Link>
+                </Container>
+
+                <Container
+                    className={styles.guideCard}
+                    heading={strings.contact}
+                    contentViewType="vertical"
+                    withHeaderBorder
+                    withInternalPadding
+                >
+                    <Link
+                        href="mailto:im@ifrc.org"
+                        variant="primary"
+                        external
+                    >
+                        im@ifrc.org
+                    </Link>
+                    <div>
+                        <div className={styles.contactInformation}>
+                            {strings.contactName}
+                        </div>
+                        <div>
+                            {strings.contactInfo}
+                        </div>
+                    </div>
+                    <Link
+                        href="mailto:justin.ginetti@ifrc.org"
+                        variant="tertiary"
+                        external
+                    >
+                        justin.ginetti@ifrc.org
+                    </Link>
+                </Container>
+
+            </Container>
+            <Container
+                contentViewType="vertical"
+                heading="Other links"
+                withHeaderBorder
+            >
+                <Link
+                    href="https://montandon-eoapi-stage.ifrc.org/stac/api.html"
+                    withUnderline
+                    withLinkIcon
+                    external
+                >
+                    {strings.accessAPILabel}
+                </Link>
+                <Link
+                    href="https://radiantearth.github.io/stac-browser/#/external/montandon-eoapi-stage.ifrc.org/stac/"
+                    withUnderline
+                    withLinkIcon
+                    external
+                >
+                    {strings.exploreRadiantEarthLabel}
+                </Link>
+            </Container>
+        </Page>
+    );
+}
+
+Component.displayName = 'montandonLandingPage';

--- a/app/src/views/MontandonLandingPage/styles.module.css
+++ b/app/src/views/MontandonLandingPage/styles.module.css
@@ -1,0 +1,43 @@
+.montandon-landing-page {
+
+    .content {
+        display: flex;
+        flex-direction: column;
+        gap: var(--go-ui-spacing-2xl);
+    }
+
+    .iframe-embed {
+        display: flex;
+        justify-content: center;
+        .iframe {
+            border: none;
+            background-color: var(--go-ui-color-gray-30);
+            width: 100%;
+            max-width: 30rem;
+            height: 100vh;
+            max-height: 20rem;
+        }
+    }
+
+    .guide-card {
+        border: var(--go-ui-width-separator-md) solid var(--go-ui-color-background);
+        border-radius: var(--go-ui-border-radius-lg);
+        box-shadow: var(--go-ui-box-shadow-md);
+
+        .contact-information {
+            font-weight: var(--go-ui-font-weight-semibold);
+        }
+    }
+
+    .separator {
+        flex-shrink: 0;
+        margin: var(--go-ui-spacing-sm) 0;
+        background-color: var(--go-ui-color-separator);
+        width: 100%;
+        height: var(--go-ui-width-separator-thin);
+    }
+
+    .icon {
+        font-size: var(--go-ui-height-icon-multiplier);
+    }
+}

--- a/translationMigrations/000029-1747222422932.json
+++ b/translationMigrations/000029-1747222422932.json
@@ -1,0 +1,197 @@
+{
+    "parent": "000028-1747134326433.json",
+    "actions": [
+        {
+            "action": "add",
+            "key": "userMenuMontandonItem",
+            "namespace": "common",
+            "value": "Montandon - the Global Crisis Data Bank"
+        },
+        {
+            "action": "add",
+            "key": "userMenuMontandonItemDescription",
+            "namespace": "common",
+            "value": "Montandon - the world's largest disaster database, containing data on hazards, impacts, and what actions were taken to address them."
+        },
+        {
+            "action": "add",
+            "key": "accessAPILabel",
+            "namespace": "montandonLandingPage",
+            "value": "Access API"
+        },
+        {
+            "action": "add",
+            "key": "apiDescription",
+            "namespace": "montandonLandingPage",
+            "value": "OpenAPI service description"
+        },
+        {
+            "action": "add",
+            "key": "apiDocumentation",
+            "namespace": "montandonLandingPage",
+            "value": "OpenAPI service documentation"
+        },
+        {
+            "action": "add",
+            "key": "blogPosts",
+            "namespace": "montandonLandingPage",
+            "value": "Blog Posts"
+        },
+        {
+            "action": "add",
+            "key": "contact",
+            "namespace": "montandonLandingPage",
+            "value": "Contact"
+        },
+        {
+            "action": "add",
+            "key": "contactInfo",
+            "namespace": "montandonLandingPage",
+            "value": "Senior Officer, Information Management and Risk Analysis, IFRC"
+        },
+        {
+            "action": "add",
+            "key": "contactName",
+            "namespace": "montandonLandingPage",
+            "value": "Justin Ginetti"
+        },
+        {
+            "action": "add",
+            "key": "emailLabel",
+            "namespace": "montandonLandingPage",
+            "value": "Email"
+        },
+        {
+            "action": "add",
+            "key": "exploreRadiantEarthLabel",
+            "namespace": "montandonLandingPage",
+            "value": "Explore Radiant Earth API"
+        },
+        {
+            "action": "add",
+            "key": "goWiki",
+            "namespace": "montandonLandingPage",
+            "value": "GO Wiki"
+        },
+        {
+            "action": "add",
+            "key": "leveragingDataBlogPostTitle",
+            "namespace": "montandonLandingPage",
+            "value": "Leveraging data to learn from past disasters"
+        },
+        {
+            "action": "add",
+            "key": "montandonEoapi",
+            "namespace": "montandonLandingPage",
+            "value": "Montandon EoAPI"
+        },
+        {
+            "action": "add",
+            "key": "montandonHeading",
+            "namespace": "montandonLandingPage",
+            "value": "Montandon - The Global Crisis Data Bank"
+        },
+        {
+            "action": "add",
+            "key": "montandonHeadingDescription",
+            "namespace": "montandonLandingPage",
+            "value": "Montandon is the world’s largest disaster database—a global public good with applications far beyond IFRC. Montandon integrates three key types of data: 1) forecasted and recorded natural hazards; 2) impact data on these hazards; and 3) operational response data (where available). Montandon contains more than millions of records about hazards and their impacts for hundreds of thousands of events."
+        },
+        {
+            "action": "add",
+            "key": "montandonPageTitle",
+            "namespace": "montandonLandingPage",
+            "value": "Montandon - The Global Crisis Data Bank"
+        },
+        {
+            "action": "add",
+            "key": "resources",
+            "namespace": "montandonLandingPage",
+            "value": "Resources"
+        },
+        {
+            "action": "add",
+            "key": "scaledUpSystemsBlogPostTitle",
+            "namespace": "montandonLandingPage",
+            "value": "Scaled-up ambitions require scaled-up systems"
+        },
+        {
+            "action": "add",
+            "key": "sharePopupTitle",
+            "namespace": "montandonLandingPage",
+            "value": "Share"
+        },
+        {
+            "action": "add",
+            "key": "shareUrlLabel",
+            "namespace": "montandonLandingPage",
+            "value": "Share the URL of this page:"
+        },
+        {
+            "action": "add",
+            "key": "sourceButtonTitle",
+            "namespace": "montandonLandingPage",
+            "value": "Source"
+        },
+        {
+            "action": "add",
+            "key": "sourcePopupTitle",
+            "namespace": "montandonLandingPage",
+            "value": "Source Data"
+        },
+        {
+            "action": "add",
+            "key": "stacIdLabel",
+            "namespace": "montandonLandingPage",
+            "value": "ID"
+        },
+        {
+            "action": "add",
+            "key": "stacIdValue",
+            "namespace": "montandonLandingPage",
+            "value": "stac-fastapi"
+        },
+        {
+            "action": "add",
+            "key": "stacLocationText",
+            "namespace": "montandonLandingPage",
+            "value": "The STAC metadata file is located at"
+        },
+        {
+            "action": "add",
+            "key": "stacVersionLabel",
+            "namespace": "montandonLandingPage",
+            "value": "STAC Version"
+        },
+        {
+            "action": "add",
+            "key": "stacVersionValue",
+            "namespace": "montandonLandingPage",
+            "value": "1.0.0"
+        },
+        {
+            "action": "add",
+            "key": "validLabel",
+            "namespace": "montandonLandingPage",
+            "value": "Valid"
+        },
+        {
+            "action": "add",
+            "key": "validValue",
+            "namespace": "montandonLandingPage",
+            "value": "Yes"
+        },
+        {
+            "action": "add",
+            "key": "videoTitle",
+            "namespace": "montandonLandingPage",
+            "value": "IFRC GO Platform: Mapping global crises' historical data with Montandon"
+        },
+        {
+            "action": "add",
+            "key": "visitGithub",
+            "namespace": "montandonLandingPage",
+            "value": "GitHub"
+        }
+    ]
+}


### PR DESCRIPTION

## Summary
Add a landing page for Montandon

## Changes

* add a basic landing page for Montandon with links and information
* add link to montandon landing page under Learn > Resources menu

## This PR Ensures:

* \[x] No typos or grammatical errors
* \[x] No conflict markers left in the code
* \[x] No unwanted comments, temporary files, or auto-generated files
* \[x] No inclusion of secret keys or sensitive data
* \[x] No `console.log` statements meant for debugging
* \[x] All CI checks have passed

