### PR TITLE
chore(vite-config): add allowed host on vite config

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -68,6 +68,7 @@ export default defineConfig(({ mode }) => {
         envPrefix: 'APP_',
         server: {
             port: 3000,
+            allowedHosts: ["host.docker.internal"],
             strictPort: true,
         },
         build: {


### PR DESCRIPTION
## Summary
- Issue: The  dev server was blocking requests from `host.docker.internal` during Playwright exports when running the  go-web-app instance on port 3001, used by the Playwright container to connect to the backend (https://github.com/IFRCGo/go-api/blob/develop/docs/playwright-exports.md)

- References:
      vitejs/vite#19273, 
      vitejs/vite#19325 (can use __VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS after upgrading to 6.2.0).

## Changes
-  Add `host.docker.internal` to `server.allowedHosts` in vite.config.js to allow the connection.

## This PR Ensures:

* \[ ] No typos or grammatical errors
* \[ ] No conflict markers left in the code
* \[ ] No unwanted comments, temporary files, or auto-generated files
* \[ ] No inclusion of secret keys or sensitive data
* \[ ] No `console.log` statements meant for debugging
* \[ ] All CI checks have passed

## Additional Notes

*Optional: Add any other relevant context, screenshots, or details here.*
