### PR TITLE
fix(montandon-landing-page): disable links to montandon api

### DIFF
--- a/.changeset/fluffy-papers-refuse.md
+++ b/.changeset/fluffy-papers-refuse.md
@@ -1,0 +1,5 @@
+---
+"go-web-app": patch
+---
+
+Remove obsolete links in Montandon landing page

--- a/app/src/views/MontandonLandingPage/i18n.json
+++ b/app/src/views/MontandonLandingPage/i18n.json
@@ -5,19 +5,6 @@
         "montandonHeading": "Montandon - The Global Crisis Data Bank",
         "montandonHeadingDescription": "Montandon is the world’s largest disaster database—a global public good with applications far beyond IFRC. Montandon integrates three key types of data: 1) forecasted and recorded natural hazards; 2) impact data on these hazards; and 3) operational response data (where available). Montandon contains more than 2 million of records about hazards and their impacts for hundreds of thousands of events.",
 
-        "sourcePopupTitle": "Source Data",
-        "stacIdLabel": "ID",
-        "stacIdValue": "stac-fastapi",
-        "stacVersionLabel": "STAC Version",
-        "stacVersionValue": "1.0.0",
-        "validLabel": "Valid",
-        "validValue": "Yes",
-        "stacLocationText": "The STAC metadata file is located at",
-
-        "sharePopupTitle": "Share",
-        "emailLabel": "Email",
-        "shareUrlLabel": "Share the URL of this page:",
-
         "videoTitle": "IFRC GO Platform: Mapping global crises' historical data with Montandon",
 
         "resources": "Resources",

--- a/app/src/views/MontandonLandingPage/index.tsx
+++ b/app/src/views/MontandonLandingPage/index.tsx
@@ -1,15 +1,7 @@
 import {
-    DrefTwoIcon,
-    MailIcon,
-    ShareLineIcon,
-} from '@ifrc-go/icons';
-import {
     Container,
     Description,
-    DropdownMenu,
-    Label,
     ListView,
-    TextOutput,
 } from '@ifrc-go/ui';
 import { useTranslation } from '@ifrc-go/ui/hooks';
 
@@ -18,12 +10,6 @@ import Page from '#components/Page';
 
 import i18n from './i18n.json';
 import styles from './styles.module.css';
-
-// TODO: Does this need translation?
-const emailSubject = encodeURIComponent('Explore Montandon Data');
-const linkToMontandon = 'https://radiantearth.github.io/stac-browser/#/external/montandon-eoapi-stage.ifrc.org/stac/';
-const emailBody = encodeURIComponent(`Sharing with you a link to Montandon API: ${linkToMontandon}`);
-const mailtoLink = `mailto:?subject=${emailSubject}&body=${emailBody}`;
 
 /** @knipignore */
 // eslint-disable-next-line import/prefer-default-export
