### PR TITLE
EAP: Hotfix for Summary export and file upload

### DIFF
--- a/.changeset/every-bags-carry.md
+++ b/.changeset/every-bags-carry.md
@@ -1,0 +1,10 @@
+---
+"go-web-app": minor
+---
+
+Fix page breaks in the EAP Summary export and validate EAP file uploads
+
+- Start each main section of the EAP Summary export on a new page
+- Show an error for unsupported files and upload only the accepted ones
+- Allow `.xlsx` files in EAP file uploads
+- Disable removing a file while the file input is disabled

--- a/app/src/components/domain/GoMultiFileInput/i18n.json
+++ b/app/src/components/domain/GoMultiFileInput/i18n.json
@@ -3,6 +3,8 @@
     "strings": {
         "goMultiFailedUploadMessage": "Failed to upload the file!",
         "noFileSelected": "No file Selected",
-        "goMultiDeleteButton": "Delete"
+        "goMultiDeleteButton": "Delete",
+        "unsupportedFileFormatMessage": "Unsupported file format!",
+        "unsupportedFileFormatDescription": "{fileNames} could not be added. Only the following file formats are accepted: {fileFormats}."
     }
 }

--- a/app/src/components/domain/GoMultiFileInput/index.tsx
+++ b/app/src/components/domain/GoMultiFileInput/index.tsx
@@ -18,6 +18,7 @@ import {
     RawFileInput,
 } from '@ifrc-go/ui';
 import { useTranslation } from '@ifrc-go/ui/hooks';
