### PR TITLE
Translatte: add application id for IFRC translation commands

### DIFF
--- a/app/scripts/translatte/commands/exportServerStringsToExcel.ts
+++ b/app/scripts/translatte/commands/exportServerStringsToExcel.ts
@@ -25,8 +25,8 @@ async function exportServerStringsToExcel(
     );
 
     worksheet.columns = [
-        { header: 'Namespace', key: 'namespace' },
-        { header: 'Key', key: 'key' },
+        { header: 'page', key: 'page' },
+        { header: 'key', key: 'key' },
         { header: 'EN', key: 'en' },
         { header: 'FR', key: 'fr' },
         { header: 'ES', key: 'es' },
@@ -52,7 +52,7 @@ async function exportServerStringsToExcel(
             const { key, page_name } = list[0];
 
             return {
-                namespace: page_name,
+                page: page_name,
                 key: key,
                 en: value.en,
                 fr: hash.fr === hash.en ? value.fr : undefined,

--- a/app/scripts/translatte/commands/lintMigrations.ts
+++ b/app/scripts/translatte/commands/lintMigrations.ts
@@ -19,10 +19,10 @@ async function lintMigrations(projectPath: string, path: string) {
 
         console.info(duplicateStr);
 
-        throw `Error: found divirging migrations!`;
+        throw `Error: found diverging migrations!`;
     }
 
-    console.info('All good! No divirging migrations!');
+    console.info('All good! No diverging migrations!');
 }
 
 export default lintMigrations;

--- a/app/scripts/translatte/commands/pushMigrationsToIfrc.ts
+++ b/app/scripts/translatte/commands/pushMigrationsToIfrc.ts
@@ -37,10 +37,7 @@ export function isTranslatedTemplateValid(
 }
 */
 
-// FIXME: get this from params
-const applicationId = 18;
-
-async function fetchTranslations(ifrcApiUrl: string, ifrcApiKey: string) {
+async function fetchTranslations(ifrcApiUrl: string, ifrcApiKey: string, applicationId: string) {
     const endpoint = resolveUrl(ifrcApiUrl, `api/Application/${applicationId}/Translation/export`);
 
     const headers: RequestInit['headers'] = {
@@ -60,7 +57,7 @@ async function fetchTranslations(ifrcApiUrl: string, ifrcApiKey: string) {
     return promise;
 }
 
-async function pushTranslations(blob: Blob, ifrcApiUrl: string, ifrcApiKey: string) {
+async function pushTranslations(blob: Blob, ifrcApiUrl: string, ifrcApiKey: string, applicationId: string) {
     const endpoint = resolveUrl(ifrcApiUrl, `api/Application/${applicationId}/Translation/fullappimport`);
 
     console.info('posting to', endpoint);
@@ -197,10 +194,11 @@ async function pushMigrationsToIfrc(
     migrationDirPath: string,
     apiUrl: string,
     apiKey: string,
+    applicationId: string,
 ) {
     const migrationFilesAttrs = await getMigrationFilesAttrs(projectPath, migrationDirPath);
 
-    const fetchResult = await fetchTranslations(apiUrl, apiKey);
+    const fetchResult = await fetchTranslations(apiUrl, apiKey, applicationId);
     const arrayBuffer = await fetchResult.arrayBuffer();
     const workbook= xlsx.read(arrayBuffer);
     const firstSheetData = xlsx.utils.sheet_to_json(
@@ -319,7 +317,7 @@ async function pushMigrationsToIfrc(
     const u8 = xlsx.write(newWorkbook, { bookType: 'xlsx', type: 'buffer' });
     const blob = new Blob([u8], { type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" })
 
-    const pushResult = await pushTranslations(blob, apiUrl, apiKey);
+    const pushResult = await pushTranslations(blob, apiUrl, apiKey, applicationId);
 
     console.info(await pushResult.text());
 }

--- a/app/scripts/translatte/commands/pushStringsFromExcel.ts
+++ b/app/scripts/translatte/commands/pushStringsFromExcel.ts
@@ -126,7 +126,7 @@ async function getExcelTranslations(excelFilePath: string) {
     firstSheet.spliceRows(1, 1);
 
     const KEY = 'key';
-    const NAMESPACE = 'namespace';
+    const NAMESPACE = 'page';
     const EN = 'en';
     const FR = 'fr';
     const ES = 'es';
@@ -178,6 +178,7 @@ async function pushStringsFromExcel(importFilePath: string, apiUrl: string, acce
 
     console.info(`Found ${translations.length} rows`);
 
+    // FIXME: this should come from params
     const applicableLanguages: Language[] = ['en', 'fr', 'es', 'ar'];
 
     const actionsByLanguage = listToMap(

--- a/app/scripts/translatte/commands/pushStringsFromExcelToIfrc.ts
+++ b/app/scripts/translatte/commands/pushStringsFromExcelToIfrc.ts
@@ -1,10 +1,12 @@
 import { readFileSync } from "fs";
 import { resolveUrl } from "../utils";
 
-// FIXME: get this from params
-const applicationId = 18;
-
-async function fullAppImport(importFilePath: string, ifrcApiUrl: string, ifrcApiKey: string) {
+async function fullAppImport(
+    importFilePath: string,
+    ifrcApiUrl: string,
+    ifrcApiKey: string,
+    applicationId: string,
+) {
     const endpoint = resolveUrl(ifrcApiUrl, `Application/${applicationId}/Translation/fullappimport`);
     const translationFile = readFileSync(importFilePath);
     const uint8FileData = new Uint8Array(translationFile);
@@ -32,8 +34,18 @@ async function fullAppImport(importFilePath: string, ifrcApiUrl: string, ifrcApi
     return promise;
 }
 
-async function pushStringsFromExcelToIfrc(importFilePath: string, apiUrl: string, apiKey: string) {
-    const response = await fullAppImport(importFilePath, apiUrl, apiKey);
+async function pushStringsFromExcelToIfrc(
+    importFilePath: string,
+    apiUrl: string,
+    apiKey: string,
+    applicationId: string,
+) {
+    const response = await fullAppImport(
+        importFilePath,
+        apiUrl,
+        apiKey,
+        applicationId,
+    );
 
     try {
         const responseJson = await response.json();

--- a/app/scripts/translatte/main.ts
+++ b/app/scripts/translatte/main.ts
@@ -47,7 +47,7 @@ yargs(hideBin(process.argv))
     )
     .command(
         'lint-migrations <MIGRATION_DIR_PATH>',
-        'Lint migration files for divirging migrations',
+        'Lint migration files for diverging migrations',
         (yargs) => {
             yargs.positional('MIGRATION_DIR_PATH', {
                 type: 'string',
@@ -260,6 +260,11 @@ yargs(hideBin(process.argv))
                     type: 'string',
                     describe: 'URL for the API server',
                     require: true,
+                },
+                'application-id': {
+                    type: 'string',
+                    describe: 'Application ID in the translation service',
+                    require: true,
                 }
             });
         },
@@ -270,6 +275,7 @@ yargs(hideBin(process.argv))
                 importFilePath,
                 argv.apiUrl as string,
                 argv.apiKey as string,
+                argv.applicationId as string,
             );
         },
     )
@@ -323,6 +329,11 @@ yargs(hideBin(process.argv))
                     type: 'string',
                     describe: 'URL for the API server',
                     require: true,
+                },
+                'application-id': {
+                    type: 'string',
+                    describe: 'Application ID in the translation service',
+                    require: true,
                 }
             });
         },
@@ -334,6 +345,7 @@ yargs(hideBin(process.argv))
                 migrationDirPath,
                 argv.apiUrl as string,
                 argv.apiKey as string,
+                argv.applicationId as string,
             );
         },
     )

--- a/app/scripts/translatte/utils.ts
+++ b/app/scripts/translatte/utils.ts
@@ -422,54 +422,6 @@ export async function fetchServerState(apiUrl: string, authToken?: string) {
     return serverStrings;
 }
 
-/*
-export function getValueFromCellValue(cellValue: CellValue) {
-    if (isNotDefined(cellValue)) {
-        return undefined;
-    }
-
-    if (
-        typeof cellValue === 'number'
-        || typeof cellValue === 'string'
-        || typeof cellValue === 'boolean'
-    ) {
-        return cellValue;
-    }
-
-    if (cellValue instanceof Date) {
-        return encodeDate(cellValue);
-    }
-
-    if ('error' in cellValue) {
-        return undefined;
-    }
-
-    if ('richText' in cellValue) {
-        return cellValue.richText.map(({ text }) => text).join('');
-    }
-
-    if ('hyperlink' in cellValue) {
-        const MAIL_IDENTIFIER = 'mailto:';
-        if (cellValue.hyperlink.startsWith(MAIL_IDENTIFIER)) {
-            return cellValue.hyperlink.substring(MAIL_IDENTIFIER.length);
-        }
-
-        return cellValue.hyperlink;
-    }
-
-    if (isNotDefined(cellValue.result)) {
-        return undefined;
-    }
-
-    if (typeof cellValue.result === 'object' && 'error' in cellValue.result) {
-        return undefined;
-    }
-
-    // Formula result
-    return getValueFromCellValue(cellValue.result);
-}
-*/
-
 function getCanonicalKey(
     item: MigrationActionItem,
     opts: { useNewKey: boolean },


### PR DESCRIPTION
### Changes

- Address PR comments in https://github.com/IFRCGo/go-web-app/pull/2099
- Introduce `application-id` from params for IFRC translation related commands
- Update excel export to match IFRC translation import