### PR TITLE
fix(montandon-landing-page): add getting started section

### DIFF
--- a/.changeset/fast-carrots-hug.md
+++ b/.changeset/fast-carrots-hug.md
@@ -1,0 +1,7 @@
+---
+"go-web-app": patch
+---
+
+Update Montandon landing page
+- Add 'Getting started' section
+- Enable external links

--- a/app/src/views/MontandonLandingPage/i18n.json
+++ b/app/src/views/MontandonLandingPage/i18n.json
@@ -3,15 +3,24 @@
     "strings": {
         "montandonPageTitle": "Montandon - The Global Crisis Data Bank",
         "montandonHeading": "Montandon - The Global Crisis Data Bank",
-        "montandonHeadingDescription": "Montandon is the world’s largest disaster database—a global public good with applications far beyond IFRC. Montandon integrates three key types of data: 1) forecasted and recorded natural hazards; 2) impact data on these hazards; and 3) operational response data (where available). Montandon contains more than 2 million of records about hazards and their impacts for hundreds of thousands of events.",
+        "montandonHeadingDescription": "Montandon is the world’s largest disaster database — a global public good with applications far beyond IFRC. Montandon integrates three key types of data: 1) forecasted and recorded natural hazards; 2) impact data on these hazards; and 3) operational response data (where available). Montandon contains more than 2 million of records about hazards and their impacts for hundreds of thousands of events.",
+
+        "sourcePopupTitle": "Source Data",
+        "stacIdLabel": "ID",
+        "stacIdValue": "stac-fastapi",
+        "stacVersionLabel": "STAC Version",
+        "stacVersionValue": "1.0.0",
+        "validLabel": "Valid",
+        "validValue": "Yes",
+        "stacLocationText": "The STAC metadata file is located at",
+
+        "sharePopupTitle": "Share",
+        "emailLabel": "Email",
+        "shareUrlLabel": "Share the URL of this page:",
 
         "videoTitle": "IFRC GO Platform: Mapping global crises' historical data with Montandon",
 
-        "resources": "Resources",
-        "visitGithub": "GitHub",
-        "goWiki": "GO Wiki",
-        "apiDescription": "OpenAPI service description",
-        "apiDocumentation": "OpenAPI service documentation",
+        "gettingStartedGuide": "Getting Started Guide",
 
         "blogPosts": "Blog Posts",
         "leveragingDataBlogPostTitle": "Leveraging data to learn from past disasters",
@@ -21,6 +30,18 @@
         "contactText": "Please get in contact with the team in case interested to collaborate or learn more",
 
         "accessAPILabel": "Access the Montandon API",
-        "exploreRadiantEarthLabel": "Explore data in STAC browser"
+        "exploreRadiantEarthLabel": "Explore data in STAC browser",
+
+        "guideGetYourToken": "1. Get your token.",
+        "guideVisitAccountPage": "Visit the {goAccountPageLink} (you must be logged in).",
+        "goAccountPageLinkButtonTitle": "GO Account Page",
+        "guideGenerateNewToken": "Generate a new token in the Montandon section.",
+        "guideSaveToken": "Copy and save the generated token, as you will not be able to view it again.",
+        "guideExploreData": "2. Explore data and use cases",
+        "guideMontandonNotebooks": "Access data and explore the API through {montandonNotebookLink}",
+        "montandonNotebooksLinkButtonTitle": "Montandon Notebooks",
+        "guideStacBrowser": "Browse data sources using the {montandonStacBrowserLink}",
+        "montandonStacBrowserLinkButtonTitle": "Montandon STAC browser"
+
     }
 }

--- a/app/src/views/MontandonLandingPage/index.tsx
+++ b/app/src/views/MontandonLandingPage/index.tsx
@@ -1,15 +1,32 @@
 import {
+    DrefTwoIcon,
+    MailIcon,
+    ShareLineIcon,
+} from '@ifrc-go/icons';
+import {
     Container,
     Description,
+    DropdownMenu,
+    Heading,
+    InlineFrame,
+    Label,
     ListView,
+    TextOutput,
 } from '@ifrc-go/ui';
 import { useTranslation } from '@ifrc-go/ui/hooks';
+import { resolveToComponent } from '@ifrc-go/ui/utils';
 
 import Link from '#components/Link';
 import Page from '#components/Page';
 
 import i18n from './i18n.json';
