### PR TITLE
Use current year in Surge overview Top 5 deployments

### DIFF
--- a/.changeset/clever-beers-crash.md
+++ b/.changeset/clever-beers-crash.md
@@ -1,0 +1,5 @@
+---
+"go-web-app": patch
+---
+
+Use current year in Surge overview Top 5 deployments

--- a/app/src/views/SurgeOverview/RapidResponsePersonnel/index.tsx
+++ b/app/src/views/SurgeOverview/RapidResponsePersonnel/index.tsx
@@ -28,7 +28,7 @@ type GetDeploymentsByNationalSocietyResponse = GoApiResponse<'/api/v2/deployment
 type DeploymentsByNationalSociety = GetDeploymentsByNationalSocietyResponse[number];
 
 const timeSeriesDataKeys = ['deployments'];
-
+const currentYear = new Date().getFullYear();
 const oneYearAgo = new Date();
 oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
 oneYearAgo.setDate(1);
@@ -102,7 +102,10 @@ export function Component() {
                 minGridColumnSize="20rem"
             >
                 <Container
-                    heading={resolveToString(strings.topFiveNationalSociety, { year: '2025' })}
+                    heading={resolveToString(
+                        strings.topFiveNationalSociety,
+                        { year: String(currentYear) },
+                    )}
                     withHeaderBorder
                     pending={pending}
                     withPadding


### PR DESCRIPTION
Refers to Daniel's notice about outdated year info on go.ifrc.org/surge/overview/rapid-response-personnel