### PR TITLE
Feature/add eru field in field report

### DIFF
--- a/app/src/components/domain/ActivityEventSearchSelectInput.tsx
+++ b/app/src/components/domain/ActivityEventSearchSelectInput.tsx
@@ -13,7 +13,7 @@ import {
 
 type GetEventParams = GoApiUrlQuery<'/api/v2/event/response-activity/'>;
 type GetEventResponse = GoApiResponse<'/api/v2/event/response-activity/'>;
-export type EventItem = Pick<NonNullable<GetEventResponse['results']>[number], 'id' | 'name' | 'dtype' | 'emergency_response_contact_email'>;
+export type EventItem = Pick<NonNullable<GetEventResponse['results']>[number], 'id' | 'name' | 'dtype'>;
 
 const keySelector = (d: EventItem) => d.id;
 const labelSelector = (d: EventItem) => d.name ?? '???';

--- a/app/src/components/domain/RiskImminentEvents/Gdacs/index.tsx
+++ b/app/src/components/domain/RiskImminentEvents/Gdacs/index.tsx
@@ -3,6 +3,7 @@ import { numericIdSelector } from '@ifrc-go/ui/utils';
 import {
     isDefined,
     isNotDefined,
+    isObject,
 } from '@togglecorp/fujs';
 import { type LngLatBoundsLike } from 'mapbox-gl';
 
@@ -229,7 +230,13 @@ function Gdacs(props: Props) {
                 ? footprint_geojson
                 : undefined;
 
-            const hazardDate = (footprint?.metadata as ({ todate?: string } | undefined))?.todate;
+            const hazardDate = (isDefined(footprint)
+                && 'metadata' in footprint
+                && isObject(footprint.metadata)
+                && 'todate' in footprint.metadata
+            )
+                ? String(footprint.metadata.todate)
+                : undefined;
 
             const geoJson: GeoJSON.FeatureCollection<GeoJSON.Geometry, RiskLayerProperties> = {
                 type: 'FeatureCollection' as const,

--- a/app/src/components/domain/RiskImminentEvents/MeteoSwiss/index.tsx
+++ b/app/src/components/domain/RiskImminentEvents/MeteoSwiss/index.tsx
@@ -3,6 +3,7 @@ import { numericIdSelector } from '@ifrc-go/ui/utils';
 import {
     isDefined,
     isNotDefined,
+    isObject,
 } from '@togglecorp/fujs';
 import type { LngLatBoundsLike } from 'mapbox-gl';
 
@@ -155,7 +156,11 @@ function MeteoSwiss(props: Props) {
             }
 
             // FIXME: fix typing in server (low priority)
-            const footprint_geojson = exposure?.footprint_geojson?.footprint_geojson;
+            const footprint_geojson = 'footprint_geojson' in exposure
+                && isObject(exposure.footprint_geojson)
+                && 'footprint_geojson' in exposure.footprint_geojson
+                ? exposure.footprint_geojson?.footprint_geojson
+                : undefined;
 
             if (isNotDefined(footprint_geojson)) {
                 return undefined;

--- a/app/src/components/domain/RiskImminentEvents/Pdc/index.tsx
+++ b/app/src/components/domain/RiskImminentEvents/Pdc/index.tsx
@@ -138,7 +138,8 @@ function Pdc(props: Props) {
             } = exposure;
 
             // FIXME: showing five days cou when three days cou is not available
-            const cyclone_cou = cyclone_three_days_cou?.[0] ?? cyclone_five_days_cou?.[0];
+            const cyclone_cou = (cyclone_three_days_cou as unknown[] | null)?.[0]
+                ?? (cyclone_five_days_cou as unknown[])?.[0];
 
             if (isNotDefined(footprint_geojson) && isNotDefined(storm_position_geojson)) {
                 return undefined;

--- a/app/src/views/AllDeployedPersonnel/index.tsx
+++ b/app/src/views/AllDeployedPersonnel/index.tsx
@@ -25,6 +25,7 @@ import {
 import { saveAs } from 'file-saver';
 import Papa from 'papaparse';
 
+import { type EventItem } from '#components/domain/ActivityEventSearchSelectInput';
 import CountrySelectInput from '#components/domain/CountrySelectInput';
 import EventSearchSelectInput from '#components/domain/EventSearchSelectInput';
 import ExportButton from '#components/domain/ExportButton';
@@ -135,7 +136,7 @@ export function Component() {
         (country) => country,
     );
 
-    const [positionFilter, setPositionFilter] = useUrlSearchState<string>(
+    const [positionFilter, setPositionFilter] = useUrlSearchState<string | undefined>(
         'role',
         (searchValue) => searchValue ?? '',
         (value) => value,
@@ -176,7 +177,7 @@ export function Component() {
                     summary: undefined,
                 },
                 name,
-            };
+            } satisfies EventItem;
 
             setEventOptions((prevOptions) => ([
                 ...prevOptions ?? [],
@@ -395,26 +396,22 @@ export function Component() {
                             name="role"
                             value={positionFilter}
                             onChange={setPositionFilter}
-                            placeholder={strings.defaultPlaceholder}
                         />
                         <NationalSocietySelectInput
                             label={strings.personnelTableDeployingParty}
                             name="deploying_party"
-                            placeholder={strings.defaultPlaceholder}
                             value={nationalSocietyFilter}
                             onChange={setNationalSocietyFilter}
                         />
                         <CountrySelectInput
                             label={strings.personnelTableDeployedTo}
                             name="deployed_to"
-                            placeholder={strings.defaultPlaceholder}
                             value={countryToFilter}
                             onChange={setCountryToFilter}
                         />
                         <EventSearchSelectInput
                             name="event"
                             label={strings.personnelTableEmergency}
-                            placeholder={strings.defaultPlaceholder}
                             value={eventFilter}
                             onChange={setEventFilter}
                             options={eventOptions}

--- a/app/src/views/FieldReportDetails/EventNumericDetails/i18n.json
+++ b/app/src/views/FieldReportDetails/EventNumericDetails/i18n.json
@@ -20,7 +20,7 @@
         "eventAssistedGovernmentLabel": "Assisted (Government)",
         "eventLocalStaffLabel": "Local Staff",
         "eventVolunteersLabel": "Volunteers",
-        "eventIfrcStaffLabel": "IFRC Staff",
+        "eventERULabel": "Emergency Response Units",
         "eventDelegatedLabel": "Delegates"
     }
 }

--- a/app/src/views/FieldReportDetails/EventNumericDetails/index.tsx
+++ b/app/src/views/FieldReportDetails/EventNumericDetails/index.tsx
@@ -94,8 +94,8 @@ function EventNumericDetails(props: Props) {
                 value={value?.num_volunteers}
             />
             <KeyFigure
-                label={strings.eventIfrcStaffLabel}
-                value={value?.num_ifrc_staff}
+                label={strings.eventERULabel}
+                value={value?.num_emergency_response_unit}
             />
             <KeyFigure
                 label={strings.eventDelegatedLabel}

--- a/app/src/views/FieldReportDetails/index.tsx
+++ b/app/src/views/FieldReportDetails/index.tsx
@@ -134,7 +134,7 @@ export function Component() {
     const dref = fieldReportResponse?.dref;
     const appeal = fieldReportResponse?.appeal;
     const fact = fieldReportResponse?.fact;
-    const ifrcStaff = fieldReportResponse?.ifrc_staff;
+    const emergencyResponseUnit = fieldReportResponse?.emergency_response_unit;
 
     // NOTE: Only in EW
 
@@ -193,7 +193,7 @@ export function Component() {
         {
             key: 'ifrc-staff',
             title: strings.fieldReportEmergencyResponseTitle,
-            value: reportType !== 'COVID' ? ifrcStaff : undefined,
+            value: reportType !== 'COVID' ? emergencyResponseUnit : undefined,
         },
         /*
         {

--- a/app/src/views/FieldReportForm/ResponseFields/i18n.json
+++ b/app/src/views/FieldReportForm/ResponseFields/i18n.json
@@ -29,8 +29,8 @@
         "fieldsStep4PlannedResponseRowsFactValueFieldLabel": "Number of people",
         "fieldsStep4PlannedResponseRowsForecastBasedActionEWLabel": "Forecast Based Action",
         "fieldsStep4PlannedResponseRowsForecastBasedActionValueFieldLabel": "Amount CHF",
-        "fieldsStep4PlannedResponseRowsIFRCStaffEVTEPIEWLabel": "Emergency Response Units",
-        "fieldsStep4PlannedResponseRowsIFRCStaffValueFieldLabel": "Units",
+        "fieldsStep4PlannedResponseRowsERUEVTEPIEWLabel": "Emergency Response Units",
+        "fieldsStep4PlannedResponseRowsERUValueFieldLabel": "Units",
         "fieldReportFormVisibility": "{visibilityValue} - {visibility}"
     }
 }

--- a/app/src/views/FieldReportForm/ResponseFields/index.tsx
+++ b/app/src/views/FieldReportForm/ResponseFields/index.tsx
@@ -281,34 +281,32 @@ function ResponseFields(props: Props) {
                         />
                     </InputSection>
                     <InputSection
-                        title={strings.fieldsStep4PlannedResponseRowsIFRCStaffEVTEPIEWLabel}
+                        title={strings.fieldsStep4PlannedResponseRowsERUEVTEPIEWLabel}
                         numPreferredColumns={2}
                         // eslint-disable-next-line max-len
-                        withAsteriskOnTitle={isDefined(value.num_ifrc_staff) || isDefined(value.ifrc_staff)}
+                        withAsteriskOnTitle={isDefined(value.num_emergency_response_unit) || isDefined(value.emergency_response_unit)}
                     >
                         <RadioInput
-                            error={error?.ifrc_staff}
-                            name="ifrc_staff"
+                            error={error?.emergency_response_unit}
+                            name="emergency_response_unit"
                             onChange={onValueChange}
                             options={requestOptions}
                             // FIXME: do not use inline functions
                             keySelector={(item) => item.key}
                             labelSelector={(item) => item.value}
-                            value={value.ifrc_staff}
+                            value={value.emergency_response_unit}
                             clearable
                             disabled={disabled}
-                        // eslint-disable-next-line max-len
-                        // withAsterisk={isDefined(value.num_ifrc_staff) || isDefined(value.ifrc_staff)}
                         />
                         <NumberInput
-                            label={strings.fieldsStep4PlannedResponseRowsIFRCStaffValueFieldLabel}
-                            name="num_ifrc_staff"
-                            value={value.num_ifrc_staff}
+                            label={strings.fieldsStep4PlannedResponseRowsERUValueFieldLabel}
+                            name="num_emergency_response_unit"
+                            value={value.num_emergency_response_unit}
                             onChange={onValueChange}
-                            error={error?.num_ifrc_staff}
+                            error={error?.num_emergency_response_unit}
                             disabled={disabled}
                             // eslint-disable-next-line max-len
-                            withAsterisk={isDefined(value.num_ifrc_staff) || isDefined(value.ifrc_staff)}
+                            withAsterisk={isDefined(value.num_emergency_response_unit) || isDefined(value.emergency_response_unit)}
                         />
                     </InputSection>
                     {reportType === 'EW' && (

--- a/app/src/views/FieldReportForm/common.ts
+++ b/app/src/views/FieldReportForm/common.ts
@@ -226,8 +226,8 @@ const fieldsInResponse = [
     'appeal_amount',
     'fact',
     'num_fact',
-    'ifrc_staff',
-    'num_ifrc_staff',
+    'emergency_response_unit',
+    'num_emergency_response_unit',
     'forecast_based_action',
     'forecast_based_action_amount',
 ] satisfies (keyof PartialFormValue)[];
@@ -696,25 +696,28 @@ export const reportSchema: FormSchema = {
         baseSchema = addCondition(
             baseSchema,
             value,
-            ['ifrc_staff', 'num_ifrc_staff', 'status', 'is_covid_report', 'dtype'],
-            ['ifrc_staff', 'num_ifrc_staff'],
-            (val): Pick<FormSchemaFields, 'ifrc_staff' | 'num_ifrc_staff'> => {
+            ['emergency_response_unit', 'num_emergency_response_unit', 'status', 'is_covid_report', 'dtype'],
+            ['emergency_response_unit', 'num_emergency_response_unit'],
+            (val): Pick<FormSchemaFields, 'emergency_response_unit' | 'num_emergency_response_unit'> => {
                 const reportType = getReportType(val?.status, val?.is_covid_report, val?.dtype);
                 if (reportType === 'COVID') {
                     return {
-                        ifrc_staff: { forceValue: nullValue },
-                        num_ifrc_staff: { forceValue: nullValue },
+                        emergency_response_unit: { forceValue: nullValue },
+                        num_emergency_response_unit: { forceValue: nullValue },
                     };
                 }
-                if (isDefined(val?.ifrc_staff) || isDefined(val?.num_ifrc_staff)) {
+                if (
+                    isDefined(val?.emergency_response_unit)
+                    || isDefined(val?.num_emergency_response_unit)
+                ) {
                     return {
-                        ifrc_staff: { required: true },
-                        num_ifrc_staff: { required: true },
+                        emergency_response_unit: { required: true },
+                        num_emergency_response_unit: { required: true },
                     };
                 }
                 return {
-                    ifrc_staff: {},
-                    num_ifrc_staff: {},
+                    emergency_response_unit: {},
+                    num_emergency_response_unit: {},
                 };
             },
         );

--- a/app/src/views/ThreeWActivityForm/index.tsx
+++ b/app/src/views/ThreeWActivityForm/index.tsx
@@ -173,6 +173,14 @@ export function Component() {
         DistrictItem[] | undefined | null
     >([]);
 
+    const { response: selectedEventDetail } = useRequest({
+        skip: isNotDefined(value.event),
+        url: '/api/v2/event/{id}/',
+        pathVariables: isDefined(value.event) ? {
+            id: value.event,
+        } : undefined,
+    });
+
     const {
         pending: fetchingActivity,
         response: activityResponse,
@@ -541,13 +549,6 @@ export function Component() {
         activityId,
         updateActivity,
         createActivity,
-    ]);
-
-    const selectedEventDetail = useMemo(() => (
-        eventOptions?.find((event) => event.id === value?.event)
-    ), [
-        eventOptions,
-        value?.event,
     ]);
 
     const countries = useCountry();

--- a/translationMigrations/000049-1758005186095.json
+++ b/translationMigrations/000049-1758005186095.json
@@ -1,0 +1,28 @@
+{
+    "parent": "000048-1758003668158.json",
+    "actions": [
+        {
+            "action": "add",
+            "key": "eventERULabel",
+            "namespace": "fieldReportDetails",
+            "value": "Emergency Response Units"
+        },
+        {
+            "action": "remove",
+            "key": "eventIfrcStaffLabel",
+            "namespace": "fieldReportDetails"
+        },
+        {
+            "action": "update",
+            "key": "fieldsStep4PlannedResponseRowsIFRCStaffEVTEPIEWLabel",
+            "newKey": "fieldsStep4PlannedResponseRowsERUEVTEPIEWLabel",
+            "namespace": "fieldReportForm"
+        },
+        {
+            "action": "update",
+            "key": "fieldsStep4PlannedResponseRowsIFRCStaffValueFieldLabel",
+            "newKey": "fieldsStep4PlannedResponseRowsERUValueFieldLabel",
+            "namespace": "fieldReportForm"
+        }
+    ]
+}


### PR DESCRIPTION
## Summary

Add 2 new fields(emergency_response_unit, num_emergency_response_unit) in field report response tab, also add the number in detail view. 

## Addresses

* Issue(s):
- https://github.com/IFRCGo/go-web-app/issues/1945

## Depends On

- https://github.com/IFRCGo/go-api/pull/2537

## Changes

* Add 2 new fields in field report response tab
* Update feild report detail page


## This PR Ensures:

* \[x] No typos or grammatical errors
* \[x] No conflict markers left in the code
* \[x] No unwanted comments, temporary files, or auto-generated files
* \[x] No inclusion of secret keys or sensitive data
* \[x] No `console.log` statements meant for debugging
* \[x] All CI checks have passed

## Additional Notes
Even though in the form we had ERU number, it was being saved in another field called ifrc_staff. Due to confusions on whether the name was replaced or ifrc_staff is required or now, we just added a new field and let ifrc_staff be as is. @frozenhelium ,  this was discussed with @udaynwa , but let me know if this is not supposed to be the case.