+import { resolveToString } from '@ifrc-go/ui/utils';
 import {
     isDefined,
     isNotDefined,
@@ -26,6 +27,7 @@ import { nonFieldError } from '@togglecorp/toggle-form';
 
 import Link from '#components/Link';
 import useAlert from '#hooks/useAlert';
+import { isFileAccepted } from '#utils/common';
 import { useLazyRequest } from '#utils/restRequest';
 import { transformObjectError } from '#utils/restRequest/error';
 
@@ -160,10 +162,41 @@ function GoMultiFileInput<T extends NameType>(props: Props<T>) {
     const inputRef = useRef<HTMLInputElement>(null);
 
     const handleChange = useCallback((files: File[] | undefined) => {
-        if (files) {
-            triggerFileUpload({ files });
+        if (isNotDefined(files) || files.length === 0) {
+            return;
         }
-    }, [triggerFileUpload]);
+
+        const acceptedFiles: File[] = [];
+        const rejectedFiles: File[] = [];
+
+        files.forEach((file) => {
+            if (isFileAccepted(file, accept)) {
+                acceptedFiles.push(file);
+            } else {
+                rejectedFiles.push(file);
+            }
+        });
+
+        if (rejectedFiles.length > 0) {
+            alert.show(
+                strings.unsupportedFileFormatMessage,
+                {
+                    variant: 'danger',
+                    description: resolveToString(
+                        strings.unsupportedFileFormatDescription,
+                        {
+                            fileNames: rejectedFiles.map((file) => file.name).join(', '),
+                            fileFormats: accept ?? '',
+                        },
+                    ),
+                },
+            );
+        }
+
+        if (acceptedFiles.length > 0) {
+            triggerFileUpload({ files: acceptedFiles });
+        }
+    }, [triggerFileUpload, accept, alert, strings]);
 
     const handleClearButtonClick = useCallback(() => {
         onChange(undefined, name);
@@ -255,6 +288,7 @@ function GoMultiFileInput<T extends NameType>(props: Props<T>) {
                                         styleVariant="action"
                                         onClick={handleFileRemove}
                                         title={strings.goMultiDeleteButton}
+                                        disabled={disabled}
                                     >
                                         <DeleteBinFillIcon />
                                     </Button>

--- a/app/src/utils/common.ts
+++ b/app/src/utils/common.ts
@@ -98,6 +98,39 @@ export function isImageFile(urlString: string | undefined | null) {
     return isTruthyString(extension) && imageFileExtensions.includes(extension);
 }
 
+export function isFileAccepted(file: File, accept: string | undefined | null) {
+    if (isNotDefined(accept)) {
+        return true;
+    }
+
+    const acceptedFormats = accept
+        .split(',')
+        .map((format) => format.trim().toLowerCase())
+        .filter(isTruthyString);
+
+    if (acceptedFormats.length === 0
+        || acceptedFormats.includes('*')
+        || acceptedFormats.includes('*/*')
+    ) {
+        return true;
+    }
+
+    const fileName = file.name.toLowerCase();
+    const fileType = file.type.toLowerCase();
+
+    return acceptedFormats.some((format) => {
+        if (format.startsWith('.')) {
+            return fileName.endsWith(format);
+        }
+
+        if (format.endsWith('/*')) {
+            return fileType.startsWith(format.substring(0, format.length - 1));
+        }
+
+        return fileType === format;
+    });
+}
+
 export function formatSourceLink(value: string | undefined): string | undefined {
     if (
         isNotDefined(value)

--- a/app/src/utils/constants.ts
+++ b/app/src/utils/constants.ts
@@ -248,4 +248,4 @@ export const EAP_STATUS_NS_ADDRESSING_COMMENTS = 30 satisfies EapStatus;
 export const EAP_STATUS_TECHNICALLY_VALIDATED = 40 satisfies EapStatus;
 export const EAP_STATUS_APPROVED = 50 satisfies EapStatus;
 export const EAP_STATUS_PROJECT_AGREEMENT_SIGNED = 60 satisfies EapStatus;
-export const EAP_ACCEPTED_FILE_FORMATS = '.pdf, .docx, .pptx, image/*';
+export const EAP_ACCEPTED_FILE_FORMATS = '.pdf, .docx, .pptx, .xlsx, image/*';

--- a/app/src/views/EapFullForm/index.tsx
+++ b/app/src/views/EapFullForm/index.tsx
@@ -210,6 +210,11 @@ export function Component() {
                 updated_checklist_file_details,
                 theory_of_change_table_file_details,
                 risk_analysis_relevant_files_details,
+                evidence_base_relevant_files_details,
+                activation_process_relevant_files_details,
+                trigger_model_relevant_files_details,
+                meal_relevant_files_details,
+                capacity_relevant_files_details,
             } = response;
             return {
                 ...prevMap,
@@ -226,6 +231,11 @@ export function Component() {
                         ...(prioritized_impact_files ?? []),
                         ...(early_action_implementation_files ?? []),
                         ...(risk_analysis_relevant_files_details ?? []),
+                        ...(evidence_base_relevant_files_details ?? []),
+                        ...(activation_process_relevant_files_details ?? []),
+                        ...(trigger_model_relevant_files_details ?? []),
+                        ...(meal_relevant_files_details ?? []),
+                        ...(capacity_relevant_files_details ?? []),
                         budget_file_details,
                         forecast_table_file_details,
                         updated_checklist_file_details,

--- a/app/src/views/EapSummaryExport/index.tsx
+++ b/app/src/views/EapSummaryExport/index.tsx
@@ -274,6 +274,7 @@ export function Component() {
             <PrintableContainer
                 heading={strings.summaryHeading}
                 headingLevel={2}
+                breakBefore
             >
                 <div
                     className={_cs(
@@ -394,6 +395,7 @@ export function Component() {
             <PrintableContainer
                 heading={strings.operationalStrategyHeading}
                 headingLevel={2}
+                breakBefore
             >
                 <PrintableContainer
                     heading={strings.nationalSocietyStrategyHeading}
@@ -423,6 +425,7 @@ export function Component() {
             <PrintableContainer
                 heading={strings.plannedOperationsHeading}
                 headingLevel={2}
+                breakBefore
             >
                 {planned_operations?.map((operation) => {
                     const apCodeSectorValue = apCodeOptions?.sector_ap_codes
@@ -552,6 +555,7 @@ export function Component() {
             <PrintableContainer
                 heading={strings.enablingApproachesLabel}
                 headingLevel={2}
+                breakBefore
             >
                 {enabling_approaches?.map((approach) => {
                     const apCodeApproachValue = apCodeOptions?.approach_ap_codes
@@ -671,6 +675,7 @@ export function Component() {
             <PrintableContainer
                 heading={strings.budgetHeading}
                 headingLevel={2}
+                breakBefore
             >
                 <ListView
                     layout="grid"

--- a/translationMigrations/000088-1786604379488.json
+++ b/translationMigrations/000088-1786604379488.json
@@ -1,0 +1,17 @@
+{
+    "parent": "000087-1786514559033.json",
+    "actions": [
+        {
+            "action": "add",
+            "key": "unsupportedFileFormatDescription",
+            "namespace": "goMultiFileInput",
+            "value": "{fileNames} could not be added. Only the following file formats are accepted: {fileFormats}."
+        },
+        {
+            "action": "add",
+            "key": "unsupportedFileFormatMessage",
+            "namespace": "goMultiFileInput",
+            "value": "Unsupported file format!"
+        }
+    ]
+}


### PR DESCRIPTION
## Summary
- Validate file uploads and fix summary export page breaks


## Changes

- Reject files that don't match the accept list in GoMultiFileInput and
  show a danger alert naming them, instead of uploading them
- Allow .xlsx in EAP_ACCEPTED_FILE_FORMATS
- Disable per-file delete when the form is readOnly, disabled or uploading
- Page Break in EAP summary export.
## This PR Ensures:

* \[X] No typos or grammatical errors
* \[X] No conflict markers left in the code
* \[X] No unwanted comments, temporary files, or auto-generated files
* \[X] No inclusion of secret keys or sensitive data
* \[X] No `console.log` statements meant for debugging
* \[X] All CI checks have passed

## Additional Notes

*Optional: Add any other relevant context, screenshots, or details here.*