-import styles from './styles.module.css';
+
+// NOTE: These are links and email bodies and don't need to be translated
+const emailSubject = encodeURIComponent('Explore Montandon Data');
+const linkToMontandonStacBrowser = 'https://radiantearth.github.io/stac-browser/#/external/montandon-eoapi-stage.ifrc.org/stac/';
+const emailBody = encodeURIComponent(`Sharing with you a link to Montandon API: ${linkToMontandonStacBrowser}`);
+const mailtoLink = `mailto:?subject=${emailSubject}&body=${emailBody}`;
+const linkToMontandonNotebooks = 'https://ifrcgo.org/montandon-notebooks/';
 
 /** @knipignore */
 // eslint-disable-next-line import/prefer-default-export
@@ -21,13 +38,101 @@ export function Component() {
             title={strings.montandonPageTitle}
             heading={strings.montandonHeading}
             description={strings.montandonHeadingDescription}
-            mainSectionClassName={styles.content}
+            actions={(
+                <>
+                    <DropdownMenu
+                        label={strings.sourcePopupTitle}
+                        labelBefore={<DrefTwoIcon />}
+                        labelColorVariant="primary"
+                        preferredPopupWidth={30}
+                        persistent
+                    >
+                        <Container
+                            heading={strings.sourcePopupTitle}
+                            withHeaderBorder
+                            headingLevel={5}
+                            withPadding
+                        >
+                            <ListView
+                                layout="block"
+                                withSpacingOpticalCorrection
+                                spacing="sm"
+                            >
+                                <TextOutput
+                                    strongLabel
+                                    label={strings.stacIdLabel}
+                                    value={strings.stacIdValue}
+                                />
+                                <TextOutput
+                                    strongLabel
+                                    label={strings.stacVersionLabel}
+                                    value={strings.stacVersionValue}
+                                />
+                                <TextOutput
+                                    strongLabel
+                                    label={strings.validLabel}
+                                    value={strings.validValue}
+                                />
+                                <Label>
+                                    {strings.stacLocationText}
+                                </Label>
+                                <Link
+                                    external
+                                    href="https://montandon-eoapi-stage.ifrc.org/stac/"
+                                    withLinkIcon
+                                    withFullWidth
+                                    styleVariant="translucent"
+                                >
+                                    https://montandon-eoapi-stage.ifrc.org/stac/
+                                </Link>
+                            </ListView>
+                        </Container>
+                    </DropdownMenu>
+                    <DropdownMenu
+                        label={strings.sharePopupTitle}
+                        labelBefore={<ShareLineIcon />}
+                        labelColorVariant="primary"
+                        preferredPopupWidth={30}
+                        persistent
+                    >
+                        <Container
+                            heading={strings.sharePopupTitle}
+                            withHeaderBorder
+                            withFooterBorder
+                            withPadding
+                            headingLevel={5}
+                            footerActions={(
+                                <Link
+                                    href={mailtoLink}
+                                    before={<MailIcon />}
+                                    colorVariant="primary"
+                                    styleVariant="outline"
+                                    external
+                                    spacing="sm"
+                                >
+                                    {strings.emailLabel}
+                                </Link>
+                            )}
+                        >
+                            <Label>
+                                {strings.shareUrlLabel}
+                            </Label>
+                            <Link
+                                href="https://radiantearth.github.io/stac-browser/#/external/montandon-eoapi-stage.ifrc.org/stac/"
+                                external
+                                withEllipsizedContent
+                                withLinkIcon
+                            >
+                                https://radiantearth.github.io/stac-browser/#/external/montandon-eoapi-stage.ifrc.org/stac/
+                            </Link>
+                        </Container>
+                    </DropdownMenu>
+                </>
+            )}
             info={(
-                <iframe
-                    className={styles.iframe}
+                <InlineFrame
                     src="https://www.youtube.com/embed/BEWxqYfrQek"
                     title={strings.videoTitle}
-                    allow=""
                     allowFullScreen
                 />
             )}
@@ -44,23 +149,15 @@ export function Component() {
                             styleVariant="outline"
                             external
                             withLinkIcon
-                            // NOTE: This is temporary till this Montandon link
-                            // is up and running
-                            style={{ pointerEvents: 'none' }}
-                            disabled
                         >
                             {strings.accessAPILabel}
                         </Link>
                         <Link
-                            href="https://radiantearth.github.io/stac-browser/#/external/montandon-eoapi-stage.ifrc.org/stac/"
+                            href={linkToMontandonStacBrowser}
                             colorVariant="primary"
                             styleVariant="outline"
                             external
                             withLinkIcon
-                            // NOTE: This is temporary till this Montandon link
-                            // is up and running
-                            style={{ pointerEvents: 'none' }}
-                            disabled
                         >
                             {strings.exploreRadiantEarthLabel}
                         </Link>
@@ -68,14 +165,9 @@ export function Component() {
                 )}
                 spacing="xl"
             >
-                <ListView
-                    layout="grid"
-                    numPreferredGridColumns={3}
-                    minGridColumnSize="20rem"
-                >
+                <ListView layout="block">
                     <Container
-                        className={styles.guideCard}
-                        heading={strings.resources}
+                        heading={strings.gettingStartedGuide}
                         withHeaderBorder
                         withPadding
                         withBackground
@@ -85,88 +177,130 @@ export function Component() {
                             layout="block"
                             withSpacingOpticalCorrection
                         >
-                            <Link
-                                href="https://github.com/IFRCGo/monty-stac-extension/blob/main/README.md"
-                                external
-                                withLinkIcon
-                            >
-                                {strings.visitGithub}
-                            </Link>
-                            <Link
-                                href="https://go-wiki.ifrc.org/en/home"
-                                external
-                                withLinkIcon
-                            >
-                                {strings.goWiki}
-                            </Link>
-                            <Link
-                                href="https://montandon-eoapi-stage.ifrc.org/stac/api"
-                                external
-                                withLinkIcon
-                            >
-                                {strings.apiDescription}
-                            </Link>
-                            <Link
-                                href="https://montandon-eoapi-stage.ifrc.org/stac/api.html"
-                                external
-                                withLinkIcon
-                            >
-                                {strings.apiDocumentation}
-                            </Link>
+                            <Heading level={5}>
+                                {strings.guideGetYourToken}
+                            </Heading>
+                            <ol type="a">
+                                <li>
+                                    {resolveToComponent(
+                                        strings.guideVisitAccountPage,
+                                        {
+                                            goAccountPageLink: (
+                                                <Link
+                                                    to="accountDetails"
+                                                    withUnderline
+                                                >
+                                                    {strings.goAccountPageLinkButtonTitle}
+                                                </Link>
+                                            ),
+                                        },
+                                    )}
+                                </li>
+                                <li>{strings.guideGenerateNewToken}</li>
+                                <li>{strings.guideSaveToken}</li>
+                            </ol>
+                            <Heading level={5}>
+                                {strings.guideExploreData}
+                            </Heading>
+                            <ol type="a">
+                                <li>
+                                    {resolveToComponent(
+                                        strings.guideMontandonNotebooks,
+                                        {
+                                            montandonNotebookLink: (
+                                                <Link
+                                                    href={linkToMontandonNotebooks}
+                                                    withUnderline
+                                                    withLinkIcon
+                                                    external
+                                                >
+                                                    {strings.montandonNotebooksLinkButtonTitle}
+                                                </Link>
+                                            ),
+                                        },
+                                    )}
+                                </li>
+                                <li>
+                                    {resolveToComponent(
+                                        strings.guideStacBrowser,
+                                        {
+                                            montandonStacBrowserLink: (
+                                                <Link
+                                                    href={linkToMontandonStacBrowser}
+                                                    withUnderline
+                                                    withLinkIcon
+                                                    external
+                                                >
+                                                    {
+
+                                                        strings.montandonStacBrowserLinkButtonTitle
+                                                    }
+                                                </Link>
+                                            ),
+                                        },
+                                    )}
+                                </li>
+                            </ol>
                         </ListView>
                     </Container>
-                    <Container
-                        heading={strings.blogPosts}
-                        withPadding
-                        withBackground
-                        withShadow
-                        withHeaderBorder
+                    <ListView
+                        layout="grid"
+                        numPreferredGridColumns={3}
+                        minGridColumnSize="30rem"
                     >
-                        <ListView
-                            layout="block"
-                            withSpacingOpticalCorrection
+                        <Container
+                            heading={strings.blogPosts}
+                            withPadding
+                            withBackground
+                            withShadow
+                            withHeaderBorder
                         >
-                            <Link
-                                href="https://ifrcgoproject.medium.com/toward-a-more-comprehensive-understanding-of-disasters-fc422d65377"
-                                external
-                                withLinkIcon
+                            <ListView
+                                layout="block"
+                                withSpacingOpticalCorrection
                             >
-                                {strings.leveragingDataBlogPostTitle}
-                            </Link>
-                            <Link
-                                href="https://ifrcgoproject.medium.com/scaled-up-ambitions-require-scaled-up-systems-4a92456fab59"
-                                external
-                                withLinkIcon
-                            >
-                                {strings.scaledUpSystemsBlogPostTitle}
-                            </Link>
-                        </ListView>
-                    </Container>
-                    <Container
-                        heading={strings.contact}
-                        withPadding
-                        withBackground
-                        withShadow
-                        withHeaderBorder
-                    >
-                        <ListView
-                            layout="block"
-                            withSpacingOpticalCorrection
+                                <Link
+                                    href="https://ifrcgoproject.medium.com/toward-a-more-comprehensive-understanding-of-disasters-fc422d65377"
+                                    external
+                                    withLinkIcon
+                                >
+                                    {strings.leveragingDataBlogPostTitle}
+                                </Link>
+                                <Link
+                                    href="https://ifrcgoproject.medium.com/scaled-up-ambitions-require-scaled-up-systems-4a92456fab59"
+                                    external
+                                    withLinkIcon
+                                >
+                                    {strings.scaledUpSystemsBlogPostTitle}
+                                </Link>
+                            </ListView>
+                        </Container>
+                        <Container
+                            heading={strings.contact}
+                            withPadding
+                            withBackground
+                            withShadow
+                            withHeaderBorder
                         >
-                            <Link
-                                href="mailto:im@ifrc.org"
-                                colorVariant="primary"
-                                styleVariant="filled"
-                                external
-                                spacing="sm"
+                            <ListView
+                                layout="block"
+                                withSpacingOpticalCorrection
                             >
-                                im@ifrc.org
-                            </Link>
-                            <Description>
-                                {strings.contactText}
-                            </Description>
-                        </ListView>
-                    </Container>
+                                <Link
+                                    href="mailto:im@ifrc.org"
+                                    colorVariant="primary"
+                                    styleVariant="filled"
+                                    external
+                                    spacing="sm"
+                                >
+                                    im@ifrc.org
+                                </Link>
+                                <Description>
+                                    {strings.contactText}
+                                </Description>
+                            </ListView>
+                        </Container>
+                    </ListView>
                 </ListView>
             </Container>
         </Page>

--- a/app/src/views/MontandonLandingPage/styles.module.css
+++ b/app/src/views/MontandonLandingPage/styles.module.css
@@ -1,9 +1,0 @@
-.iframe {
-    margin: 0 auto;
-    border: none;
-    background-color: var(--go-ui-color-gray-30);
-    width: 100%;
-    max-width: 30rem;
-    height: 100vh;
-    max-height: 20rem;
-}

--- a/translationMigrations/000073-1773284377611.json
+++ b/translationMigrations/000073-1773284377611.json
@@ -1,0 +1,168 @@
+{
+    "parent": "000072-1773206343469.json",
+    "actions": [
+        {
+            "action": "add",
+            "key": "emailLabel",
+            "namespace": "montandonLandingPage",
+            "value": "Email"
+        },
+        {
+            "action": "add",
+            "key": "gettingStartedGuide",
+            "namespace": "montandonLandingPage",
+            "value": "Getting Started Guide"
+        },
+        {
+            "action": "add",
+            "key": "goAccountPageLinkButtonTitle",
+            "namespace": "montandonLandingPage",
+            "value": "GO Account Page"
+        },
+        {
+            "action": "add",
+            "key": "guideExploreData",
+            "namespace": "montandonLandingPage",
+            "value": "2. Explore data and use cases"
+        },
+        {
+            "action": "add",
+            "key": "guideGenerateNewToken",
+            "namespace": "montandonLandingPage",
+            "value": "Generate a new token in the Montandon section."
+        },
+        {
+            "action": "add",
+            "key": "guideGetYourToken",
+            "namespace": "montandonLandingPage",
+            "value": "1. Get your token."
+        },
+        {
+            "action": "add",
+            "key": "guideMontandonNotebooks",
+            "namespace": "montandonLandingPage",
+            "value": "Access data and explore the API through {montandonNotebookLink}"
+        },
+        {
+            "action": "add",
+            "key": "guideSaveToken",
+            "namespace": "montandonLandingPage",
+            "value": "Copy and save the generated token, as you will not be able to view it again."
+        },
+        {
+            "action": "add",
+            "key": "guideStacBrowser",
+            "namespace": "montandonLandingPage",
+            "value": "Browse data sources using the {montandonStacBrowserLink}"
+        },
+        {
+            "action": "add",
+            "key": "guideVisitAccountPage",
+            "namespace": "montandonLandingPage",
+            "value": "Visit the {goAccountPageLink} (you must be logged in)."
+        },
+        {
+            "action": "add",
+            "key": "montandonNotebooksLinkButtonTitle",
+            "namespace": "montandonLandingPage",
+            "value": "Montandon Notebooks"
+        },
+        {
+            "action": "add",
+            "key": "montandonStacBrowserLinkButtonTitle",
+            "namespace": "montandonLandingPage",
+            "value": "Montandon STAC browser"
+        },
+        {
+            "action": "add",
+            "key": "sharePopupTitle",
+            "namespace": "montandonLandingPage",
+            "value": "Share"
+        },
+        {
+            "action": "add",
+            "key": "shareUrlLabel",
+            "namespace": "montandonLandingPage",
+            "value": "Share the URL of this page:"
+        },
+        {
+            "action": "add",
+            "key": "sourcePopupTitle",
+            "namespace": "montandonLandingPage",
+            "value": "Source Data"
+        },
+        {
+            "action": "add",
+            "key": "stacIdLabel",
+            "namespace": "montandonLandingPage",
+            "value": "ID"
+        },
+        {
+            "action": "add",
+            "key": "stacIdValue",
+            "namespace": "montandonLandingPage",
+            "value": "stac-fastapi"
+        },
+        {
+            "action": "add",
+            "key": "stacLocationText",
+            "namespace": "montandonLandingPage",
+            "value": "The STAC metadata file is located at"
+        },
+        {
+            "action": "add",
+            "key": "stacVersionLabel",
+            "namespace": "montandonLandingPage",
+            "value": "STAC Version"
+        },
+        {
+            "action": "add",
+            "key": "stacVersionValue",
+            "namespace": "montandonLandingPage",
+            "value": "1.0.0"
+        },
+        {
+            "action": "add",
+            "key": "validLabel",
+            "namespace": "montandonLandingPage",
+            "value": "Valid"
+        },
+        {
+            "action": "add",
+            "key": "validValue",
+            "namespace": "montandonLandingPage",
+            "value": "Yes"
+        },
+        {
+            "action": "remove",
+            "key": "apiDescription",
+            "namespace": "montandonLandingPage"
+        },
+        {
+            "action": "remove",
+            "key": "apiDocumentation",
+            "namespace": "montandonLandingPage"
+        },
+        {
+            "action": "remove",
+            "key": "goWiki",
+            "namespace": "montandonLandingPage"
+        },
+        {
+            "action": "remove",
+            "key": "resources",
+            "namespace": "montandonLandingPage"
+        },
+        {
+            "action": "remove",
+            "key": "visitGithub",
+            "namespace": "montandonLandingPage"
+        },
+        {
+            "action": "update",
+            "key": "montandonHeadingDescription",
+            "namespace": "montandonLandingPage",
+            "newValue": "Montandon is the world’s largest disaster database — a global public good with applications far beyond IFRC. Montandon integrates three key types of data: 1) forecasted and recorded natural hazards; 2) impact data on these hazards; and 3) operational response data (where available). Montandon contains more than 2 million of records about hazards and their impacts for hundreds of thousands of events."
+        }
+    ]
+}


### PR DESCRIPTION
## Summary
Add a 'getting started' section in Montandon Landing page and re-enable previously disabled links.

## Changes

* Add a 'getting started' section
* Re-enable previously disabled links

## This PR Ensures:

* \[x] No typos or grammatical errors
* \[x] No conflict markers left in the code
* \[x] No unwanted comments, temporary files, or auto-generated files
* \[x] No inclusion of secret keys or sensitive data
* \[x] No `console.log` statements meant for debugging
* \[x] All CI checks have passed

