### PR TITLE
remove(montandon-landing): swagger api button

### DIFF
--- a/.changeset/nice-months-join.md
+++ b/.changeset/nice-months-join.md
@@ -1,0 +1,5 @@
+---
+"go-web-app": patch
+---
+
+Remove Swagger API link from Montandon landing page

--- a/app/src/views/MontandonLandingPage/i18n.json
+++ b/app/src/views/MontandonLandingPage/i18n.json
@@ -29,7 +29,6 @@
         "contact": "Contact",
         "contactText": "Please get in contact with the team in case interested to collaborate or learn more",
 
-        "accessAPILabel": "Access the Montandon API",
         "exploreRadiantEarthLabel": "Explore data in STAC browser",
 
         "guideGetYourToken": "1. Get your token.",

--- a/app/src/views/MontandonLandingPage/index.tsx
+++ b/app/src/views/MontandonLandingPage/index.tsx
@@ -144,15 +144,6 @@ export function Component() {
                         spacing="sm"
                     >
                         <Link
-                            href="https://montandon-eoapi-stage.ifrc.org/stac/api.html"
-                            colorVariant="primary"
-                            styleVariant="outline"
-                            external
-                            withLinkIcon
-                        >
-                            {strings.accessAPILabel}
-                        </Link>
-                        <Link
                             href={linkToMontandonStacBrowser}
                             colorVariant="primary"
                             styleVariant="outline"

--- a/translationMigrations/000074-1773302401100.json
+++ b/translationMigrations/000074-1773302401100.json
@@ -1,0 +1,10 @@
+{
+    "parent": "000073-1773284377611.json",
+    "actions": [
+        {
+            "action": "remove",
+            "key": "accessAPILabel",
+            "namespace": "montandonLandingPage"
+        }
+    ]
+}


### PR DESCRIPTION
## Summary

Remove Swagger API link from Montandon landing page

## Changes

* Remove Swagger API link from Montandon landing page
## This PR Ensures:

* \[x] No typos or grammatical errors
* \[x] No conflict markers left in the code
* \[x] No unwanted comments, temporary files, or auto-generated files
* \[x] No inclusion of secret keys or sensitive data
* \[x] No `console.log` statements meant for debugging
* \[x] All CI checks have passed