### PR TITLE
tag: go-web-app@7.24.0-beta-0: Update Finalize Permission in Dref Table Action.

### DIFF
--- a/app/src/views/AccountMyFormsDref/ActiveDrefTable/i18n.json
+++ b/app/src/views/AccountMyFormsDref/ActiveDrefTable/i18n.json
@@ -10,9 +10,9 @@
         "activeDrefTableCountryHeading": "Country",
         "activeDrefTableStatusHeading": "Status",
         "activeDrefTableStatusDraftDescription": "The form is in its initial stage and has not been finalized yet.",
-        "activeDrefTableStatusFinalizingDescription": "The form is being finalizing. The original language content is being translated into English.",
+        "activeDrefTableStatusFinalizingDescription": "The form is being finalizing. The fields are being translated into English.",
         "activeDrefTableStatusFinalizedDescription": "The form has been finalized, and the original language has been switched to English. All further edits must now be made in English.",
-        "activeDrefTableStatusApprovedDescription": "Approved: The form has been reviewed and approved.",
+        "activeDrefTableStatusApprovedDescription": "The form has been reviewed and approved.",
         "activeDrefTableStatusFailedDescription": "The form finalization process has failed. You can retry to finalize the form again"
     }
 }

--- a/app/src/views/AccountMyFormsDref/DrefTableActions/index.tsx
+++ b/app/src/views/AccountMyFormsDref/DrefTableActions/index.tsx
@@ -564,8 +564,8 @@ function DrefTableActions(props: Props) {
 
     const canApprove = status === DREF_STATUS_FINALIZED && hasPermissionToApprove;
 
-    const canFinalize = status === (DREF_STATUS_DRAFT
-        || DREF_STATUS_FAILED)
+    const canFinalize = (status === DREF_STATUS_DRAFT
+        || status === DREF_STATUS_FAILED)
         && hasPermissionToApprove;
 
     const shouldConfirmImminentAddOpsUpdate = drefType === DREF_TYPE_IMMINENT && isDrefImminentV2;

--- a/app/src/views/DrefApplicationForm/index.tsx
+++ b/app/src/views/DrefApplicationForm/index.tsx
@@ -583,11 +583,19 @@ export function Component() {
                 updateDref({
                     ...result.value,
                     modified_at: modifiedAt ?? lastModifiedAtRef.current,
+                    cover_image_file: isNotDefined(result.value.cover_image_file?.id)
+                        ? null : result.value.cover_image_file,
+                    event_map_file: isNotDefined(result.value.event_map_file?.id)
+                        ? null : result.value.cover_image_file,
                 } as DrefRequestBody);
             } else {
                 createDref({
                     ...result.value,
                     modified_at: modifiedAt ?? lastModifiedAtRef.current,
+                    cover_image_file: isNotDefined(result.value.cover_image_file?.id)
+                        ? null : result.value.cover_image_file,
+                    event_map_file: isNotDefined(result.value.event_map_file?.id)
+                        ? null : result.value.cover_image_file,
                 } as DrefRequestPostBody);
             }
         },

--- a/app/src/views/DrefFinalReportForm/index.tsx
+++ b/app/src/views/DrefFinalReportForm/index.tsx
@@ -385,6 +385,10 @@ export function Component() {
             updateFinalReport({
                 ...result.value,
                 modified_at: modifiedAt ?? lastModifiedAtRef.current,
+                cover_image_file: isNotDefined(result.value.cover_image_file?.id)
+                    ? null : result.value.cover_image_file,
+                event_map_file: isNotDefined(result.value.event_map_file?.id)
+                    ? null : result.value.cover_image_file,
             } as FinalReportRequestBody);
         },
         [validate, setError, updateFinalReport],

--- a/app/src/views/DrefOperationalUpdateForm/index.tsx
+++ b/app/src/views/DrefOperationalUpdateForm/index.tsx
@@ -434,6 +434,10 @@ export function Component() {
             updateOpsUpdate({
                 ...result.value,
                 modified_at: modifiedAt ?? lastModifiedAtRef.current,
+                cover_image_file: isNotDefined(result.value.cover_image_file?.id)
+                    ? null : result.value.cover_image_file,
+                event_map_file: isNotDefined(result.value.event_map_file?.id)
+                    ? null : result.value.cover_image_file,
             } as OpsUpdateRequestBody);
         },
         [validate, setError, updateOpsUpdate],

--- a/translationMigrations/000055-1762770478382.json
+++ b/translationMigrations/000055-1762770478382.json
@@ -1,0 +1,17 @@
+{
+    "parent": "000054-1762426529619.json",
+    "actions": [
+        {
+            "action": "update",
+            "key": "activeDrefTableStatusApprovedDescription",
+            "namespace": "accountMyFormsDref",
+            "newValue": "The form has been reviewed and approved."
+        },
+        {
+            "action": "update",
+            "key": "activeDrefTableStatusFinalizingDescription",
+            "namespace": "accountMyFormsDref",
+            "newValue": "The form is being finalizing. The fields are being translated into English."
+        }
+    ]
+}


### PR DESCRIPTION
## Summary

Hotfix for the dref translation.

## Addresses

* Issue(s): 
- DREF FIle Dangling
- FAILED Dref status

## Changes

* update permission for finalizing dref forms
* update descriptions for status info in dref active table
* check id for event_map_file and cover_image_file before update and create every dref

## This PR Ensures:

* \[x] No typos or grammatical errors
* \[x] No conflict markers left in the code
* \[x] No unwanted comments, temporary files, or auto-generated files
* \[x] No inclusion of secret keys or sensitive data
* \[x] No `console.log` statements meant for debugging
* \[x] All CI checks have passed