### PR TITLE
chore(ci): remove test environment from chromatic CI

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -36,7 +36,6 @@ jobs:
             packages/go-ui-storybook/**
   ui:
     name: Build UI Library
-    environment: 'test'
     runs-on: ubuntu-latest
     needs: [changed-files]
     if: ${{ needs.changed-files.outputs.any_changed == 'true' }}


### PR DESCRIPTION
## Summary

Remove test environment from chromatic CI

## Changes

* Remove test environment from chromatic CI

## This PR Ensures:

* \[x] No typos or grammatical errors
* \[x] No conflict markers left in the code
* \[x] No unwanted comments, temporary files, or auto-generated files
* \[x] No inclusion of secret keys or sensitive data
* \[x] No `console.log` statements meant for debugging
* \[ ] All CI checks have passed