### PR TITLE
fix(dref): disable ops update for old imminents

### DIFF
--- a/.changeset/eight-grapes-march.md
+++ b/.changeset/eight-grapes-march.md
@@ -1,0 +1,5 @@
+---
+"go-web-app": patch
+---
+
+Fix logic to disable ops update for old imminents

--- a/app/src/views/AccountMyFormsDref/ActiveDrefTable/index.tsx
+++ b/app/src/views/AccountMyFormsDref/ActiveDrefTable/index.tsx
@@ -243,7 +243,7 @@ function ActiveDrefTable(props: Props) {
                         // NOTE: Adding this to disable updates just for the old imminents
                         && (item.type_of_dref !== DREF_TYPE_IMMINENT
                             || (item.type_of_dref === DREF_TYPE_IMMINENT
-                                && isDefined(is_dref_imminent_v2))
+                                && !!is_dref_imminent_v2)
                         );
 
                     const canCreateFinalReport = !has_final_report


### PR DESCRIPTION
## Summary

Fix logic for disabling ops update for old imminents

## Changes

* Fix logic for disabling ops update for old imminents

## This PR Ensures:

* \[x] No typos or grammatical errors
* \[x] No conflict markers left in the code
* \[x] No unwanted comments, temporary files, or auto-generated files
* \[x] No inclusion of secret keys or sensitive data
* \[x] No `console.log` statements meant for debugging
* \[x] All CI checks have passed
