### PR TITLE
EAP: fix view mode in both EAP forms

### DIFF
--- a/app/src/components/domain/Admin2Input/index.tsx
+++ b/app/src/components/domain/Admin2Input/index.tsx
@@ -343,11 +343,13 @@ function Admin2Input<const NAME>(props: Props<NAME>) {
                                     onClick={removeSelection}
                                     styleVariant="action"
                                     readOnly
+                                    disabled={readOnly}
                                 >
                                     <CloseLineIcon />
                                 </Button>
                             )}
                             readOnly
+                            disabled={readOnly}
                         >
                             {admin2NameMap?.[admin2Id] ?? admin2Id}
                         </ButtonLayout>

--- a/app/src/components/domain/PrintableActivityOutput/index.tsx
+++ b/app/src/components/domain/PrintableActivityOutput/index.tsx
@@ -1,4 +1,7 @@
-import { useMemo } from 'react';
+import {
+    useCallback,
+    useMemo,
+} from 'react';
 import {
     compareNumber,
     isDefined,
@@ -15,6 +18,7 @@ import {
     TIMEFRAME_HOURS,
     TIMEFRAME_MONTHS,
     TIMEFRAME_YEAR,
+    type TimeFrameEnumKey,
 } from '#utils/constants';
 
 type OperationActivity = components['schemas']['OperationActivity'];
@@ -61,16 +65,11 @@ interface Props {
 
 function PrintableActivityOutput(props: Props) {
     const {
-        activity: activityFromProps,
-        prevActivity,
+        activity: currentActivity,
+        prevActivity: previousActivity,
         withDiff,
         index,
     } = props;
-
-    const {
-        time_value,
-        timeframe,
-    } = activityFromProps;
 
     const {
         eap_years_timeframe_value,
@@ -111,27 +110,27 @@ function PrintableActivityOutput(props: Props) {
         )
     ), [eap_years_timeframe_value]);
 
-    const timeValue = useMemo(() => {
-        const sortedTimeValue = time_value.toSorted(compareNumber);
+    const timeValue = useCallback((timeArray: number[], timeframeKey: TimeFrameEnumKey) => {
+        const sortedTimeValue = timeArray.toSorted(compareNumber);
 
-        if (timeframe === TIMEFRAME_HOURS && isDefined(hoursTimeframeMap)) {
+        if (timeframeKey === TIMEFRAME_HOURS && isDefined(hoursTimeframeMap)) {
             return sortedTimeValue.map(
                 (hour) => hoursTimeframeMap?.[hour as HoursTimeFrameKey],
             ).filter(isDefined);
         }
-        if (timeframe === TIMEFRAME_DAYS && isDefined(daysTimeframeMap)) {
+        if (timeframeKey === TIMEFRAME_DAYS && isDefined(daysTimeframeMap)) {
             return sortedTimeValue.map(
                 (day) => daysTimeframeMap?.[day as DaysTimeFrameKey],
             ).filter(isDefined);
         }
 
-        if (timeframe === TIMEFRAME_MONTHS && isDefined(monthsTimeframeMap)) {
+        if (timeframeKey === TIMEFRAME_MONTHS && isDefined(monthsTimeframeMap)) {
             return sortedTimeValue.map(
                 (month) => monthsTimeframeMap?.[month as MonthsTimeFrameKey],
             ).filter(isDefined);
         }
 
-        if (timeframe === TIMEFRAME_YEAR && isDefined(yearsTimeframeMap)) {
+        if (timeframeKey === TIMEFRAME_YEAR && isDefined(yearsTimeframeMap)) {
             return sortedTimeValue.map(
                 (year) => yearsTimeframeMap?.[year as YearsTimeFrameKey],
             ).filter(isDefined);
@@ -143,14 +142,17 @@ function PrintableActivityOutput(props: Props) {
         daysTimeframeMap,
         monthsTimeframeMap,
         yearsTimeframeMap,
-        timeframe,
-        time_value,
     ]);
 
     const activity = {
-        ...activityFromProps,
-        time_value: timeValue,
+        ...currentActivity,
+        time_value: timeValue(currentActivity.time_value, currentActivity.timeframe),
     };
+
+    const prevActivity = isDefined(previousActivity) ? {
+        ...previousActivity,
+        time_value: timeValue(previousActivity?.time_value, previousActivity?.timeframe),
+    } : previousActivity;
 
     return (
         <PrintableDataDisplay

--- a/app/src/components/printable/DiffTextOutput/index.tsx
+++ b/app/src/components/printable/DiffTextOutput/index.tsx
@@ -20,6 +20,8 @@ interface Props {
     prevValue?: string | null;
 }
 
+const diffMatch = new DiffMatchPatch();
+
 function DiffTextOutput(props: Props) {
     const {
         className,
@@ -32,8 +34,10 @@ function DiffTextOutput(props: Props) {
         if (!withDiff) {
             return undefined;
         }
-        const diffMatch = new DiffMatchPatch();
-        return diffMatch.diff_main(prevValue ?? '', value ?? '');
+        const diffs = diffMatch.diff_main(prevValue ?? '', value ?? '');
+        diffMatch.diff_cleanupSemantic(diffs);
+
+        return diffs;
     }, [withDiff, value, prevValue]);
 
     if (isNotDefined(diff)) {

--- a/app/src/utils/constants.ts
+++ b/app/src/utils/constants.ts
@@ -227,7 +227,7 @@ export const EAP_TYPE_SIMPLIFIED = 20 satisfies EapTypeEnumKey;
 export const EAP_TYPE_FULL = 10 satisfies EapTypeEnumKey;
 
 // Timeframe
-type TimeFrameEnumKey = components['schemas']['EapTimeframeEnumKey'];
+export type TimeFrameEnumKey = components['schemas']['EapTimeframeEnumKey'];
 
 export const TIMEFRAME_YEAR = 10 satisfies TimeFrameEnumKey;
 export const TIMEFRAME_DAYS = 30 satisfies TimeFrameEnumKey;

--- a/app/src/views/AccountMyFormsEap/EapStatus/index.tsx
+++ b/app/src/views/AccountMyFormsEap/EapStatus/index.tsx
@@ -86,11 +86,25 @@ function EapStatus(props: Props) {
         details,
     } = props;
 
-    const simplifiedEapDetails = details.simplified_eap_details;
-    const fullEapDetails = details.full_eap_details;
+    const latestId = useMemo(() => {
+        if (details.eap_type === EAP_TYPE_SIMPLIFIED) {
+            return details.latest_simplified_eap ?? undefined;
+        }
 
-    const isSimplifiedEapLocked = simplifiedEapDetails[0]?.is_locked;
-    const isFullEapLocked = fullEapDetails[0]?.is_locked;
+        if (details.eap_type === EAP_TYPE_FULL) {
+            return details.latest_full_eap ?? undefined;
+        }
+
+        return undefined;
+    }, [details]);
+
+    const latestSimplifiedEap = details.eap_type === EAP_TYPE_SIMPLIFIED
+        ? details.simplified_eap_details.find(({ id }) => latestId === id)
+        : undefined;
+
+    const latestFullEap = details.eap_type === EAP_TYPE_FULL
+        ? details.full_eap_details.find(({ id }) => latestId === id)
+        : undefined;
 
     const alert = useAlert();
 
@@ -158,10 +172,16 @@ function EapStatus(props: Props) {
         setNewStatus(undefined);
     }, []);
 
+    const isSimplifiedEapLocked = status === EAP_STATUS_NS_ADDRESSING_COMMENTS
+        && latestSimplifiedEap?.is_locked;
+    const isFullEapLocked = status === EAP_STATUS_NS_ADDRESSING_COMMENTS
+        && latestFullEap?.is_locked;
+
     const confirmDisabled = (
         (newStatus === EAP_STATUS_NS_ADDRESSING_COMMENTS && isNotDefined(checklistFile))
             || (newStatus === EAP_STATUS_PENDING_PFA && !hasValidatedBudgetFile)
         || isDefined(responseFormErrors)
+        || isSimplifiedEapLocked || isFullEapLocked
     );
 
     return (
@@ -176,7 +196,8 @@ function EapStatus(props: Props) {
                         key={option.key}
                         type="button"
                         name={option.key}
-                        disabled={!validStatusTransition[status].includes(option.key)}
+                        disabled={!validStatusTransition[status].includes(option.key)
+                            || isNotDefined(latestId)}
                         onClick={setNewStatus}
                     >
                         {option.value}
@@ -196,8 +217,8 @@ function EapStatus(props: Props) {
                                     <Link
                                         to="simplifiedEapForm"
                                         urlParams={{ eapId }}
-                                        urlSearch={isDefined(simplifiedEapDetails[0]?.version)
-                                            ? `version=${simplifiedEapDetails[0].version}`
+                                        urlSearch={isDefined(latestSimplifiedEap?.version)
+                                            ? `version=${latestSimplifiedEap.version}`
                                             : undefined}
                                         title={strings.editSimplifiedEapFormLinkLabel}
                                         state={{ error: responseFormErrors }}
@@ -214,8 +235,8 @@ function EapStatus(props: Props) {
                                     <Link
                                         to="eapFullExport"
                                         urlParams={{ eapId }}
-                                        urlSearch={isDefined(fullEapDetails[0]?.version)
-                                            ? `version=${fullEapDetails[0].version}`
+                                        urlSearch={isDefined(latestFullEap?.version)
+                                            ? `version=${latestFullEap.version}`
                                             : undefined}
                                         title={strings.editFullEapFormLinkLabel}
                                         state={{ error: responseFormErrors }}

--- a/app/src/views/AccountMyFormsEap/EapTableActions/index.tsx
+++ b/app/src/views/AccountMyFormsEap/EapTableActions/index.tsx
@@ -490,17 +490,6 @@ function EapTableActions(props: Props) {
                             {environment === 'development' && isCreated && (
                                 <ListView layout="block">
                                     <Link
-                                        to="eapSummaryExport"
-                                        urlParams={{ eapId: eap.id }}
-                                        urlSearch={isDefined(latestVersion)
-                                            ? `version=${latestVersion}`
-                                            : undefined}
-                                        title={strings.previewExportLinkLabel}
-                                        before={<DocumentPdfLineIcon fontSize={18} />}
-                                    >
-                                        {strings.previewSummaryExportLinkLabel}
-                                    </Link>
-                                    <Link
                                         to="eapFullExport"
                                         urlParams={{ eapId: eap.id }}
                                         urlSearch={isDefined(details?.data.version)
@@ -510,6 +499,17 @@ function EapTableActions(props: Props) {
                                         before={<DocumentPdfLineIcon fontSize={18} />}
                                     >
                                         {strings.previewExportLinkLabel}
+                                    </Link>
+                                    <Link
+                                        to="eapSummaryExport"
+                                        urlParams={{ eapId: eap.id }}
+                                        urlSearch={isDefined(latestVersion)
+                                            ? `version=${latestVersion}`
+                                            : undefined}
+                                        title={strings.previewExportLinkLabel}
+                                        before={<DocumentPdfLineIcon fontSize={18} />}
+                                    >
+                                        {strings.previewSummaryExportLinkLabel}
                                     </Link>
                                 </ListView>
                             )}

--- a/app/src/views/EapFullExport/index.tsx
+++ b/app/src/views/EapFullExport/index.tsx
@@ -322,7 +322,7 @@ export function Component() {
     );
 
     const prevEnableApproachesMapping = useMemo(
-        () => listToMap(prev_enabling_approaches ?? [], (approach) => approach.id!),
+        () => listToMap(prev_enabling_approaches ?? [], (approach) => approach.approach!),
         [prev_enabling_approaches],
     );
 
@@ -1215,7 +1215,7 @@ export function Component() {
                                         <PrintableDescription
                                             value={trigger.source_link}
                                             prevValue={prevEvidenceBaseSourceInformationMapping[
-                                                trigger.id!]?.source_link}
+                                                trigger.previous_id!]?.source_link}
                                             withDiff={withDiff}
                                         />
                                     )}

--- a/app/src/views/EapFullForm/FinanceLogistics/i18n.json
+++ b/app/src/views/EapFullForm/FinanceLogistics/i18n.json
@@ -21,7 +21,7 @@
         "financeReadinessCostDescription1": "For each item of readiness costs in the budget, explain why these are necessary for the upkeep of the EAP and how these were calculated.",
         "financeReadinessCostDescription2": "Indicate who will manage these funds and describe how it will be ensured that they are only used for the indicated purposes.",
         "financeReadinessBudgetLabel": "Readiness Budget(CHF)",
-        "financePrePositioningTitle": "Pre-positioning cost",
+        "financePrePositioningTitle": "Pre-positioning cost(CHF)",
         "financePrePositioningExplanatoryNote": "In order to ensure the feasibility of the rapid distribution of items in the short timeframe between forecast and event, pre-positioning of goods might be necessary. They should normally have a lifetime of at least the lifecycle of the EAP and should only be replenished after an activation. The DREF covers these costs, combined with readiness, to a maximum amount of 65% of the EAP budget (combined with the readiness activities). Please note that costs that are not for the procurement of the items but related to the maintenance of the stock, such as warehousing, are part of the readiness costs of an EAP (see section 9.2.)",
         "financePrePositioningDescription1": "If funds for pre-positioning are requested from the DREF, explain for which items and why no other option is possible. Explain why standard response stocks cannot be used.",
         "financePrePositioningDescription2": "Expiry date of the items should not be prior to the end of the lifecycle of the EAP",

--- a/app/src/views/EapFullForm/Overview/KeyActorsInput/index.tsx
+++ b/app/src/views/EapFullForm/Overview/KeyActorsInput/index.tsx
@@ -103,6 +103,7 @@ function KeyActorsInput(props: Props) {
                         onChange={onFieldChange}
                         required
                         maxLength={charLimits.key_actors}
+                        readOnly={readOnly}
                     />
                 </ListView>
             </InlineLayout>

--- a/app/src/views/EapFullForm/Overview/index.tsx
+++ b/app/src/views/EapFullForm/Overview/index.tsx
@@ -216,6 +216,7 @@ function Overview(props: Props) {
                             fileIdToUrlMap={fileIdToUrlMap}
                             setFileIdToUrlMap={setFileIdToUrlMap}
                             label={strings.formUploadAnImageLabel}
+                            readOnly={readOnly}
                             disabled={disabled}
                         />
                     </InputSection>
@@ -261,6 +262,7 @@ function Overview(props: Props) {
                             error={getErrorString(error?.partners)}
                             onChange={setFieldValue}
                             disabled={disabled}
+                            readOnly={readOnly}
                         />
                     </InputSection>
                 </ListView>

--- a/app/src/views/EapFullForm/RiskAnalysis/index.tsx
+++ b/app/src/views/EapFullForm/RiskAnalysis/index.tsx
@@ -416,7 +416,7 @@ function RiskAnalysis(props: Props) {
                         <Button
                             name={undefined}
                             onClick={handlePrioritizedImpactAdd}
-                            disabled={disabled}
+                            disabled={disabled || readOnly}
                             before={<AddLineIcon />}
                         >
                             {strings.addButtonLabel}

--- a/app/src/views/EapFullForm/TriggerModel/index.tsx
+++ b/app/src/views/EapFullForm/TriggerModel/index.tsx
@@ -590,6 +590,7 @@ function TriggerModel(props: Props) {
                                 value={value?.admin2}
                                 countryId={eapRegistrationDetail.country}
                                 error={getErrorString(error?.admin2)}
+                                readOnly={readOnly}
                             />
                         )}
                     </InputSection>

--- a/app/src/views/EapFullForm/common.tsx
+++ b/app/src/views/EapFullForm/common.tsx
@@ -69,6 +69,7 @@ const riskAnalysisTabFields: (keyof PartialEapFullFormType)[] = [
     'hazard_selection',
     'exposed_element_and_vulnerability_factor',
     'exposed_element_and_vulnerability_factor_images',
+    'prioritized_impact',
     'prioritized_impacts',
     'prioritized_impact_images',
     'risk_analysis_relevant_files',

--- a/app/src/views/EapFullForm/index.tsx
+++ b/app/src/views/EapFullForm/index.tsx
@@ -157,7 +157,6 @@ export function Component() {
             : undefined,
     });
 
-    const isRevision = eapDetailResponse?.status === EAP_STATUS_NS_ADDRESSING_COMMENTS;
     const selectedFullEap = eapDetailResponse?.full_eap_details?.find(
         (fullEap) => String(fullEap.version) === String(version),
     );
@@ -170,6 +169,11 @@ export function Component() {
     const currentFullEap = selectedFullEap ?? latestFullEap;
     const currentFullEapId = currentFullEap?.id;
     const getIsSubmission = () => shouldSubmitRef.current;
+
+    const isLocked = currentFullEap?.is_locked;
+    const isRevision = eapDetailResponse?.status === EAP_STATUS_NS_ADDRESSING_COMMENTS
+        && (isDefined(currentFullEap?.version) && currentFullEap?.version > 1)
+        && !isLocked;
 
     const {
         value,
@@ -816,8 +820,6 @@ export function Component() {
     const fullEapFormAccess = (isNotDefined(eapDetailResponse?.eap_type)
         || eapDetailResponse?.eap_type === EAP_TYPE_FULL)
         && isNotDefined(fullEapResponseError);
-
-    const isLocked = currentFullEap?.is_locked;
 
     const isEditable = isLatestVersion
         && !isLocked

--- a/app/src/views/EapSimplifiedForm/EnablingApproaches/ApproachesInput/index.tsx
+++ b/app/src/views/EapSimplifiedForm/EnablingApproaches/ApproachesInput/index.tsx
@@ -73,7 +73,7 @@ function OperationsBySectorInput(props: Props) {
                     onClick={onRemove}
                     styleVariant="action"
                     title={strings.approachRemoveButton}
-                    disabled={disabled}
+                    disabled={disabled || readOnly}
                 >
                     <DeleteBinTwoLineIcon />
                 </Button>

--- a/app/src/views/EapSimplifiedForm/Overview/index.tsx
+++ b/app/src/views/EapSimplifiedForm/Overview/index.tsx
@@ -213,6 +213,7 @@ function Overview(props: Props) {
                             error={getErrorString(error?.partners)}
                             onChange={setFieldValue}
                             disabled={disabled}
+                            readOnly={readOnly}
                         />
                     </InputSection>
                 </ListView>

--- a/app/src/views/EapSimplifiedForm/index.tsx
+++ b/app/src/views/EapSimplifiedForm/index.tsx
@@ -160,7 +160,11 @@ export function Component() {
     const currentSimplifiedEap = selectedSimplifiedEap ?? latestSimplifiedEap;
     const currentSimplifiedEapId = currentSimplifiedEap?.id;
 
-    const isRevision = eapRegistrationResponse?.status === EAP_STATUS_NS_ADDRESSING_COMMENTS;
+    const isLocked = currentSimplifiedEap?.is_locked;
+    const isRevision = eapRegistrationResponse?.status === EAP_STATUS_NS_ADDRESSING_COMMENTS
+        && (isDefined(currentSimplifiedEap?.version) && currentSimplifiedEap?.version > 1)
+        && !isLocked;
+
     const getIsSubmission = useCallback(() => shouldSubmitRef.current, []);
     const {
         value,
@@ -454,8 +458,6 @@ export function Component() {
     const simplifiedEapFormAccess = (isNotDefined(eapRegistrationResponse?.eap_type)
         || eapRegistrationResponse?.eap_type === EAP_TYPE_SIMPLIFIED)
         && isNotDefined(simplifiedEapResponseError);
-
-    const isLocked = currentSimplifiedEap?.is_locked;
 
     const isEditable = isLatestVersion
         && !isLocked

--- a/app/src/views/EapSummaryExport/index.tsx
+++ b/app/src/views/EapSummaryExport/index.tsx
@@ -72,7 +72,7 @@ export function Component() {
         url: '/api/v2/full-eap/{id}/',
         pathVariables: isDefined(currentFullEapId)
             ? {
-                id: Number(selectedFullEap?.id),
+                id: Number(currentFullEapId),
             }
             : undefined,
     });


### PR DESCRIPTION
## Changes

    - add value mapping for previous Activity in eap export
    - add missing readOnly in form fields
    - update isRevision in both EAP forms
    - fix enabling approach map
    - fix summary export not loading issue
    - use clean up semantics from diff-match-patch package for cleaner diff view

## This PR Ensures:

* \[x] No typos or grammatical errors
* \[x] No conflict markers left in the code
* \[x] No unwanted comments, temporary files, or auto-generated files
* \[x] No inclusion of secret keys or sensitive data
* \[x] No `console.log` statements meant for debugging
* \[x] All CI checks have passed