@@ -36,98 +22,6 @@ export function Component() {
             heading={strings.montandonHeading}
             description={strings.montandonHeadingDescription}
             mainSectionClassName={styles.content}
-            actions={(
-                <>
-                    <DropdownMenu
-                        label={strings.sourcePopupTitle}
-                        labelBefore={<DrefTwoIcon />}
-                        labelColorVariant="primary"
-                        preferredPopupWidth={30}
-                        persistent
-                    >
-                        <Container
-                            heading={strings.sourcePopupTitle}
-                            withHeaderBorder
-                            headingLevel={5}
-                            withPadding
-                        >
-                            <ListView
-                                layout="block"
-                                withSpacingOpticalCorrection
-                                spacing="sm"
-                            >
-                                <TextOutput
-                                    strongLabel
-                                    label={strings.stacIdLabel}
-                                    value={strings.stacIdValue}
-                                />
-                                <TextOutput
-                                    strongLabel
-                                    label={strings.stacVersionLabel}
-                                    value={strings.stacVersionValue}
-                                />
-                                <TextOutput
-                                    strongLabel
-                                    label={strings.validLabel}
-                                    value={strings.validValue}
-                                />
-                                <div className={styles.separator} />
-                                <Label>
-                                    {strings.stacLocationText}
-                                </Label>
-                                <Link
-                                    external
-                                    href="https://montandon-eoapi-stage.ifrc.org/stac/"
-                                    withLinkIcon
-                                    withFullWidth
-                                    styleVariant="translucent"
-                                >
-                                    https://montandon-eoapi-stage.ifrc.org/stac/
-                                </Link>
-                            </ListView>
-                        </Container>
-                    </DropdownMenu>
-                    <DropdownMenu
-                        label={strings.sharePopupTitle}
-                        labelBefore={<ShareLineIcon className={styles.icon} />}
-                        labelColorVariant="primary"
-                        preferredPopupWidth={30}
-                        persistent
-                    >
-                        <Container
-                            heading={strings.sharePopupTitle}
-                            withHeaderBorder
-                            withFooterBorder
-                            withPadding
-                            headingLevel={5}
-                            footerActions={(
-                                <Link
-                                    href={mailtoLink}
-                                    before={<MailIcon className={styles.icon} />}
-                                    colorVariant="primary"
-                                    styleVariant="outline"
-                                    external
-                                    spacing="sm"
-                                >
-                                    {strings.emailLabel}
-                                </Link>
-                            )}
-                        >
-                            <Label>
-                                {strings.shareUrlLabel}
-                            </Label>
-                            <Link
-                                href="https://radiantearth.github.io/stac-browser/#/external/montandon-eoapi-stage.ifrc.org/stac/"
-                                external
-                                withEllipsizedContent
-                                withLinkIcon
-                            >
-                                https://radiantearth.github.io/stac-browser/#/external/montandon-eoapi-stage.ifrc.org/stac/
-                            </Link>
-                        </Container>
-                    </DropdownMenu>
-                </>
-            )}
             info={(
                 <iframe
                     className={styles.iframe}
@@ -150,6 +44,10 @@ export function Component() {
                             styleVariant="outline"
                             external
                             withLinkIcon
+                            // NOTE: This is temporary till this Montandon link
+                            // is up and running
+                            style={{ pointerEvents: 'none' }}
+                            disabled
                         >
                             {strings.accessAPILabel}
                         </Link>
@@ -159,6 +57,10 @@ export function Component() {
                             styleVariant="outline"
                             external
                             withLinkIcon
+                            // NOTE: This is temporary till this Montandon link
+                            // is up and running
+                            style={{ pointerEvents: 'none' }}
+                            disabled
                         >
                             {strings.exploreRadiantEarthLabel}
                         </Link>

--- a/translationMigrations/000067-1769409822797.json
+++ b/translationMigrations/000067-1769409822797.json
@@ -1,0 +1,60 @@
+{
+    "parent": "000066-1768996132048.json",
+    "actions": [
+        {
+            "action": "remove",
+            "key": "emailLabel",
+            "namespace": "montandonLandingPage"
+        },
+        {
+            "action": "remove",
+            "key": "sharePopupTitle",
+            "namespace": "montandonLandingPage"
+        },
+        {
+            "action": "remove",
+            "key": "shareUrlLabel",
+            "namespace": "montandonLandingPage"
+        },
+        {
+            "action": "remove",
+            "key": "sourcePopupTitle",
+            "namespace": "montandonLandingPage"
+        },
+        {
+            "action": "remove",
+            "key": "stacIdLabel",
+            "namespace": "montandonLandingPage"
+        },
+        {
+            "action": "remove",
+            "key": "stacIdValue",
+            "namespace": "montandonLandingPage"
+        },
+        {
+            "action": "remove",
+            "key": "stacLocationText",
+            "namespace": "montandonLandingPage"
+        },
+        {
+            "action": "remove",
+            "key": "stacVersionLabel",
+            "namespace": "montandonLandingPage"
+        },
+        {
+            "action": "remove",
+            "key": "stacVersionValue",
+            "namespace": "montandonLandingPage"
+        },
+        {
+            "action": "remove",
+            "key": "validLabel",
+            "namespace": "montandonLandingPage"
+        },
+        {
+            "action": "remove",
+            "key": "validValue",
+            "namespace": "montandonLandingPage"
+        }
+    ]
+}


### PR DESCRIPTION
## Summary
Disable links to Montandon API as the api is not working at the moment.

## Addresses
https://github.com/IFRCGo/go-web-app/issues/2214

## Changes

* Disable links to Montandon API

## This PR Ensures:

* \[x] No typos or grammatical errors
* \[x] No conflict markers left in the code
* \[x] No unwanted comments, temporary files, or auto-generated files
* \[x] No inclusion of secret keys or sensitive data
* \[x] No `console.log` statements meant for debugging
* \[x] All CI checks have passed

