### PR TITLE
Hotfix: Local unit for extra error in form

### DIFF
--- a/.changeset/deep-frogs-give.md
+++ b/.changeset/deep-frogs-give.md
@@ -1,0 +1,5 @@
+---
+"go-web-app": patch
+---
+
+Remove extra error in local unit form if is it externally managed

--- a/app/src/views/CountryNsOverviewContextAndStructure/NationalSocietyLocalUnits/LocalUnitsFormModal/LocalUnitsForm/index.tsx
+++ b/app/src/views/CountryNsOverviewContextAndStructure/NationalSocietyLocalUnits/LocalUnitsFormModal/LocalUnitsForm/index.tsx
@@ -466,6 +466,9 @@ function LocalUnitsForm(props: Props) {
         && !(localUnitDetailsResponse?.status === VALIDATED);
 
     const permissionError = useMemo(() => {
+        if (isExternallyManaged && isDefined(localUnitDetailsResponse?.bulk_upload)) {
+            return strings.noPermissionFormUpdateExternallyManaged;
+        }
         if (isExternallyManaged && !hasAddEditLocalUnitPermission) {
             if (isDefined(localUnitId)) {
                 return strings.noBothPermissionEditFormError;
@@ -483,14 +486,16 @@ function LocalUnitsForm(props: Props) {
         }
         return undefined;
     }, [
+        localUnitId,
         isExternallyManaged,
         hasAddEditLocalUnitPermission,
+        localUnitDetailsResponse?.bulk_upload,
+        strings.noPermissionFormUpdateExternallyManaged,
         strings.noLocalUnitAddPermission,
         strings.noLocalUnitEditPermission,
         strings.noPermissionFormExternallyManaged,
         strings.noBothPermissionAddFormError,
         strings.noBothPermissionEditFormError,
-        localUnitId,
     ]);
 
     const submitButton = readOnly ? null : (
@@ -690,11 +695,6 @@ function LocalUnitsForm(props: Props) {
                 <NonFieldError
                     error={error?.health}
                 />
-                {isDefined(localUnitDetailsResponse?.bulk_upload) && (
-                    <NonFieldError
-                        error={strings.noPermissionFormUpdateExternallyManaged}
-                    />
-                )}
                 <FormGrid>
                     <FormColumnContainer>
                         <DiffWrapper


### PR DESCRIPTION
## Summary

Removed extra error in local unit form while it is externally managed

## Addresses

* Issue(s): #1962 

## Changes

* Add extra error in permission error function

## This PR Ensures:

* [x] No typos or grammatical errors
* [x] No conflict markers left in the code
* [x] No unwanted comments, temporary files, or auto-generated files
* [x] No inclusion of secret keys or sensitive data
* [x] No `console.log` statements meant for debugging
* [x] All CI checks have passed
