### PR TITLE
fix(translatte): detect migrations with duplicate numbers

### DIFF
--- a/app/scripts/translatte/commands/lintMigrations.ts
+++ b/app/scripts/translatte/commands/lintMigrations.ts
@@ -5,21 +5,23 @@ async function lintMigrations(projectPath: string, path: string) {
     const migrationFileAttrs = await getMigrationFilesAttrs(projectPath, path);
     console.info(`Found ${migrationFileAttrs.length} migration files.`);
 
+    // Group by `num` (the leading NNNNNN), not the full name: two branches
+    // each generating the next number produce diverging same-numbered migrations.
     const migrationGroups = listToGroupList(
         migrationFileAttrs,
-        ({ migrationName }) => migrationName,
+        ({ num }) => num,
     );
 
     const duplicates = Object.values(migrationGroups).filter((group) => group.length > 1);
 
     if (duplicates.length > 0) {
         const duplicateStr = duplicates.map((duplicate) => (
-            duplicate.map(({ migrationName }) => migrationName).join(' <> ')
+            duplicate.map(({ migrationFileName }) => migrationFileName).join(' <> ')
         )).join('\n');
 
         console.info(duplicateStr);
 
-        throw `Error: found diverging migrations!`;
+        throw `Error: found migrations with duplicate numbers!`;
     }
 
     console.info('All good! No diverging migrations!');


### PR DESCRIPTION
- group migration files by leading number, not the full num-timestamp name
- lint-migrations now fails when two files share a number
- list the conflicting filenames in the error
